### PR TITLE
Add speed index unit test

### DIFF
--- a/www/unittests/data/sample_timeline.json
+++ b/www/unittests/data/sample_timeline.json
@@ -1,0 +1,81 @@
+[
+  {
+    "type": "Paint",
+    "comment": "This paint event occurs before Layout, it will be filtered out.",
+    "startTime": 0,
+    "endTime": 0,
+    "data": {
+      "clip": [ 0, 0, 1000, 0, 1000, 800, 0, 800 ]
+    },
+    "frameId": "1.1",
+    "children": []
+  },
+  {
+    "type": "ResourceReceiveResponse",
+    "startTime": 0,
+    "endTime": 10,
+    "children": []
+  },
+  {
+    "type": "Layout",
+    "startTime": 10,
+    "endTime": 20,
+    "children": []
+  },
+  {
+    "type": "Paint",
+    "comment": "Full-screen paint event; area 1,000,000",
+    "startTime": 100,
+    "endTime": 100,
+    "data": {
+      "clip": [ 0, 0, 1000, 0, 1000, 1000, 0, 1000 ]
+    },
+    "frameId": "1.1",
+    "children": []
+  },
+  {
+    "type": "Paint",
+    "comment": "This paint event is not a leaf event. Area 300,000, time 400",
+    "startTime": 200,
+    "endTime": 400,
+    "data": {
+      "clip": [ 0, 0, 1000, 0, 1000, 300, 0, 300 ]
+    },
+    "frameId": "1.1",
+    "children": [
+      {
+        "type": "Paint",
+        "comment": "Area 300,000, time 300",
+        "startTime": 200,
+        "endTime": 300,
+        "data": {
+          "clip": [ 0, 0, 1000, 0, 1000, 300, 0, 300 ]
+        },
+        "frameId": "1.1",
+        "children": []
+      },
+      {
+        "type": "Paint",
+        "comment": "Area 300,000, time 400",
+        "startTime": 300,
+        "endTime": 400,
+        "data": {
+          "clip": [ 0, 0, 1000, 0, 1000, 300, 0, 300 ]
+        },
+        "frameId": "1.1",
+        "children": []
+      }
+    ]
+  },
+  {
+    "type": "Paint",
+    "comment": "Final paint event, with an area of 200,000 ",
+    "startTime": 550,
+    "endTime": 800,
+    "data": {
+      "clip": [ 0, 0, 1000, 0, 1000, 200, 0, 200 ]
+    },
+    "frameId": "1.1",
+    "children": []
+  }
+]

--- a/www/unittests/tests/testDevToolsSpeedIndex.php
+++ b/www/unittests/tests/testDevToolsSpeedIndex.php
@@ -1,0 +1,57 @@
+<?php
+
+// www/devtools.inc.php depends on some functions that are defined in
+// www/common_lib.inc, so include that file first. However, in that file it
+// is assumed that the cwd is the www directory, so we need to chdir.
+chdir('..');
+include_once 'common_lib.inc';
+chdir('unittests');
+
+include_once '../devtools.inc.php';
+
+// Note: www/unittests/runAllTests.php appears to not detect new tests until
+// one of the already-detected tests changes.
+
+class DevToolsSpeedIndexTests extends \Enhance\TestFixture
+{
+
+  public function SetUp() {
+    // Although this script is run from 'www/unittests', the actual Enhance
+    // unit tests are run from 'www', so the unit test data directory must be
+    // relative to that.
+    $testDir = 'unittests/data';
+
+    // After running through the body of GetDevToolsProgress, the results is
+    // cached in a file, devToolsProgress.json.gz, so that it doesn't need
+    // to be re-computed. However, for these tests, we do want the body of
+    // GetDevToolsProgress to be run each time.
+    $cachedFileName = "$testDir/devToolsProgress.json.gz";
+    if (file_exists($cachedFileName)) {
+      unlink($cachedFileName);
+    }
+
+    $this->progress = GetDevToolsProgress($testDir, 'sample', false);
+  }
+
+  public function TestSampleVisualProgress() {
+    // Test visual progress.
+    // The area points that the events at 100, 300, 400 and 800 count for
+    // respectively are 500,000, 100,000, 200,000 and 200,000 (total 1,000,000).
+    // Note that this is counting the one event in the sample data that is not
+    // a leaf event.
+    \Enhance\Assert::areIdentical(4, count($this->progress['VisualProgress']));
+    \Enhance\Assert::areIdentical(0.5, $this->progress['VisualProgress'][100]);
+    \Enhance\Assert::areIdentical(0.6, $this->progress['VisualProgress'][300]);
+    \Enhance\Assert::areIdentical(0.8, $this->progress['VisualProgress'][400]);
+    \Enhance\Assert::areIdentical(1.0, $this->progress['VisualProgress'][800]);
+  }
+
+  public function TestSampleSpeedIndex() {
+    // Given the visual progress numbers above, the speed index can be
+    // calculated to be 320.0.
+    \Enhance\Assert::areIdentical(320.0, $this->progress['SpeedIndex']);
+  }
+
+}
+
+?>


### PR DESCRIPTION
This is a some sample data and assertions I was using while testing the telemetry speed index. This test should only pass if all of the paint events except for the first one are counted, and the largest paint event is discounted by 50%.

When I first ran this test I had some mysterious problems -- runAllTests.php wouldn't detect this test until I renamed tests/testWorkDone.php, and then tests/testPcapUpload.php was throwing errors. (Then, when Pcap errors was moved away, this test was run and it suceeded.)
