### PR TITLE
Support basic authentication and HTTPS when communicating with WP

### DIFF
--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -537,11 +537,11 @@ bool WebPagetest::CrackUrl(CString url, CString &host, unsigned short &port,
       object = path;
       object += extra;
       if (!lstrcmpi(scheme, _T("https"))) {
-		    secure_flag = INTERNET_FLAG_SECURE;
-		    if (!_settings._requireValidCertificate) {
-			    secure_flag |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID |
-				    INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
-		    }
+        secure_flag = INTERNET_FLAG_SECURE;
+        if (!_settings._requireValidCertificate) {
+          secure_flag |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID |
+          INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+        }
         if (!port)
           port = INTERNET_DEFAULT_HTTPS_PORT;
       } else if (!port)

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -282,7 +282,7 @@ bool WebPagetest::UploadData(WptTestDriver& test, bool done) {
 }
 
 /*-----------------------------------------------------------------------------
-  Set the credentials requuired to access the server, if configured
+  Set the credentials required to access the server, if configured
 -----------------------------------------------------------------------------*/
 void WebPagetest::SetLoginCredentials(HINTERNET request) {
   if (!_settings._username.IsEmpty() & !_settings._password.IsEmpty()) {

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -285,7 +285,7 @@ bool WebPagetest::UploadData(WptTestDriver& test, bool done) {
   Set the credentials required to access the server, if configured
 -----------------------------------------------------------------------------*/
 void WebPagetest::SetLoginCredentials(HINTERNET request) {
-  if (!_settings._username.IsEmpty() & !_settings._password.IsEmpty()) {
+  if (!_settings._username.IsEmpty() && !_settings._password.IsEmpty()) {
     InternetSetOption(request, INTERNET_OPTION_USERNAME,
       (LPVOID)(PCTSTR)(_settings._username), _settings._username.GetLength() + 1);
     InternetSetOption(request, INTERNET_OPTION_PASSWORD,

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "StdAfx.h"
 #include "webpagetest.h"
-#include <Wininet.h>
 #include <Wincrypt.h>
 #include <Shellapi.h>
 #include <IPHlpApi.h>
@@ -283,6 +282,18 @@ bool WebPagetest::UploadData(WptTestDriver& test, bool done) {
 }
 
 /*-----------------------------------------------------------------------------
+  Set the credentials requuired to access the server, if configured
+-----------------------------------------------------------------------------*/
+void WebPagetest::SetLoginCredentials(HINTERNET request) {
+  if (!_settings._username.IsEmpty() & !_settings._password.IsEmpty()) {
+    InternetSetOption(request, INTERNET_OPTION_USERNAME,
+      (LPVOID)(PCTSTR)(_settings._username), _settings._username.GetLength() + 1);
+    InternetSetOption(request, INTERNET_OPTION_PASSWORD,
+      (LPVOID)(PCTSTR)(_settings._password), _settings._password.GetLength() + 1);
+  }
+}
+
+/*-----------------------------------------------------------------------------
   Perform a http GET operation and return the body as a string
 -----------------------------------------------------------------------------*/
 bool WebPagetest::HttpGet(CString url, WptTestDriver& test,
@@ -304,43 +315,56 @@ bool WebPagetest::HttpGet(CString url, WptTestDriver& test,
                       &timeout, sizeof(timeout));
     CString host, object;
     unsigned short port;
-    DWORD secure_flag;
-    if (CrackUrl(url, host, port, object, secure_flag)) {
-      HINTERNET http_request = InternetOpenUrl(internet, url, NULL, 0, 
-                                  INTERNET_FLAG_NO_CACHE_WRITE | 
-                                  INTERNET_FLAG_NO_UI | 
-                                  INTERNET_FLAG_PRAGMA_NOCACHE | 
-                                  INTERNET_FLAG_RELOAD |
-                                  secure_flag, NULL);
-      if (http_request) {
-        TCHAR mime_type[1024] = TEXT("\0");
-        DWORD len = _countof(mime_type);
-        if (HttpQueryInfo(http_request,HTTP_QUERY_CONTENT_TYPE, mime_type, 
-                            &len, NULL)) {
-          result = true;
-          bool is_zip = false;
-          char buff[4097];
-          DWORD bytes_read, bytes_written;
-          HANDLE file = INVALID_HANDLE_VALUE;
-          if (!lstrcmpi(mime_type, _T("application/zip"))) {
-            zip_file = test._directory + _T("\\wpt.zip");
-            file = CreateFile(zip_file,GENERIC_WRITE,0,0,CREATE_ALWAYS,0,NULL);
-            is_zip = true;
-          }
-          while (InternetReadFile(http_request, buff, sizeof(buff) - 1, 
-                  &bytes_read) && bytes_read) {
-            if (is_zip) {
-              WriteFile(file, buff, bytes_read, &bytes_written, 0);
-            } else {
-              // NULL-terminate it and add it to our response string
-              buff[bytes_read] = 0;
-              test_string += CA2T(buff, CP_UTF8);
+    DWORD secure_flags;
+    if (CrackUrl(url, host, port, object, secure_flags)) {
+      HINTERNET connect = InternetConnect(internet, host, port, NULL, NULL,
+        INTERNET_SERVICE_HTTP, 0, 0);
+      if (connect) {
+        HINTERNET request = HttpOpenRequest(connect, _T("GET"), object, NULL, NULL, NULL,
+          INTERNET_FLAG_NO_CACHE_WRITE |
+          INTERNET_FLAG_NO_UI |
+          INTERNET_FLAG_PRAGMA_NOCACHE |
+          INTERNET_FLAG_RELOAD | 
+          INTERNET_FLAG_KEEP_CONNECTION | 
+          secure_flags, 0);
+        if (request) {
+
+          SetLoginCredentials(request);
+
+          if (HttpSendRequest(request, NULL, 0, NULL, 0)) {
+            TCHAR mime_type[1024] = TEXT("\0");
+            DWORD len = _countof(mime_type);
+
+            if (HttpQueryInfo(request, HTTP_QUERY_CONTENT_TYPE, mime_type,
+              &len, NULL)) {
+              result = true;
+              bool is_zip = false;
+              char buff[4097];
+              DWORD bytes_read, bytes_written;
+              HANDLE file = INVALID_HANDLE_VALUE;
+              if (!lstrcmpi(mime_type, _T("application/zip"))) {
+                zip_file = test._directory + _T("\\wpt.zip");
+                file = CreateFile(zip_file, GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, NULL);
+                is_zip = true;
+              }
+              while (InternetReadFile(request, buff, sizeof(buff) - 1,
+                &bytes_read) && bytes_read) {
+                if (is_zip) {
+                  WriteFile(file, buff, bytes_read, &bytes_written, 0);
+                }
+                else {
+                  // NULL-terminate it and add it to our response string
+                  buff[bytes_read] = 0;
+                  test_string += CA2T(buff, CP_UTF8);
+                }
+              }
+              if (file != INVALID_HANDLE_VALUE)
+                CloseHandle(file);
             }
           }
-          if (file != INVALID_HANDLE_VALUE)
-            CloseHandle(file);
+          InternetCloseHandle(request);
         }
-        InternetCloseHandle(http_request);
+        InternetCloseHandle(connect);
       }
     }
     InternetCloseHandle(internet);
@@ -413,6 +437,7 @@ bool WebPagetest::UploadFile(CString url, bool done, WptTestDriver& test,
                                               INTERNET_FLAG_KEEP_CONNECTION |
                                               secure_flag, NULL);
         if (request) {
+          SetLoginCredentials(request);
           if (HttpAddRequestHeaders(request, headers, headers.GetLength(), 
                                     HTTP_ADDREQ_FLAG_ADD |
                                     HTTP_ADDREQ_FLAG_REPLACE)) {
@@ -512,9 +537,11 @@ bool WebPagetest::CrackUrl(CString url, CString &host, unsigned short &port,
       object = path;
       object += extra;
       if (!lstrcmpi(scheme, _T("https"))) {
-        secure_flag = INTERNET_FLAG_SECURE |
-                      INTERNET_FLAG_IGNORE_CERT_CN_INVALID |
-                      INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+		    secure_flag = INTERNET_FLAG_SECURE;
+		    if (!_settings._requireValidCertificate) {
+			    secure_flag |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID |
+				    INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+		    }
         if (!port)
           port = INTERNET_DEFAULT_HTTPS_PORT;
       } else if (!port)

--- a/agent/wptdriver/webpagetest.h
+++ b/agent/wptdriver/webpagetest.h
@@ -27,6 +27,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
 #pragma once
+
+#include <Wininet.h>
+
 class WebPagetest {
 public:
   WebPagetest(WptSettings &settings, WptStatus &status);
@@ -50,6 +53,7 @@ private:
   CString       _computer_name;
   CString       _dns_servers;
 
+  void SetLoginCredentials(HINTERNET request);
   bool HttpGet(CString url, WptTestDriver& test, CString& test_string, 
                CString& zip_file);
   bool ParseTest(CString& test_string, WptTestDriver& test);

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -150,10 +150,10 @@ bool WptSettings::Load(void) {
 -----------------------------------------------------------------------------*/
 void WptSettings::LoadFromEC2(void) {
 
-  CString userData = "wpt_username=feo wpt_password=Fe0Optimize@ wpt_validcertificate=1 wpt_server=https://54.204.44.126 wpt_location=us_east_ie10 wpt_key=1UsKey1";
-  //if (GetUrlText(_T("http://169.254.169.254/latest/user-data"), userData)) {
+  CString userData;
+  if (GetUrlText(_T("http://169.254.169.254/latest/user-data"), userData)) {
     ParseInstanceData(userData);
-  /*}
+  }
 
   if (_location.IsEmpty()) {
     CString zone;
@@ -170,7 +170,7 @@ void WptSettings::LoadFromEC2(void) {
 
   GetUrlText(_T("http://169.254.169.254/latest/meta-data/instance-id"), 
     _ec2_instance);
-  _ec2_instance = _ec2_instance.Trim();*/
+  _ec2_instance = _ec2_instance.Trim();
 }
 
 /*-----------------------------------------------------------------------------
@@ -492,7 +492,6 @@ void BrowserSettings::CleanupCustomBrowsers(CString browser) {
   Reset the browser user profile (nuke the directory, copy the template over)
 -----------------------------------------------------------------------------*/
 void BrowserSettings::ResetProfile(bool clear_certs) {
-  return;
   // clear the browser-specific profile directory
   if (_cache_directory.GetLength()) {
     DeleteDirectory(_cache_directory, false);

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -87,13 +87,13 @@ bool WptSettings::Load(void) {
   }
 
   if (GetPrivateProfileString(_T("WebPagetest"), _T("username"), _T(""), buff,
-	  _countof(buff), iniFile)) {
-	  _username = buff;
+    _countof(buff), iniFile)) {
+    _username = buff;
   }
 
   if (GetPrivateProfileString(_T("WebPagetest"), _T("password"), _T(""), buff,
-	  _countof(buff), iniFile)) {
-	  _password = buff;
+    _countof(buff), iniFile)) {
+    _password = buff;
   }
 
   if (GetPrivateProfileString(_T("WebPagetest"), _T("Location"), _T(""), buff, 
@@ -108,7 +108,7 @@ bool WptSettings::Load(void) {
 
   if (GetPrivateProfileInt(_T("WebPagetest"), _T("Valid Certificate"), 
     _requireValidCertificate, iniFile)) {
-	  _requireValidCertificate = true;
+    _requireValidCertificate = true;
   }
 
   #ifdef DEBUG

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -225,10 +225,11 @@ void WptSettings::ParseInstanceData(CString &userData) {
           if (!key.CompareNoCase(_T("wpt_server"))) {
             if (value.Find(_T("http://")) == -1 && value.Find(_T("https://")) == -1)
               _server = CString(_T("http://")) + value + _T("/");
-            else
+            else {
               _server = value;
               if (_server.Right(1) != '/')
                 _server += "/";
+            }
           } else if (!key.CompareNoCase(_T("wpt_username")))
             _username = value;
           else if (!key.CompareNoCase(_T("wpt_password")))

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -42,7 +42,8 @@ WptSettings::WptSettings(WptStatus &status):
   ,_polling_delay(DEFAULT_POLLING_DELAY)
   ,_debug(0)
   ,_status(status)
-  ,_software_update(status) {
+  ,_software_update(status)
+  ,_requireValidCertificate(false) {
 }
 
 /*-----------------------------------------------------------------------------
@@ -85,6 +86,16 @@ bool WptSettings::Load(void) {
     _server.Replace(_T("www.webpagetest.org"), _T("agent.webpagetest.org"));
   }
 
+  if (GetPrivateProfileString(_T("WebPagetest"), _T("username"), _T(""), buff,
+	  _countof(buff), iniFile)) {
+	  _username = buff;
+  }
+
+  if (GetPrivateProfileString(_T("WebPagetest"), _T("password"), _T(""), buff,
+	  _countof(buff), iniFile)) {
+	  _password = buff;
+  }
+
   if (GetPrivateProfileString(_T("WebPagetest"), _T("Location"), _T(""), buff, 
     _countof(buff), iniFile )) {
     _location = buff;
@@ -93,6 +104,11 @@ bool WptSettings::Load(void) {
   if (GetPrivateProfileString(_T("WebPagetest"), _T("Key"), _T(""), buff, 
     _countof(buff), iniFile )) {
     _key = buff;
+  }
+
+  if (GetPrivateProfileInt(_T("WebPagetest"), _T("Valid Certificate"), 
+    _requireValidCertificate, iniFile)) {
+	  _requireValidCertificate = true;
   }
 
   #ifdef DEBUG
@@ -134,10 +150,10 @@ bool WptSettings::Load(void) {
 -----------------------------------------------------------------------------*/
 void WptSettings::LoadFromEC2(void) {
 
-  CString userData;
-  if (GetUrlText(_T("http://169.254.169.254/latest/user-data"), userData)) {
+  CString userData = "wpt_username=feo wpt_password=Fe0Optimize@ wpt_validcertificate=1 wpt_server=https://54.204.44.126 wpt_location=us_east_ie10 wpt_key=1UsKey1";
+  //if (GetUrlText(_T("http://169.254.169.254/latest/user-data"), userData)) {
     ParseInstanceData(userData);
-  }
+  /*}
 
   if (_location.IsEmpty()) {
     CString zone;
@@ -154,7 +170,7 @@ void WptSettings::LoadFromEC2(void) {
 
   GetUrlText(_T("http://169.254.169.254/latest/meta-data/instance-id"), 
     _ec2_instance);
-  _ec2_instance = _ec2_instance.Trim();
+  _ec2_instance = _ec2_instance.Trim();*/
 }
 
 /*-----------------------------------------------------------------------------
@@ -206,8 +222,19 @@ void WptSettings::ParseInstanceData(CString &userData) {
         CString value = token.Mid(split + 1).Trim();
 
         if (key.GetLength() && value.GetLength()) {
-          if (!key.CompareNoCase(_T("wpt_server")))
-            _server = CString(_T("http://")) + value + _T("/");
+          if (!key.CompareNoCase(_T("wpt_server"))) {
+            if (value.Find(_T("http://")) == -1 && value.Find(_T("https://")) == -1)
+              _server = CString(_T("http://")) + value + _T("/");
+            else
+              _server = value;
+              if (_server.Right(1) != '/')
+                _server += "/";
+          } else if (!key.CompareNoCase(_T("wpt_username")))
+            _username = value;
+          else if (!key.CompareNoCase(_T("wpt_password")))
+            _password = value;
+          else if (!key.CompareNoCase(_T("wpt_validcertificate")))
+            _requireValidCertificate = (0 == value.Compare(_T("1")));
           else if (!key.CompareNoCase(_T("wpt_loc")))
             _location = value; 
           else if (_location.IsEmpty() &&
@@ -465,6 +492,7 @@ void BrowserSettings::CleanupCustomBrowsers(CString browser) {
   Reset the browser user profile (nuke the directory, copy the template over)
 -----------------------------------------------------------------------------*/
 void BrowserSettings::ResetProfile(bool clear_certs) {
+  return;
   // clear the browser-specific profile directory
   if (_cache_directory.GetLength()) {
     DeleteDirectory(_cache_directory, false);

--- a/agent/wptdriver/wpt_settings.h
+++ b/agent/wptdriver/wpt_settings.h
@@ -102,6 +102,8 @@ public:
   bool ReInstallBrowser();
 
   CString _server;
+  CString _username;
+  CString _password;
   CString _location;
   CString _key;
   DWORD   _timeout;
@@ -113,6 +115,7 @@ public:
   CString _ec2_instance;
   CString _azure_instance;
   CString _clients_directory;
+  BOOL _requireValidCertificate;
 
   BrowserSettings _browser;
   SoftwareUpdate _software_update;

--- a/agent/wptdriver/wptdriver.ini.sample
+++ b/agent/wptdriver/wptdriver.ini.sample
@@ -5,6 +5,13 @@ Time Limit=120
 ;key=TestKey123
 ;Automatically install and update support software (Flash, Silverlight, etc)
 software=http://www.webpagetest.org/installers/software.dat
+; Optional credentials
+; username=user
+; password=mypassword
+; Optional: only applies if the scheme of the URL is https.
+; Check if the CN of the WPT server SSL certificate matches the host in the url parameter, and if the certificate has expired.
+; Default is '0', which disables these checks.
+; Valid Certificate=1
 
 [Chrome]
 exe="%PROGRAM_FILES%\Google\Chrome\Application\chrome.exe"


### PR DESCRIPTION
Support basic authentication and HTTPS when communicating with the WPT server.  Can also select whether a valid certificate is expected.  All parameters are configurable through the settings.ini or EC2 user-data.

Note that the credentials are sent with the initial request to the WPT server, instead of sending a request without credentials, detecting the 401 response, then re-requesting with the credentials.