### PR TITLE
Add Surge as a known CDN

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -87,9 +87,9 @@ CDN_PROVIDER cdnList[] = {
   {".nyiftw.com", _T("NYI FTW")},
   {".resrc.it", _T("ReSRC.it")},
   {".zenedge.net", _T("Zenedge")},
-  {".lswcdn.net", _T("LeaseWeb CDN")},  
-  {".revcn.net", _T("Rev Software")},  
-  {".revdn.net", _T("Rev Software")},  
+  {".lswcdn.net", _T("LeaseWeb CDN")},
+  {".revcn.net", _T("Rev Software")},
+  {".revdn.net", _T("Rev Software")},
   {".caspowa.com", _T("Caspowa")},
   {NULL, NULL}
 };
@@ -118,5 +118,6 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "leasewebcdn", _T("LeaseWeb CDN")},
   {"Via", "Rev-Cache", _T("Rev Software")},
   {"X-Rev-Cache", "", _T("Rev Software")},
-  {"Server", "Caspowa", _T("Caspowa")}
+  {"Server", "Caspowa", _T("Caspowa")},
+  {"Server", "SurgeCDN", "Surge"}
 };

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -2,27 +2,27 @@
 Copyright (c) 2011, Google Inc.
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright notice, 
+    * Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
-    * Neither the name of the <ORGANIZATION> nor the names of its contributors 
-    may be used to endorse or promote products derived from this software 
+    * Neither the name of the <ORGANIZATION> nor the names of its contributors
+    may be used to endorse or promote products derived from this software
     without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
@@ -127,7 +127,7 @@ CDN_PROVIDER cdnList[] = {
   {".nyiftw.com", "NYI FTW"},
   {".resrc.it", "ReSRC.it"},
   {".zenedge.net", "Zenedge"},
-  {".lswcdn.net", "LeaseWeb CDN"},  
+  {".lswcdn.net", "LeaseWeb CDN"},
   {".revcn.net", "Rev Software"},
   {".revdn.net", "Rev Software"},
   {".caspowa.com", "Caspowa"},
@@ -153,5 +153,6 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "leasewebcdn", "LeaseWeb CDN"},
   {"Via", "Rev-Cache", "Rev Software"},
   {"X-Rev-Cache", "", "Rev Software"},
-  {"Server", "Caspowa", "Caspowa"}
+  {"Server", "Caspowa", "Caspowa"},
+  {"Server", "SurgeCDN", "Surge"}
 };


### PR DESCRIPTION
[Surge](https://surge.sh/) is a static hosting platform which also has its own CDN platform. 