### PR TITLE
Include full version number in urlblast & wptdriver requests to getwork.php

### DIFF
--- a/agent/browser/ie/urlBlast/UrlMgrHttp.cpp
+++ b/agent/browser/ie/urlBlast/UrlMgrHttp.cpp
@@ -37,7 +37,10 @@ CUrlMgrHttp::CUrlMgrHttp(CLog &logRef):
 	, nextCheck(0)
 	, videoSupported(false)
 	, lastSuccess(0)
-	, version(0)
+	, majorVer(0)
+	, minorVer(0)
+	, buildNo(0)
+	, revisionNo(0)
 	, noUpdate(false)
   , port(80)
   , requestFlags(0)
@@ -84,7 +87,12 @@ CUrlMgrHttp::CUrlMgrHttp(CLog &logRef):
 				if( VerQueryValue(pVersion, _T("\\"), (LPVOID*)&info, &size) )
 				{
 					if( info )
-						version = LOWORD(info->dwFileVersionLS);
+					{
+						majorVer = HIWORD(info->dwFileVersionMS);
+						minorVer = LOWORD(info->dwFileVersionMS);
+						buildNo = HIWORD(info->dwFileVersionLS);
+						revisionNo = LOWORD(info->dwFileVersionLS);
+					}
 				}
 			}
 
@@ -154,8 +162,8 @@ void CUrlMgrHttp::Start()
 			CString videoStr;
 			if( videoSupported )
 				videoStr = _T("&video=1");
-			if( version && !noUpdate )
-				verString.Format(_T("&ver=%d"), version);
+			if( ( majorVer || minorVer || buildNo || revisionNo) && !noUpdate )
+				verString.Format(_T("&ver=%d.%d.%d.%d"), majorVer, minorVer, buildNo, revisionNo);
 			CString ec2;
 			if( ec2Instance.GetLength() )
 				ec2 = CString(_T("&ec2=")) + ec2Instance;

--- a/agent/browser/ie/urlBlast/UrlMgrHttp.h
+++ b/agent/browser/ie/urlBlast/UrlMgrHttp.h
@@ -33,7 +33,10 @@ protected:
 	DWORD	nextCheck;
 	bool	videoSupported;
 	DWORD	lastSuccess;
-	DWORD	version;
+	DWORD	majorVer;
+	DWORD	minorVer;
+	DWORD	buildNo;
+	DWORD	revisionNo;
 	CString verString;
   DWORD requestFlags;
   CString dnsServers;

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -43,7 +43,10 @@ static const TCHAR * NO_FILE = _T("");
 WebPagetest::WebPagetest(WptSettings &settings, WptStatus &status):
   _settings(settings)
   ,_status(status)
-  ,_version(0)
+  ,_majorVer(0)
+  ,_minorVer(0)
+  ,_buildNo(0)
+  ,_revisionNo(0)
   ,_exit(false)
   ,has_gpu_(false) {
   SetErrorMode(SEM_FAILCRITICALERRORS);
@@ -58,7 +61,12 @@ WebPagetest::WebPagetest(WptSettings &settings, WptStatus &status):
         VS_FIXEDFILEINFO * info = NULL;
         UINT size = 0;
         if( VerQueryValue(pVersion, _T("\\"), (LPVOID*)&info, &size) && info )
-          _version = LOWORD(info->dwFileVersionLS);
+        {
+		      _majorVer = HIWORD(info->dwFileVersionMS);
+		      _minorVer = LOWORD(info->dwFileVersionMS);
+		      _buildNo = HIWORD(info->dwFileVersionLS);
+		      _revisionNo = LOWORD(info->dwFileVersionLS);
+        }
       }
 
       delete [] pVersion;
@@ -97,10 +105,11 @@ bool WebPagetest::GetTest(WptTestDriver& test) {
   url += CString(_T("&location=")) + _settings._location;
   if (_settings._key.GetLength())
     url += CString(_T("&key=")) + _settings._key;
-  if (_version) {
-    buff.Format(_T("&software=wpt&ver=%d"), _version);
+  if (_majorVer || _minorVer || _buildNo || _revisionNo) {
+    buff.Format(_T("&software=wpt&ver=%d.%d.%d.%d"), _majorVer, _minorVer, _buildNo, _revisionNo);
     url += buff;
   }
+
   if (_computer_name.GetLength())
     url += CString(_T("&pc=")) + _computer_name;
   if (_settings._ec2_instance.GetLength())
@@ -794,7 +803,11 @@ bool WebPagetest::InstallUpdate(CString dir) {
 
   if (ok) {
     // prevent executing multiple updates in case something goes wrong
-    _version = 0;
+    _majorVer = 0;
+    _minorVer = 0;
+    _buildNo = 0;
+    _revisionNo = 0;
+    
     ShellExecute(NULL,NULL,dir+_T("\\wptupdate.exe"),NULL,dir,SW_SHOWNORMAL);
 
     // wait for up to 2 minutes for the update process to close us

--- a/agent/wptdriver/webpagetest.h
+++ b/agent/wptdriver/webpagetest.h
@@ -42,7 +42,10 @@ public:
 private:
   WptSettings&  _settings;
   WptStatus&    _status;
-  DWORD         _version;
+  DWORD         _majorVer;
+  DWORD         _minorVer;
+  DWORD         _buildNo;
+  DWORD         _revisionNo;
   CString       _computer_name;
   CString       _dns_servers;
 

--- a/www/work/getwork.php
+++ b/www/work/getwork.php
@@ -288,7 +288,9 @@ function GetUpdate()
         if( is_file("$updateDir/{$fileBase}update.ini") && is_file("$updateDir/{$fileBase}update.zip") )
         {
             $update = parse_ini_file("$updateDir/{$fileBase}update.ini");
-            if( $update['ver'] && (int)$update['ver'] != (int)$_GET['ver'] )
+
+            // Check for inequality allows both upgrade and quick downgrade
+            if( $update['ver'] && $update['ver'] !== $_GET['ver'] )
             {
                 header('Content-Type: application/zip');
                 header("Cache-Control: no-cache, must-revalidate");


### PR DESCRIPTION
Tested upgrade and downgrade from x to x.x.x.x style version numbers. 

Checked getTesters.php to ensure correct version number was shown.

(urlblast changes were tested by building in VS10 and inserting it into existing update.zip)
