### PR TITLE
support ignoreSSL option in nodejs agent 

### DIFF
--- a/agent/js/src/browser_local_chrome.js
+++ b/agent/js/src/browser_local_chrome.js
@@ -57,6 +57,8 @@ function BrowserLocalChrome(app, args) {
   this.serverUrl_ = undefined;  // WebDriver server URL for WebDriver tests.
   this.devToolsPort_ = 1234;  // If running without chromedriver.
   this.devToolsUrl_ = undefined;    // If running without chromedriver.
+  this.chromeFlags_ = CHROME_FLAGS;
+  this.task_ = args.task;
 }
 util.inherits(BrowserLocalChrome, browser_base.BrowserBase);
 /** @constructor */
@@ -101,9 +103,12 @@ BrowserLocalChrome.prototype.startWdServer = function(browserCaps) {
 BrowserLocalChrome.prototype.startBrowser = function() {
   'use strict';
   // TODO(klm): clean profile, see how ChromeDriver does it.
-  this.startChildProcess(this.chrome_ || 'chrome',
-      CHROME_FLAGS.concat('-remote-debugging-port=' + this.devToolsPort_),
-      'Chrome');
+  var flags = CHROME_FLAGS;
+  flags.push('-remote-debugging-port=' + this.devToolsPort_);
+  if (this.task_.ignoreSSL) {
+    flags.push('--ignore-certificate-errors');
+  }
+  this.startChildProcess(this.chrome_ || 'chrome', flags, 'Chrome');
   // Make sure we set devToolsUrl_ only after the child process start success.
   this.app_.schedule('Set DevTools URL', function() {
     this.devToolsUrl_ = 'http://localhost:' + this.devToolsPort_ + '/json';


### PR DESCRIPTION
Allows to test https urls with self-signed certificates with the nodejs agent and a local chrome browser.
Tested this on CentOS7 with node v0.10.36. Passed unit test and lint checks. This would be my first contribution.