### PR TITLE
Initial support for posting results to StatsD

### DIFF
--- a/www/lib/statsd-php/Domnikl/Statsd/Client.php
+++ b/www/lib/statsd-php/Domnikl/Statsd/Client.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace Domnikl\Statsd;
+
+/**
+ * the statsd client
+ *
+ * @author Dominik Liebler <liebler.dominik@googlemail.com>
+ */
+class Client
+{
+    /**
+     * Connection object that messages get send to
+     *
+     * @var Connection
+     */
+    protected $_connection;
+
+    /**
+     * holds all the timings that have not yet been completed
+     *
+     * @var array
+     */
+    protected $_timings = array();
+
+    /**
+     * holds all memory profiles like timings
+     *
+     * @var array
+     */
+    protected $_memoryProfiles = array();
+
+    /**
+     * global key namespace
+     *
+     * @var string
+     */
+    protected $_namespace = '';
+
+    /**
+     * stores the batch after batch processing was started
+     *
+     * @var array
+     */
+    protected $_batch = array();
+
+    /**
+     * batch mode?
+     *
+     * @var boolean
+     */
+    protected $_isBatch = false;
+
+    /**
+     * inits the Client object
+     *
+     * @param Connection $connection
+     * @param string $namespace global key namespace
+     */
+    public function __construct(Connection $connection, $namespace = '')
+    {
+        $this->_connection = $connection;
+        $this->_namespace = (string) $namespace;
+    }
+
+    /**
+     * increments the key by 1
+     *
+     * @param string $key
+     * @param int $sampleRate
+     *
+     * @return void
+     */
+    public function increment($key, $sampleRate = 1)
+    {
+        $this->count($key, 1, $sampleRate);
+    }
+
+    /**
+     * decrements the key by 1
+     *
+     * @param string $key
+     * @param int $sampleRate
+     *
+     * @return void
+     */
+    public function decrement($key, $sampleRate = 1)
+    {
+        $this->count($key, -1, $sampleRate);
+    }
+    /**
+     * sends a count to statsd
+     *
+     * @param string $key
+     * @param int $value
+     * @param int $sampleRate (optional) the default is 1
+     *
+     * @return void
+     */
+    public function count($key, $value, $sampleRate = 1)
+    {
+        $this->_send($key, (int) $value, 'c', $sampleRate);
+    }
+
+    /**
+     * sends a timing to statsd (in ms)
+     *
+     * @param string $key
+     * @param int $value the timing in ms
+     * @param int $sampleRate the sample rate, if < 1, statsd will send an average timing
+     *
+     * @return void
+     */
+    public function timing($key, $value, $sampleRate = 1)
+    {
+        $this->_send($key, (int) $value, 'ms', $sampleRate);
+    }
+
+    /**
+     * starts the timing for a key
+     *
+     * @param string $key
+     *
+     * @return void
+     */
+    public function startTiming($key)
+    {
+        $this->_timings[$key] = gettimeofday(true);
+    }
+
+    /**
+     * ends the timing for a key and sends it to statsd
+     *
+     * @param string $key
+     * @param int $sampleRate (optional)
+     *
+     * @return void
+     */
+    public function endTiming($key, $sampleRate = 1)
+    {
+        $end = gettimeofday(true);
+
+        if (array_key_exists($key, $this->_timings)) {
+            $timing = ($end - $this->_timings[$key]) * 1000;
+            $this->timing($key, $timing, $sampleRate);
+            unset($this->_timings[$key]);
+        }
+    }
+
+    /**
+     * start memory "profiling"
+     *
+     * @param string $key
+     *
+     * @return void
+     */
+    public function startMemoryProfile($key)
+    {
+        $this->_memoryProfiles[$key] = memory_get_usage();
+    }
+
+    /**
+     * ends the memory profiling and sends the value to the server
+     *
+     * @param string $key
+     * @param int $sampleRate
+     *
+     * @return void
+     */
+    public function endMemoryProfile($key, $sampleRate = 1)
+    {
+        $end = memory_get_usage();
+
+        if (array_key_exists($key, $this->_memoryProfiles)) {
+            $memory = ($end - $this->_memoryProfiles[$key]);
+            $this->memory($key, $memory, $sampleRate);
+
+            unset($this->_memoryProfiles[$key]);
+        }
+    }
+
+    /**
+     * report memory usage to statsd. if memory was not given report peak usage
+     *
+     * @param string $key
+     * @param int $memory
+     * @param int $sampleRate
+     *
+     * @return void
+     */
+    public function memory($key, $memory = null, $sampleRate = 1)
+    {
+        if (null === $memory) {
+            $memory = memory_get_peak_usage();
+        }
+
+        $this->count($key, (int) $memory, $sampleRate);
+    }
+
+    /**
+     * executes a Closure and records it's execution time and sends it to statsd
+     * returns the value the Closure returned
+     *
+     * @param string $key
+     * @param \Closure $_block
+     * @param int $sampleRate (optional) default = 1
+     *
+     * @return mixed
+     */
+    public function time($key, \Closure $_block, $sampleRate = 1)
+    {
+        $this->startTiming($key);
+        $return = $_block();
+        $this->endTiming($key, $sampleRate);
+
+        return $return;
+    }
+
+    /**
+     * sends a gauge, an arbitrary value to StatsD
+     *
+     * @param string $key
+     * @param int $value
+     * 
+     * @return void
+     */
+    public function gauge($key, $value)
+    {
+        $this->_send($key, (int) $value, 'g', 1);
+    }
+
+    /**
+     * sends a set member
+     *
+     * @param string $key
+     * @param int $value
+     * 
+     * @return void
+     */
+    public function set($key, $value)
+    {
+        $this->_send($key, $value, 's', 1);
+    }
+
+    /**
+     * actually sends a message to to the daemon and returns the sent message
+     *
+     * @param string $key
+     * @param int $value
+     * @param string $type
+     * @param int $sampleRate
+     *
+     * @return void
+     */
+    protected function _send($key, $value, $type, $sampleRate)
+    {
+        if (0 != strlen($this->_namespace)) {
+            $key = sprintf('%s.%s', $this->_namespace, $key);
+        }
+
+        $message = sprintf("%s:%d|%s", $key, $value, $type);
+        $sampledData = '';
+
+        $sample = mt_rand() / mt_getrandmax();
+
+        if ($sample > $sampleRate) {
+            return;
+        }
+
+        if ($sampleRate < 1 || $this->_connection->forceSampling()) {
+            $sampledData = sprintf('%s|@%s', $message, $sampleRate);
+        } else {
+            $sampledData = $message;
+        }
+
+        if (!$this->_isBatch) {
+            $this->_connection->send($sampledData);
+        } else {
+            $this->_batch[] = $sampledData;
+        }
+    }
+
+    /**
+     * changes the global key namespace
+     *
+     * @param string $namespace
+     *
+     * @return void
+     */
+    public function setNamespace($namespace)
+    {
+        $this->_namespace = (string) $namespace;
+    }
+
+    /**
+     * gets the global key namespace
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->_namespace;
+    }
+
+    /**
+     * is batch processing running?
+     *
+     * @return boolean
+     */
+    public function isBatch()
+    {
+        return $this->_isBatch;
+    }
+    
+    /**
+     * start batch-send-recording
+     * 
+     * @return void
+     */
+    public function startBatch()
+    {
+        $this->_isBatch = true;
+    }
+    
+    /**
+     * ends batch-send-recording and sends the recorded messages to the connection
+     *
+     * @return void
+     */
+    public function endBatch()
+    {
+        $this->_isBatch = false;
+        $this->_connection->send(join("\n", $this->_batch));
+        $this->_batch = array();
+    }
+    
+    /**
+     * stops batch-recording and resets the batch
+     *
+     * @return void
+     */
+    public function cancelBatch()
+    {
+        $this->_isBatch = false;
+        $this->_batch = array();
+    }
+}

--- a/www/lib/statsd-php/Domnikl/Statsd/Connection.php
+++ b/www/lib/statsd-php/Domnikl/Statsd/Connection.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Domnikl\Statsd;
+
+/**
+ * An interface for a Statsd connection implementation
+ *
+ * @author Derek Gallo <dgallo@avectra.com>
+ */
+interface Connection
+{
+
+    /**
+     * sends a message to Statsd
+     *
+     * @param $message
+     *
+     * @return void
+     */
+    public function send($message);
+    
+    /**
+     * is sampling forced?
+     *
+     * @return boolean
+     */
+    public function forceSampling();
+}
+	

--- a/www/lib/statsd-php/Domnikl/Statsd/Connection/Blackhole.php
+++ b/www/lib/statsd-php/Domnikl/Statsd/Connection/Blackhole.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Domnikl\Statsd\Connection;
+
+use Domnikl\Statsd\Connection as Connection;
+
+/**
+ * drops all requests, useful for dev environments
+ *
+ * @author Andrei Serdeliuc <andrei@serdeliuc.ro>
+ */
+class Blackhole implements Connection
+{ 
+    /**
+     * Drops any incoming messages
+     *
+     * @param $message
+     *
+     * @return void
+     */
+    public function send($message)
+    {
+        return false;
+    }
+
+    /**
+     * is sampling forced?
+     *
+     * @return boolean
+     */
+    public function forceSampling()
+    {
+        return false;
+    }
+}

--- a/www/lib/statsd-php/Domnikl/Statsd/Connection/Socket.php
+++ b/www/lib/statsd-php/Domnikl/Statsd/Connection/Socket.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Domnikl\Statsd\Connection;
+
+use Domnikl\Statsd\Connection as Connection;
+
+/**
+ * encapsulates the connection to the statsd service
+ *
+ * @author Dominik Liebler <liebler.dominik@googlemail.com>
+ */
+class Socket implements Connection
+{
+    /**
+     * host name
+     *
+     * @var string
+     */
+    protected $_host;
+
+    /**
+     * port number
+     *
+     * @var int
+     */
+    protected $_port;
+
+    /**
+     * Socket timeout
+     *
+     * @var int
+     */
+    protected $_timeout;
+
+    /**
+     * Persistent connection
+     *
+     * @var bool
+     */
+    protected $_persistent = false;
+
+    /**
+     * the used socket resource
+     *
+     * @var resource
+     */
+    protected $_socket;
+
+    /**
+     * is sampling allowed?
+     *
+     * @var bool
+     */
+    protected $_forceSampling = false;
+
+    /**
+     * instantiates the Connection object and a real connection to statsd
+     *
+     * @param string $host Statsd hostname
+     * @param int $port Statsd port
+     * @param int $timeout Connection timeout
+     * @param bool $persistent (default FALSE) Use persistent connection or not
+     */
+    public function __construct($host = 'localhost', $port = 8125, $timeout = null, $persistent = false)
+    {
+        $this->_host = (string)$host;
+        $this->_port = (int)$port;
+        $this->_timeout = $timeout;
+        $this->_persistent = $persistent;
+    }
+
+    /**
+     * connect to statsd service
+     */
+    protected function connect()
+    {
+        $errno = null;
+        $errstr = null;
+        if ($this->_persistent) {
+            $this->_socket = pfsockopen(sprintf("udp://%s", $this->_host), $this->_port, $errno, $errstr, $this->_timeout);
+        } else {
+            $this->_socket = fsockopen(sprintf("udp://%s", $this->_host), $this->_port, $errno, $errstr, $this->_timeout);
+        }
+    }
+
+    /**
+     * sends a message to the UDP socket
+     *
+     * @param $message
+     *
+     * @return void
+     */
+    public function send($message)
+    {
+        if (!$this->_socket) {
+            $this->connect();
+        }
+        if (0 != strlen($message) && $this->_socket) {
+            try {
+                // total suppression of errors
+                @fwrite($this->_socket, $message);
+            } catch (\Exception $e) {
+                // ignore it: stats logging failure shouldn't stop the whole app
+            }
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->_host;
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getPort()
+    {
+        return $this->_port;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeout()
+    {
+        return $this->_timeout;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPersistent()
+    {
+        return $this->_persistent;
+    }
+
+    /**
+     * is sampling forced?
+     *
+     * @return boolean
+     */
+    public function forceSampling()
+    {
+        return (bool)$this->_forceSampling;
+    }
+}

--- a/www/lib/statsd-php/LICENCE
+++ b/www/lib/statsd-php/LICENCE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2013 Dominik Liebler
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/www/lib/statsd.inc.php
+++ b/www/lib/statsd.inc.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Send test result to a Statsd instance
+ */
+require_once('./statsd-php/lib/Domnikl/Statsd/Connection.php');
+require_once('./statsd-php/lib/Domnikl/Statsd/Connection/Socket.php');
+require_once('./statsd-php/lib/Domnikl/Statsd/Client.php');
+
+function StatsdPostResult(&$test, $testPath) {
+  require_once ('page_data.inc');
+
+  $runs = $test['runs'];
+  if (array_key_exists('discard', $test) &&
+    $test['discard'] > 0 &&
+    $test['discard'] <= $runs) {
+    $runs -= $test['discard'];
+  }
+
+  if ($runs) {
+    $pageData = loadAllPageData($testPath);
+    $medians = array(GetMedianRun($pageData, 0), GetMedianRun($pageData, 1));
+    if (isset($pageData) && is_array($pageData)) {
+      foreach ($pageData as $run => &$pageRun) {
+        foreach ($pageRun as $cached => &$testData) {
+          if (GetSetting('statsdPattern') && !preg_match('/' . GetSetting('statsdPattern') . '/', $test['label'])) {
+            continue;
+          }
+          if (GetSetting('statsdMedianOnly') && !($medians[$cached] == $run)) {
+            continue;
+          }
+          $graphData = array();
+          foreach ($testData as $metric => $value) {
+            if (is_float($value)) {
+              $value = intval($value);
+            }
+
+            if (is_int($value) && $metric != 'result') {
+              $graphData[$metric] = $value;
+            }
+          }
+          StatsdPost($test['location'], $test['browser'], $test['label'], $cached, $graphData);
+        }
+      }
+    }
+  }
+}
+
+function StatsdPost($location, $browser, $label, $cached, &$metrics) {
+  $connection = new \Domnikl\Statsd\Connection\Socket(GetSetting('statsdHost'), (GetSetting('statsdPort') ?: 8125));
+  $statsd = new \Domnikl\Statsd\Client($connection, (GetSetting('statsdPrefix') ?: ''));
+
+  $base_key = graphite_key($location, $browser, $label, $cached);
+
+  foreach ($metrics as $metric => $value) {
+    $statsd->gauge($base_key . $metric, $value);
+  }
+}
+
+function graphite_key($location, $browser, $label, $cached, $metric) {
+  if (GetSetting('statsdCleanPattern')) {
+    $label = preg_replace('/' . GetSetting('statsdPattern') . '/', '', $label);
+  }
+  $fvrv = $cached ? 'repeat' : 'first';
+  $locationParts = explode('_', $location);
+  $location = $locationParts[0];
+  return "{$location}.{$browser}.{$label}.{$fvrv}.";
+}
+
+?>

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -70,6 +70,24 @@ allowPrivate=1
 ;tsview time-series database
 ;tsviewdb=http://<server:port>/src/v1/
 
+
+; Publish test results to a StatsD backend
+; for trend visualization.
+;
+; statsdHost - StatsD hostname.
+; statsdPort - StatsD port number (default: 8125).
+; statsdPrefix - Graphite key prefix (default: '').
+; statsdPattern - Set to a valid regexp pattern to send only matching tests labels.
+; statsdCleanPattern - Set to 1 to exclude pattern from label (default: 0).
+; statsdMedianOnly - Set to 1 to send only median tests to StatsD. (default: 0).
+;
+;statsdHost=127.0.0.1
+;statsdPort=8125
+;statsdPrefix=webpagetest
+;statsdPattern=^cron_
+;statsdCleanPattern=0
+;statsdMedianOnly=0
+
 ; Serialize the test results to a log file in JSON format for
 ; bulk logs processing (splunk, logster, flume, etc).
 ; The directories must already exist and have permissions set so the web server

--- a/www/work/postprocess.php
+++ b/www/work/postprocess.php
@@ -138,7 +138,14 @@ if (array_key_exists('test', $_REQUEST)) {
       require_once('./lib/tsview.inc.php');
       TSViewPostResult($testInfo, $id, $testPath, $settings['tsviewdb'], $testInfo['tsview_id']);
     }
-    
+
+    // post the test to statsd if requested
+    if (GetSetting('statsdHost') &&
+        is_file('./lib/statsd.inc.php')) {
+      require_once('./lib/statsd.inc.php');
+      StatsdPostResult($testInfo, $testPath);
+    }
+ 
     // Send an email notification if necessary
     $notifyFrom = GetSetting('notifyFrom');
     if ($notifyFrom && strlen($notifyFrom) && is_file("$testPath/testinfo.ini")) {


### PR DESCRIPTION
1. Adding a fully configurable statsd module to allow publishing results to a dedicated server for visualization of trends.
2. Embeding Domnikl/Statsd in the lib directory for the statsd protocol publishing phase.
3. This is a feature that seems to be used/request allot for webpagatest like done in [WptScript](https://github.com/etsy/wpt-script).

Output sample with [Grafana](http://grafana.org/) dashboard:
![image](https://cloud.githubusercontent.com/assets/3163605/5009809/09297b24-6a74-11e4-8e3e-d788637d65f0.png)

Many thanks for making this project !
