### PR TITLE
Fix request details content area overflow.

### DIFF
--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -241,7 +241,7 @@ table.pretty th.border, table.pretty td.border { border-left: 2px black solid; }
 table.pretty td.even { background: whitesmoke; }
 
 /* details page */
-#headers {text-align: left; width:930px; overflow:hidden;}
+#headers {text-align: left; width:930px; overflow:auto;}
 #headers h1, #headers h2 {text-transform:none;} 
 
 /* feeds */


### PR DESCRIPTION
The hidden overflow makes it difficult to view long lines of text. By setting it to auto instead, the user can scroll freely without the content overflowing beyond the container. When there's nothing to scroll, no scroll bars are visible.