### PR TITLE
We need the test labels to be reflected in the page id of the exported H...

### DIFF
--- a/www/export.php
+++ b/www/export.php
@@ -141,10 +141,7 @@ function BuildResult(&$pageData)
                 $pd['title'] .= "First View";
             $pd['title'] .= " for " . $data['URL'];
 	    $testInfo = GetTestInfo($id);
-	    if (array_key_exists('label', $testInfo) && strlen($testInfo['label']))
-                $pd['label'] = $testInfo['label'];
-            $pd['id'] = "{$data['URL']}_{$testInfo['browser']}_{$testInfo['connectivity']}_{$run}_{$cached}";
-	    $pd['id'] = "page_{$run}_{$cached}_{$id_label}";
+	    pd['id'] = "{$data['URL']}_{$testInfo['label']}_{$testInfo['location']}_{$testInfo['browser']}_{$testInfo['connectivity']}_{$run}_{$cached}";
             $pd['pageTimings'] = array( 'onLoad' => $data['docTime'], 'onContentLoad' => -1, '_startRender' => $data['render'] );
             
             // add the pagespeed score


### PR DESCRIPTION
Currently the "id" field on exported HARs does not contain the test labels which were assigned during test creation. This patch propagates the label value to the exported HAR so that we know which HAR is which
