### PR TITLE
add config for accounts without a default VPC

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -479,13 +479,27 @@ function EC2_LaunchInstance($region, $ami, $size, $user_data, $loc) {
   if ($key && $secret) {
     try {
       $ec2 = \Aws\Ec2\Ec2Client::factory(array('key' => $key, 'secret' => $secret, 'region' => $region));
-      $response = $ec2->runInstances(array(
-          'ImageId' => $ami,
-          'MinCount' => 1,
-          'MaxCount' => 1,
-          'InstanceType' => $size,
-          'UserData' => base64_encode($user_data)
-      ));
+      $ec2_options = array (
+        'ImageId' => $ami,
+        'MinCount' => 1,
+        'MaxCount' => 1,
+        'InstanceType' => $size,
+        'UserData' => base64_encode ( $user_data )
+      );
+
+      //add/modify the SecurityGroupIds if present in config
+      $securityGroupIds = explode(",", GetSetting('EC2.'.$region.'.securityGroup'));
+      if (isset($securityGroupIds)) {
+        $ec2_options['SecurityGroupIds'] = $securityGroupIds;
+      }
+
+      //add/modify the SubnetId if present in config
+      $subnetId = GetSetting('EC2.'.$region.'.subnetId');
+      if (isset($subnetId)) {
+        $ec2_options['SubnetId'] = $subnetId;
+      }
+
+      $response = $ec2->runInstances ( $ec2_options );
       $ret = true;
       if (isset($loc) && strlen($loc) && isset($response['Instances'][0]['InstanceId'])) {
         $instance_id = $response['Instances'][0]['InstanceId'];

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -160,3 +160,9 @@ allowPrivate=1
 ; different settings (EC2.<location>.min/max).
 ;EC2.us-east-1.min=0
 ;EC2.us-east-1.max=1
+
+; Per-location Security Group and Subnet IDs to enable launching into VPCs 
+; (note that this will pin your instances to the availability zone associated with 
+; the subnet). This is required only if you do not have a default VPC.
+;EC2.us-west-2.securityGroup=sg-a0011b223,sg-b1122c334
+;EC2.us-west-2.subnetId=subnet-aaa0011bc1


### PR DESCRIPTION
This configuration change allows me to launch the new WPT AMI in my VPC and have the the browser instances also launching in my VPC so that no public DNS/IP is required for the WPT server. Tested well locally.