### PR TITLE
Ensure that test labels wrap to fit within the container

### DIFF
--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -197,6 +197,10 @@ else
                     padding-top: 1em;
                     padding-left: 2em;
                 }
+                #statusTable a
+                {
+                    color: inherit;
+                }
                 #image
                 {
                     margin-left:auto; 
@@ -651,7 +655,7 @@ function DisplayStatus()
     echo "<table id=\"statusTable\"><tr><th>Test</th><th>Status</th></tr><tr>";
     foreach($tests as &$test)
     {
-        echo "<tr><td>{$test['name']}</td><td>";
+        echo "<tr><td><a href="/result/{$test['id']}/">{$test['name']}</a></td><td>";
         if( $test['done'] )
             echo "Done";
         elseif( $test['started'] )


### PR DESCRIPTION
Test labels are commonly defaulted to the test URL. URL strings may not contain many word-breaking characters, so the text overflows beyond the container.

word-wrap: break-word; ensures that the text breaks as necessary to keep the entire label visible.

Read more: https://developer.mozilla.org/en-US/docs/Web/CSS/word-wrap
