### PR TITLE
Update cdn.h

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -46,6 +46,8 @@ typedef struct {
 CDN_PROVIDER cdnList[] = {
   {".akamai.net", "Akamai"},
   {".akamaiedge.net", "Akamai"},
+  {".edgesuite.net", "Akamai"},
+  {".edgekey.net", "Akamai"},
   {".llnwd.net", "Limelight"},
   {"edgecastcdn.net", "Edgecast"},
   {".systemcdn.net", "Edgecast"},


### PR DESCRIPTION
Updated CDN provider list with common Akamai CDN hostnames .edgesuite.net and .edgekey.net.
