### PR TITLE
allow clearing out disk space without archiving

### DIFF
--- a/www/archive.inc
+++ b/www/archive.inc
@@ -17,6 +17,9 @@ function ArchiveTest($id, $store_result = true, $delete = false) {
     if ( strpos($id, '.') === false &&                           // make sure it isn't a relay test
         (array_key_exists('archive_dir', $settings) ||           // local mount
         array_key_exists('archive_s3_server', $settings)) ) {    // S3 Interface (Internet Archive or standard)
+        if ($settings['archive_dir'] == 'none') { // don't archive anything
+            return true;
+        }
         $status = GetTestStatus($id, false);
         $completed = true;
         if ($status['statusCode'] >= 100 && $status['statusCode'] < 200)
@@ -144,6 +147,9 @@ function RestoreArchive($id) {
             array_key_exists('archive_dir', $settings) || 
             array_key_exists('archive_s3_url', $settings) ||
             array_key_exists('archive_s3_server', $settings)) {
+            if ($settings['archive_dir'] == 'none') { // don't restore anything
+                return true;
+            }
             $deleteZip = true;
             $zipfile = "./tmp/$id.zip";
             if (strlen($url)) {

--- a/www/cli/archive.php
+++ b/www/cli/archive.php
@@ -225,7 +225,7 @@ function CheckTest($testPath, $id, $elapsedDays) {
     if (isset($elapsed)) {
       if( $elapsed >= $MIN_DAYS ) {
           $delete = true;
-          if (ArchiveTest($id) ) {
+          if (ArchiveTest($id) || $archive_dir == 'none') { // archive_dir == none indicates don't archive anything
               $archiveCount++;
               $logLine .= "Archived";
                                                                                             

--- a/www/cli/archive.php
+++ b/www/cli/archive.php
@@ -225,7 +225,10 @@ function CheckTest($testPath, $id, $elapsedDays) {
     if (isset($elapsed)) {
       if( $elapsed >= $MIN_DAYS ) {
           $delete = true;
-          if ($archive_dir != 'none' && ArchiveTest($id)) { // archive_dir == none indicates don't archive anything
+          if ($archive_dir == 'none') { // archive_dir == none indicates don't archive anything
+              $delete = true;
+          }
+          else if (ArchiveTest($id)) {
               $archiveCount++;
               $logLine .= "Archived";
                                                                                             

--- a/www/cli/archive.php
+++ b/www/cli/archive.php
@@ -225,7 +225,7 @@ function CheckTest($testPath, $id, $elapsedDays) {
     if (isset($elapsed)) {
       if( $elapsed >= $MIN_DAYS ) {
           $delete = true;
-          if (ArchiveTest($id) || $archive_dir == 'none') { // archive_dir == none indicates don't archive anything
+          if ($archive_dir != 'none' && ArchiveTest($id)) { // archive_dir == none indicates don't archive anything
               $archiveCount++;
               $logLine .= "Archived";
                                                                                             


### PR DESCRIPTION
Specifying archive_dir='none' in settings.ini will now skip archiving
in www/cli/archive.php

See discussion in http://www.webpagetest.org/forums/showthread.php?tid=13516&pid=25469