### PR TITLE
Added yahooapis.com to the CDN list

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -17,6 +17,7 @@ CDN_PROVIDER cdnList[] = {
 	{".footprint.net", _T("Level 3")},
 	{".ay1.b.yahoo.com", _T("Yahoo")},
 	{".yimg.", _T("Yahoo")},
+	{".yahooapis.com", _T("Yahoo")},
 	{".google.", _T("Google")},
 	{"googlesyndication.", _T("Google")},
 	{"youtube.", _T("Google")},

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -57,6 +57,7 @@ CDN_PROVIDER cdnList[] = {
   {".footprint.net", "Level 3"},
   {".ay1.b.yahoo.com", "Yahoo"},
   {".yimg.", "Yahoo"},
+  {".yahooapis.com", "Yahoo"},
   {".google.", "Google"},
   {"googlesyndication.", "Google"},
   {"youtube.", "Google"},


### PR DESCRIPTION
`yui.yahooapis.com` is the CDN where [YUI Library](http://yuilibrary.com/) and various other Yahoo projects are hosted.
