### PR TITLE
Fix #464: build issues related to mozjpeg

### DIFF
--- a/agent/wpthook/mozjpeg/.gitignore
+++ b/agent/wpthook/mozjpeg/.gitignore
@@ -12,8 +12,6 @@ Makefile
 /stamp-h*
 /java/classnoinst.stamp
 /pkgscripts/
-/jconfig.h
-/jconfigint.h
 /config.guess
 /config.h
 /config.h.in

--- a/agent/wpthook/mozjpeg/jconfig.h
+++ b/agent/wpthook/mozjpeg/jconfig.h
@@ -1,0 +1,50 @@
+/* jconfig.vc --- jconfig.h for Microsoft Visual C++ on Windows 95 or NT. */
+/* see jconfig.txt for explanations */
+
+#define JPEG_LIB_VERSION 62
+#define LIBJPEG_TURBO_VERSION 3.1
+#define C_ARITH_CODING_SUPPORTED 
+#define D_ARITH_CODING_SUPPORTED
+#define MEM_SRCDST_SUPPORTED
+
+/*
+ * Define BITS_IN_JSAMPLE as either
+ *   8   for 8-bit sample values (the usual setting)
+ *   12  for 12-bit sample values
+ * Only 8 and 12 are legal data precisions for lossy JPEG according to the
+ * JPEG standard, and the IJG code does not support anything else!
+ * We do not support run-time selection of data precision, sorry.
+ */
+
+#define BITS_IN_JSAMPLE  8      /* use 8 or 12 */
+
+#define HAVE_UNSIGNED_CHAR
+#define HAVE_UNSIGNED_SHORT
+/* #define void char */
+/* #define const */
+#undef __CHAR_UNSIGNED__
+#define HAVE_STDDEF_H
+#define HAVE_STDLIB_H
+#undef NEED_BSD_STRINGS
+#undef NEED_SYS_TYPES_H
+#undef NEED_FAR_POINTERS	/* we presume a 32-bit flat memory model */
+#undef INCOMPLETE_TYPES_BROKEN
+
+/* Define "boolean" as unsigned char, not int, per Windows custom */
+#ifndef __RPCNDR_H__		/* don't conflict if rpcndr.h already read */
+typedef unsigned char boolean;
+#endif
+#define HAVE_BOOLEAN		/* prevent jmorecfg.h from redefining it */
+
+/* Define "INT32" as int, not long, per Windows custom */
+#if !(defined(_BASETSD_H_) || defined(_BASETSD_H))   /* don't conflict if basetsd.h already read */
+typedef short INT16;
+typedef signed int INT32;
+#endif
+#define XMD_H                   /* prevent jmorecfg.h from redefining it */
+
+#ifdef JPEG_INTERNALS
+
+#undef RIGHT_SHIFT_IS_UNSIGNED
+
+#endif /* JPEG_INTERNALS */

--- a/agent/wpthook/mozjpeg/jconfigint.h
+++ b/agent/wpthook/mozjpeg/jconfigint.h
@@ -1,0 +1,13 @@
+#define VERSION "3.1"
+#define BUILD "20150722"
+#define PACKAGE_NAME "mozjpeg"
+
+#ifndef INLINE
+#if defined(__GNUC__)
+#define INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define INLINE __forceinline
+#else
+#define INLINE
+#endif
+#endif

--- a/agent/wpthook/wpthook.vcxproj
+++ b/agent/wpthook/wpthook.vcxproj
@@ -670,6 +670,14 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="mozjpeg\jcarith.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="mozjpeg\jdarith.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="mozjpeg\jcapimin.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>


### PR DESCRIPTION
-- Generate jconfig.h and jconfigint.h using CMake
-- Include jcarith.c and jdarith.c to enable arithmetic encoding/decoding
-- Remove jconfig.h and jconfigint.h from .gitignore for successful builds