### PR TITLE
Fix #436: Invalid UTF-8 in HAR output

### DIFF
--- a/www/har.inc.php
+++ b/www/har.inc.php
@@ -200,8 +200,17 @@ function BuildHAR(&$pageData, $id, $testPath, $options) {
         if( isset($parts['query']) ) {
           $qs = array();
           parse_str($parts['query'], $qs);
-          foreach($qs as $name => $val)
-            $request['queryString'][] = array('name' => (string)$name, 'value' => (string)$val );
+          foreach($qs as $name => $val) {
+            if (!mb_detect_encoding($name, 'UTF-8', true)) {
+              // not a valid UTF-8 string. URL encode it again so it can be safely consumed by the client.
+              $name = urlencode($name);
+            }
+            if (!mb_detect_encoding($val, 'UTF-8', true)) {
+              // not a valid UTF-8 string. URL encode it again so it can be safely consumed by the client.
+              $val = urlencode($val);
+            }
+            $request['queryString'][] = array('name' => (string)$name, 'value' => (string)$val);
+          }
         }
         
         if( !strcasecmp(trim($request['method']), 'post') ) {


### PR DESCRIPTION
Testing notes: I tested the fix with [this] (http://www.saturn.de/mcs/product/_SIEMENS-WT-44-W-2-ED,48352,1003822.html?langId=-3) website. Without the fix, the HAR that is produced contains invalid UTF-8 output as indicated by python's json.tool:

```
$ python -m json.tool www.saturn.de.150908_2X_240.har 
'utf8' codec can't decode byte 0xe4 in position 54: invalid continuation byte
```

With the fix, python (as well as iconv) parses the file successfully.