### PR TITLE
Fixes #188 - Adding label overrides to video creation

### DIFF
--- a/www/video/create.php
+++ b/www/video/create.php
@@ -34,7 +34,7 @@ if( !isset($_REQUEST['tests']) && isset($_REQUEST['t']) )
     foreach( $_GET as $key => $value )
         if( $key != 't' && !is_array($value))
             $params .= "&$key=" . urlencode($value);
-    header("Location: http://$host$uri?tests=$tests{$params}");    
+    header("Location: http://$host$uri?tests=$tests{$params}");
 }
 else
 {
@@ -51,7 +51,7 @@ else
     $json = false;
     if( !strcasecmp($_REQUEST['f'], 'json') )
         $json = true;
-    
+
     // make sure the work directory exists
     if( !is_dir('./work/video/tmp') )
         mkdir('./work/video/tmp', 0777, true);
@@ -59,7 +59,7 @@ else
     // get the list of tests and test runs
     $tests = array();
     $id = null;
-    
+
     $exists = false;
     if( isset($_REQUEST['id']) )
     {
@@ -77,7 +77,7 @@ else
         if( strlen($_REQUEST['end']) )
             $endTime = trim($_REQUEST['end']);
         $videoIdExtra = "";
-        
+
         $compTests = explode(',', $_REQUEST['tests']);
         foreach($compTests as $t)
         {
@@ -92,7 +92,7 @@ else
                 $test['syncStartRender'] = "";
                 $test['syncDocTime'] = "";
                 $test['syncFullyLoaded'] = "";
-                    
+
                 for( $i = 1; $i < count($parts); $i++ )
                 {
                     $p = explode(':', $parts[$i]);
@@ -115,14 +115,14 @@ else
                             $test['syncFullyLoaded'] = (int)$p[1];
                     }
                 }
-                
+
                 RestoreTest($test['id']);
                 $test['path'] = GetTestPath($test['id']);
                 $test['pageData'] = loadAllPageData($test['path']);
-                
+
                 if( !$test['run'] )
                     $test['run'] = GetMedianRun($test['pageData'], 0, $median_metric);
-                    
+
                 // figure out the real end time (in ms)
                 if( isset($test['end']) )
                 {
@@ -161,7 +161,7 @@ else
                 $test['videoPath'] = "./{$test['path']}/video_{$test['run']}";
                 if( $test['cached'] )
                     $test['videoPath'] .= '_cached';
-                    
+
                 if ($test['syncStartRender'] || $test['syncDocTime'] || $test['syncFullyLoaded'])
                     $videoIdExtra .= ".{$test['syncStartRender']}.{$test['syncDocTime']}.{$test['syncFullyLoaded']}";
 
@@ -172,10 +172,21 @@ else
                   if (array_key_exists('locationText', $testInfo))
                     $test['location'] = $testInfo['locationText'];
                 }
-                if( !strlen($test['label']) )
+
+                if (!strlen($test['label'])) {
                     $test['label'] = trim($test['pageData'][1][0]['URL']);
-                $labels[] = $test['label'];
-                
+                }
+
+                // See if the label has been edited
+                $new_label = getLabel($test['id'], $user);
+
+                if (!empty($new_label)) {
+                    $labels[] = $new_label;
+                } else {
+                    $labels[] = $test['label'];
+                }
+
+
                 if( is_dir($test['videoPath']) )
                     $tests[] = $test;
             }
@@ -216,7 +227,7 @@ else
                 $scriptFile = "./video/templates/$count.avs";
                 if( strlen($_REQUEST['template']) )
                     $scriptFile = "./video/templates/{$_REQUEST['template']}.avs";
-                
+
                 $script = file_get_contents($scriptFile);
                 if( strlen($script) )
                 {
@@ -242,7 +253,7 @@ else
                             $dir = opendir($test['videoPath']);
                             if( $dir )
                             {
-                                while($file = readdir($dir)) 
+                                while($file = readdir($dir))
                                 {
                                     $path = $test['videoPath'] . "/$file";
                                     if( is_file($path) && (stripos($file, '.jpg') || stripos($file, '.avs')) &&  strpos($file, '.thm') === false )
@@ -251,15 +262,15 @@ else
 
                                 closedir($dir);
                             }
-                            
+
                             // update the label in the script
                             $script = str_replace("%$index%", $test['label'], $script);
-                            
+
                             if( count($files) )
                                 $zip->add($files, PCLZIP_OPT_REMOVE_ALL_PATH, PCLZIP_OPT_ADD_PATH, "$index");
                         }
                     }
-                    
+
                     // see if they want the video in slow motion
                     if( $_REQUEST['slow'] )
                         $script .= "\r\nAssumeFPS(2)\r\n";
@@ -269,7 +280,7 @@ else
                     file_put_contents($tmpScript, $script);
                     $zip->add($tmpScript, PCLZIP_CB_PRE_ADD, 'ZipAvsCallback');
                     unlink($tmpScript);
-                    
+
                     // create an ini file for the job as well
                     $ini = "[info]\r\n";
                     $ini .= "id=$id\r\n";
@@ -277,7 +288,7 @@ else
                     file_put_contents($tmpIni, $ini);
                     $zip->add($tmpIni, PCLZIP_CB_PRE_ADD, 'ZipIniCallback');
                     unlink($tmpIni);
-                    
+
                     // set up the result directory
                     $dest = './' . GetVideoPath($id);
                     if( !is_dir($dest) )
@@ -285,7 +296,7 @@ else
                     if( count($labels) )
                         file_put_contents("$dest/labels.txt", json_encode($labels));
                     gz_file_put_contents("$dest/testinfo.json", json_encode($tests));
-                    
+
                     // move the file to the video work directory
                     rename( $zipFile, "./work/video/$id.zip" );
                 }
@@ -328,7 +339,7 @@ else
         }
         else
         {
-            header("Location: http://$host$uri/view.php?id=$id");    
+            header("Location: http://$host$uri/view.php?id=$id");
         }
     }
     else
@@ -360,7 +371,7 @@ else
 
 /**
 * Override the script file name
-* 
+*
 * @param mixed $p_event
 * @param mixed $p_header
 * @return mixed
@@ -373,7 +384,7 @@ function ZipAvsCallback($p_event, &$p_header)
 
 /**
 * Override the ini file name
-* 
+*
 * @param mixed $p_event
 * @param mixed $p_header
 * @return mixed


### PR DESCRIPTION
Sorry about all of the whitespace changes, but this should fix issue #188 by checking for a label override before setting the label for the video.  **This is untested** since I couldn't really do it easily with my current dev install.  Hopefully it's not a huge burden for you to test.
