### PR TITLE
Android - Added a flag to disable external intent requests

### DIFF
--- a/agent/js/src/browser_android_chrome.js
+++ b/agent/js/src/browser_android_chrome.js
@@ -45,7 +45,9 @@ var CHROME_FLAGS = [
     // Stabilize Chrome performance.
     '--disable-fre', '--enable-benchmarking', '--metrics-recording-only',
     // Suppress location JS API to avoid a location prompt obscuring the page.
-    '--disable-geolocation'
+    '--disable-geolocation',
+    // Disable external URL handlers from opening
+    '--disable-external-intent-requests'
   ];
 
 


### PR DESCRIPTION
According to https://codereview.chromium.org/71283003/ Chrome supports a command-line flag to disable external intent notifications (bot sure which versions but it doesn't appear to be supported in 31 - probably 32 or 33 based on the date).

This will make sure requested URLs open in Chrome and aren't opened in an external app and will also allow Chrome Stable and beta to be run on the same device.
