### PR TITLE
Add fonts to content breakdown

### DIFF
--- a/www/contentColors.inc
+++ b/www/contentColors.inc
@@ -75,6 +75,7 @@ function MimeColors() {
         'text'  => array(254,241,132),
         'image' => array(196,154,232),
         'flash' => array(45,183,193),
+        'font' => array(255,82,62),
         'other' => array(196,196,196)
         );
     return $colors;
@@ -100,6 +101,8 @@ function ContentType($mime) {
         $content_type = 'image';
     } elseif (!strcasecmp($mime, 'application/x-shockwave-flash')) {
         $content_type = 'flash';
+    } elseif (!stripos($mime, 'font') !== false) {
+        $content_type = 'font';
     }
     return $content_type;
 }


### PR DESCRIPTION
Added fonts as a separate category in the content breakdown.

Breakdown uses the same color as the Chrome network panel (i.e. as the rest of WPT does)

Can you review the mimetype test for fonts, I think it's good enough but it's a bit lazy (IMV)
