### PR TITLE
Add two powershell scripts to automate the build of wptdriver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ webpagetest.vsmdi
 *.idx
 *.ncb
 *.$wrk
+*.swp
 agent/js/*.log
 agent/js/node_modules/.bin/jshint
 agent/js/node_modules/jshint/

--- a/agent/browser/chrome/compile.cmd
+++ b/agent/browser/chrome/compile.cmd
@@ -25,4 +25,3 @@ copy "%~dp0extension\manifest.json" "%~dp0extension\release\manifest.json"
 copy "%~dp0extension\wpt\*.html" "%~dp0extension\release\wpt\"
 copy "%~dp0extension\wpt\*.jpg"  "%~dp0extension\release\wpt\"
 copy "%~dp0extension\wpt\*.css"  "%~dp0extension\release\wpt\"
-pause

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,52 @@
+# Setup & Build scripts
+
+This directory contains a few scripts to simplify setting up the Windows agent
+of webpagetest.
+
+The scripts have been developed and tested on Windows 8.1 Enterprise
+
+## Requirements
+```
+# Use at our own risks.
+Set-ExecutionPolicy Unrestricted
+```
+
+## Setup script
+```installdeps.ps1``` simplifies installing webpagetest dependencies, such as
+Visual Studio for compiling wpt-driver. It will first download
+and install [Chocolatey](https://chocolatey.org), a package manager for Windows.
+
+Usage:
+from a Powershell with Administrative power
+```
+cd \Path\To\WebPageTest
+.\scripts\installdeps.ps1
+```
+
+## Building wpt-driver update archive
+```create-update.ps``` compiles the wpt-driver Visual Studio solution using
+whichever version of Visual Studio is available in the path. If you used
+```installdeps.ps1``` for setting up your machine, it will most likely be Visual
+Studio 2013 Community Edition. It will then bundle up the binary along with the
+browser extensions and produce a zip file suitable for updating agents
+
+It is recommended to run this script from the a GitHub powershell, as it's PATH
+is already miraculously setup to contain everything needed
+
+Usage:
+```
+cd \Path\To\WebPageTest
+.\scripts\create-update.ps1
+```
+
+### Troubleshooting
+If you see a whole bunch of red lines when executing one of these scripts, you
+have a problem. Here are a few things to check:
+* You are running in a shell with administrative powers
+* You have all the dependencies installed (in particular, Visual Studio)
+* ```MSBuild.exe``` is in the PATH
+* ```python.exe``` is in the PATH
+
+# Copyright
+Copyright (c) AppDynamics, Inc., and its affiliates 2015  
+All rights reserved

--- a/scripts/create-update.ps1
+++ b/scripts/create-update.ps1
@@ -1,0 +1,92 @@
+<#
+Copyright (c) AppDynamics, Inc., and its affiliates 2015
+All rights reserved
+
+Build script for wpt-driver.
+
+REQUIREMENTS:
+- msbuild.exe and python.exe (required by the Chrome compile.cmd) should be in
+  the path
+
+This script has been tested in GitHub's Git Shell.
+Executing it in a regular PowerShell may also work, but you will have to
+setup the path for each dependencies.
+#>
+
+param(
+    [string]$configuration = "Release"
+)
+
+$wptroot = $PSScriptRoot + "\.."
+
+"*** Building wpt-driver with $configuration configuration"
+
+# ZipFiles implementation from:
+# http://stackoverflow.com/a/13302548
+function ZipFiles( $zipFilename, $sourceDir)
+{
+   Add-Type -Assembly System.IO.Compression.FileSystem
+   $compressionLevel = [System.IO.Compression.CompressionLevel]::Optimal
+   [System.IO.Compression.ZipFile]::CreateFromDirectory($sourcedir,
+        $zipfilename, $compressionLevel, $false)
+}
+
+$releasedir = Get-ChildItem $wptroot $configuration
+$outdir = ($releasedir.fullname + "\dist")
+
+# Create output directories
+if (test-path $outdir) { remove-item -recurse $outdir }
+mkdir $outdir | Out-Null
+mkdir ($outdir + "\extension") | Out-Null
+mkdir ($outdir + "\extension\templates") | Out-Null
+
+"-> Building the Visual Studio Solution in $configuration configuration"
+"(log file is $wptroot\$configuration\msbuild.log)"
+msbuild.exe webpagetest.sln /P:Configuration=$configuration | Out-File ($outdir + "\msbuild.log")
+
+# Copying compiled stuff into the output directory
+$binaries = "wptbho.dll", "wptdriver.exe", "wpthook.dll", "wptload.dll", "wptupdate.exe", "wptwatchdog.exe"
+foreach ($bin in $binaries) {
+	Get-ChildItem -Path $wptroot\$configuration $bin | Copy-Item -Destination $outdir
+}
+
+"-> Building and copying Chrome extension"
+"(log file is $wptroot\$configuration\msbuild.log)"
+& $wptroot\agent\browser\chrome\compile.cmd 2>&1 | Out-File ($outdir + "\chromebuild.log")
+copy-item -recurse $wptroot\agent\browser\chrome\extension\release\ $wptroot\$configuration\dist\extension\extension
+
+"-> Zipping Chrome extension"
+$extdir=Get-ChildItem $wptroot\$configuration\dist extension
+Add-Type -Assembly System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::CreateFromDirectory($extdir.fullname,
+	($outdir + "\extension.zip"))
+
+"-> Copying Firefox extension"
+copy-item -recurse $wptroot\agent\browser\firefox\ $wptroot\$configuration\dist\extension\templates\Firefox
+
+"-> Writing wptupdate.ini with MD5 hashes"
+$tohash= $binaries + "extension.zip"
+
+$wptexec = ($releasedir.fullname + "\wptdriver.exe")
+$ver = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($wptexec).FileVersion.split(".")[3]
+
+$ini=@"
+[version]
+ver=$ver
+
+[md5]
+"@
+
+$wptupdate = ($outdir + "\wptupdate.ini")
+$ini | Out-File  $wptupdate
+foreach ($filename in $tohash) {
+	$md5 = Get-FileHash ($outdir + "\" + $filename) -Algorithm MD5
+	($filename + "=" + $md5.hash) | Out-File -Append $wptupdate
+}
+
+$updatezip = ($releasedir.fullname + "\wptupdate.zip")
+"-> Creating " + $updatezip
+if (test-path $updatezip) { remove-item $updatezip }
+[System.IO.Compression.ZipFile]::CreateFromDirectory($outdir, $updatezip)
+
+"-> $updatezip created"

--- a/scripts/create-update.ps1
+++ b/scripts/create-update.ps1
@@ -79,10 +79,10 @@ ver=$ver
 "@
 
 $wptupdate = ($outdir + "\wptupdate.ini")
-$ini | Out-File  $wptupdate
+$ini | Out-File $wptupdate -Encoding "ASCII" -Append
 foreach ($filename in $tohash) {
 	$md5 = Get-FileHash ($outdir + "\" + $filename) -Algorithm MD5
-	($filename + "=" + $md5.hash) | Out-File -Append $wptupdate
+	($filename + "=" + $md5.hash) | Out-File $wptupdate -Encoding "ASCII" -Append
 }
 
 $updatezip = ($releasedir.fullname + "\wptupdate.zip")

--- a/scripts/installdeps.ps1
+++ b/scripts/installdeps.ps1
@@ -1,0 +1,15 @@
+<#
+Copyright (c) AppDynamics, Inc., and its affiliates 2015
+All rights reserved
+
+Installation script to setup dependencies using the Chocoloatey package manager.
+#>
+
+# Install choco
+iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+
+# Install webpagetest dependencies
+# WARNING: the google-chrome-x64 Chocolatey is incompatible with WPT hook, as
+# the hook is compiled in 32bit mode. GoogleChrome is the 32bit version of
+# Chrome
+choco install -y visualstudiocommunity2013 python2

--- a/scripts/installdeps.ps1
+++ b/scripts/installdeps.ps1
@@ -9,7 +9,4 @@ Installation script to setup dependencies using the Chocoloatey package manager.
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Install webpagetest dependencies
-# WARNING: the google-chrome-x64 Chocolatey is incompatible with WPT hook, as
-# the hook is compiled in 32bit mode. GoogleChrome is the 32bit version of
-# Chrome
 choco install -y visualstudiocommunity2013 python2


### PR DESCRIPTION
These two scripts simplify the building of update.zip from the command line or from a Continuous Integration System:

* ```scripts\installdeps.ps1```: install required software
* ```scripts\create-update.ps1```: build and package a wpt update archive