### PR TITLE
Fixed graph titles

### DIFF
--- a/www/graph_page_data.php
+++ b/www/graph_page_data.php
@@ -1,7 +1,7 @@
 <?php 
 // We intend to change to "?tests" but also allow "?test" so as to not break existing links.
 $tests = (isset($_REQUEST['tests'])) ? $_REQUEST['tests'] : $_REQUEST['test'];
-$tests = preg_replace('/[^a-zA-Z0-9,_\.\-:]/', '', $tests);
+$tests = preg_replace('/[^a-zA-Z0-9,_\.\-:\ ]/', '', $tests);
 
 // Get choice of statistical control from request URL.
 $statControl = 'None'; // 'None' or index starting with 1 into list of tests.

--- a/www/graph_page_data.php
+++ b/www/graph_page_data.php
@@ -1,7 +1,7 @@
 <?php 
 // We intend to change to "?tests" but also allow "?test" so as to not break existing links.
 $tests = (isset($_REQUEST['tests'])) ? $_REQUEST['tests'] : $_REQUEST['test'];
-$tests = preg_replace('/[^a-zA-Z0-9,_\.\-]/', '', $tests);
+$tests = preg_replace('/[^a-zA-Z0-9,_\.\-:]/', '', $tests);
 
 // Get choice of statistical control from request URL.
 $statControl = 'None'; // 'None' or index starting with 1 into list of tests.


### PR DESCRIPTION
The XSS protection that was implemented a few days ago broke the ability to have custom labels for graphs. E.g.

http://www.webpagetest.org/graph_page_data.php?tests=150719_V6_86a50070c2de235195ba33d81e1d306e-l:test,150719_8F_ed3ff2b7158eba3b3bdcc2124fd65548-l:control&medianMetric=loadTime&fv=1&median_value=1&control=NOSTAT
