### PR TITLE
Removed W3 Total Cache endorsement

### DIFF
--- a/www/tips_data/cms_wp_tc.html
+++ b/www/tips_data/cms_wp_tc.html
@@ -1,1 +1,0 @@
-If you are running a site based on WordPress, the <a href="http://wordpress.org/extend/plugins/w3-total-cache/" target="_blank">W3 Total Cache plugin</a> makes it easy to optimize your site.


### PR DESCRIPTION
The other day I saw this endorsement while waiting for a test to finish:

![image](https://cloud.githubusercontent.com/assets/23369/3276592/2c1f5d54-f34d-11e3-9d3e-ad0c6edde911.png)

I immediately took a screenshot to remind myself to complain about this, because
I'm on a minor crusade to discourage anyone from ever using W3TC. :)

When we first added memcached metrics to our app and infrastructure, we noticed
periodic dips, where all of a sudden we lost about a third of the keys in
memcached.  We spent months mulling this over and adding more logging whenever
we thought of a new theory, until one day we discovered that the W3TC plugin
(running on our small on-the-side Wordpress blog) would perform a _full
memcached flush_ whenever it thought memcached was too full.  This is a pretty
stupid way to handle memcached in the first place (it has expiration times
after all), but it also assumes Wordpress is the only thing using memcached,
which is not a great assumption.  Thankfully it wasn't ever completely emptying
the cache, because our process limiter would kill the process for taking too
long.

We opted to skip application caching in Wordpress entirely and just utilize
Varnish edge-caching, a scheme that has worked suitably well.

Several months later, I heard about [a vulnerability](http://www.acunetix.com/blog/web-security-zone/wp-plugins-remote-code-execution/) in W3TC, which made it
apparent the plugin was _eval-ing code in user-submitted comments_!

Those two incidents (although there [have been others](http://wordpress.org/support/topic/w3-total-cache-critical-vulnerability-disclosed)) convinced me the
plugin authors should never be trusted to write anything that ends up on my
servers.  The gross levels of incompetence displayed there should make anyone
extremely wary, and it certainly shouldn't be recommended by such a well-known
tool as WebPagetest.

---

_Note: I already sent you an email about this, but then I realized it might be in the source code and I could just open a pull request.  So I did._
