### PR TITLE
wptdriver. Leading zeros in date/time in results.

### DIFF
--- a/agent/wpthook/results.cc
+++ b/agent/wpthook/results.cc
@@ -400,11 +400,11 @@ void Results::SavePageData(OptimizationChecks& checks){
     // build up the string of data fileds for the page result
 
     // Date
-    buff.Format("%d/%d/%d\t", _test_state._start_time.wMonth,
+    buff.Format("%02d/%02d/%d\t", _test_state._start_time.wMonth,
           _test_state._start_time.wDay, _test_state._start_time.wYear);
     result += buff;
     // Time
-    buff.Format("%d:%d:%d\t", _test_state._start_time.wHour,
+    buff.Format("%02d:%02d:%02d\t", _test_state._start_time.wHour,
           _test_state._start_time.wMinute, _test_state._start_time.wSecond);
     result += buff;
     // Event Name
@@ -923,11 +923,11 @@ void Results::SaveRequest(HANDLE file, HANDLE headers, Request * request,
   CStringA buff;
 
   // Date
-  buff.Format("%d/%d/%d\t", _test_state._start_time.wMonth,
+  buff.Format("%02d/%02d/%02d\t", _test_state._start_time.wMonth,
         _test_state._start_time.wDay, _test_state._start_time.wYear);
   result += buff;
   // Time
-  buff.Format("%d:%d:%d\t", _test_state._start_time.wHour,
+  buff.Format("%02d:%02d:%02d\t", _test_state._start_time.wHour,
         _test_state._start_time.wMinute, _test_state._start_time.wSecond);
   result += buff;
   // Event Name


### PR DESCRIPTION
The tab-delimited summary and detail files _IEWPG.txt and _IEWTR.txt sent to
wpt server had dates and times without leading zeros, e.g. "1/2/2013 5:6:0"
which messes up a lot of things, in particular Splunk's timestamp detection.

Rather than fuffing about with the format on the server side, fix this in the
source, i.e. in wptdirver.

UrlBlaster seems to be using correct format, but they also use Date/Time
format string in CString::Format() rather than raw "%d". Perhaps we should
do the same here in wptdriver.
