### PR TITLE
Fix timeout on websites with basic auth

### DIFF
--- a/agent/browser/chrome/extension/wpt/background.js
+++ b/agent/browser/chrome/extension/wpt/background.js
@@ -362,6 +362,15 @@ chrome.webRequest.onErrorOccurred.addListener(function(details) {
   }, {urls: ['http://*/*', 'https://*/*'], types: ['main_frame']}
 );
 
+chrome.webRequest.onAuthRequired.addListener(function(details, cb) {
+    console.log("CB: " + cb);
+    if (g_active && details.tabId == g_tabid) {
+       return {
+         cancel: true
+       };
+    }
+}, {urls: ["<all_urls>"]}, ["blocking"]);
+
 chrome.webRequest.onCompleted.addListener(function(details) {
     if (g_active && details.tabId == g_tabid) {
       wpt.LOG.info('Completed, status = ' + details.statusCode);

--- a/agent/browser/chrome/extension/wpt/background.js
+++ b/agent/browser/chrome/extension/wpt/background.js
@@ -363,7 +363,6 @@ chrome.webRequest.onErrorOccurred.addListener(function(details) {
 );
 
 chrome.webRequest.onAuthRequired.addListener(function(details, cb) {
-    console.log("CB: " + cb);
     if (g_active && details.tabId == g_tabid) {
        return {
          cancel: true

--- a/agent/browser/firefox/extension/chrome.manifest
+++ b/agent/browser/firefox/extension/chrome.manifest
@@ -1,3 +1,4 @@
 content wptdriver chrome/content/
 
-overlay chrome://browser/content/browser.xul	chrome://wptdriver/content/overlay.xul
+overlay chrome://global/content/commonDialog.xul chrome://wptdriver/content/dialogOverlay.xul
+overlay chrome://browser/content/browser.xul chrome://wptdriver/content/overlay.xul

--- a/agent/browser/firefox/extension/chrome/content/dialogOverlay.js
+++ b/agent/browser/firefox/extension/chrome/content/dialogOverlay.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) AppDynamics, Inc., and its affiliates
+ * 2015
+ * All Rights Reserved
+ */
+
+// Namespace wpt.moz.main:
+window['wpt'] = window['wpt'] || {};
+window.wpt['moz'] = window.wpt['moz'] || {};
+
+window.addEventListener("load", function() {
+  var chromewindow = window.QueryInterface(Ci.nsIInterfaceRequestor)
+                              .getInterface(Ci.nsIDOMWindow);
+  // chromewindow.args contains the arguments passed to the dialog
+  if (chromewindow.args.promptType === 'promptUserAndPass') {
+    var observerService = Components.classes["@mozilla.org/observer-service;1"].
+      getService(Components.interfaces.nsIObserverService);
+    observerService.notifyObservers(null, "wpt-unauthorised-errors", "");
+    window.close();
+  }
+}, false);

--- a/agent/browser/firefox/extension/chrome/content/dialogOverlay.xul
+++ b/agent/browser/firefox/extension/chrome/content/dialogOverlay.xul
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<overlay id="main-window"
+         xmlns:html="http://www.w3.org/1999/xhtml"
+         xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+   <script type="application/x-javascript" src="chrome://wptdriver/content/mozutil.js"/>
+   <script type="application/x-javascript" src="chrome://wptdriver/content/dialogOverlay.js"/>
+</overlay>

--- a/agent/browser/firefox/extension/chrome/content/overlay.js
+++ b/agent/browser/firefox/extension/chrome/content/overlay.js
@@ -132,6 +132,25 @@ wpt.moz.main.onStartup = function() {
   windowMediator.addListener(listener);
 })();
 
+/**
+ * Get notifications from the dialog overlay to log a navigation error when
+ * basic auth is required and no credentials have been supplied.
+ */
+(function() {
+  var observerService = Components.classes["@mozilla.org/observer-service;1"].
+    getService(Components.interfaces.nsIObserverService);
+
+  var observeUnauthorizedErrors = {
+    observe: function(aSubject, aTopic, aData) {
+			wpt.moz.main.sendEventToDriver_('navigate_error?error=401');
+      g_active = false;
+      wptExtension.uninit();
+    }
+  };
+
+  observerService.addObserver(observeUnauthorizedErrors, "wpt-unauthorised-errors", false);
+})();
+
 // Get the next task from the wptdriver.
 wpt.moz.main.getTask = function() {
   if (!g_requesting_task && !g_processing_task) {

--- a/agent/browser/ie/wptbho/wptbho.cc
+++ b/agent/browser/ie/wptbho/wptbho.cc
@@ -16,7 +16,7 @@ STDMETHODIMP WptBHO::SetSite(IUnknown *pUnkSite) {
   if (pUnkSite) {
     if (!_web_browser) {
       _web_browser = pUnkSite;
-      // Set up ServiceProvideer for intercepting auth requests
+      // Set up ServiceProvider for intercepting auth requests
       basicAuthDismissed = false;
       CComQIPtr<IServiceProvider> sp(_web_browser);
       if (sp) {
@@ -30,7 +30,7 @@ STDMETHODIMP WptBHO::SetSite(IUnknown *pUnkSite) {
       }
       _wpt.InstallHook();
       DispEventAdvise(pUnkSite, &DIID_DWebBrowserEvents2);
-	  }
+    }
   } else {
     DispEventUnadvise(_web_browser, &DIID_DWebBrowserEvents2);
     _wpt.Stop();
@@ -42,10 +42,10 @@ STDMETHODIMP WptBHO::SetSite(IUnknown *pUnkSite) {
 
 
 HRESULT STDMETHODCALLTYPE WptBHO::Authenticate(
-	__RPC__deref_out_opt HWND *phwnd,
-	__RPC__deref_out_opt LPWSTR *pszUsername,
-	__RPC__deref_out_opt LPWSTR *pszPassword) {
-	AtlTrace(_T("[WptBHO] Request for Authentication"));
+  __RPC__deref_out_opt HWND *phwnd,
+  __RPC__deref_out_opt LPWSTR *pszUsername,
+  __RPC__deref_out_opt LPWSTR *pszPassword) {
+  AtlTrace(_T("[WptBHO] Request for Authentication"));
   basicAuthDismissed = true;
   return E_ACCESSDENIED;
 }

--- a/agent/browser/ie/wptbho/wptbho.cc
+++ b/agent/browser/ie/wptbho/wptbho.cc
@@ -6,6 +6,7 @@
 #include "dllmain.h"
 #include "xdlldata.h"
 #include "wptbho.h"
+#include "Shobjidl.h"
 
 /*-----------------------------------------------------------------------------
   Main entry point that is called when IE starts up
@@ -15,9 +16,21 @@ STDMETHODIMP WptBHO::SetSite(IUnknown *pUnkSite) {
   if (pUnkSite) {
     if (!_web_browser) {
       _web_browser = pUnkSite;
+      // Set up ServiceProvideer for intercepting auth requests
+      basicAuthDismissed = false;
+      CComQIPtr<IServiceProvider> sp(_web_browser);
+      if (sp) {
+        CComPtr<IProfferService> theProfferService;
+        HRESULT hr1 = sp->QueryService(SID_SProfferService, IID_IProfferService, (LPVOID*)&theProfferService);
+        if (SUCCEEDED(hr1) && theProfferService != 0)
+        {
+          DWORD cookie;
+          theProfferService->ProfferService(IID_IAuthenticate, this, &cookie);
+        }
+      }
       _wpt.InstallHook();
       DispEventAdvise(pUnkSite, &DIID_DWebBrowserEvents2);
-    }
+	  }
   } else {
     DispEventUnadvise(_web_browser, &DIID_DWebBrowserEvents2);
     _wpt.Stop();
@@ -25,6 +38,23 @@ STDMETHODIMP WptBHO::SetSite(IUnknown *pUnkSite) {
   }
   AtlTrace(_T("[WptBHO] SetSite complete\n"));
   return IObjectWithSiteImpl<WptBHO>::SetSite(pUnkSite);
+}
+
+
+HRESULT STDMETHODCALLTYPE WptBHO::Authenticate(
+	__RPC__deref_out_opt HWND *phwnd,
+	__RPC__deref_out_opt LPWSTR *pszUsername,
+	__RPC__deref_out_opt LPWSTR *pszPassword) {
+	AtlTrace(_T("[WptBHO] Request for Authentication"));
+  basicAuthDismissed = true;
+  return E_ACCESSDENIED;
+}
+
+HRESULT STDMETHODCALLTYPE WptBHO::QueryService(REFGUID guidService, REFIID riid, void** ppvObject) {    
+  if (guidService == IID_IAuthenticate && riid == IID_IAuthenticate) {
+    return QueryInterface(IID_IAuthenticate, ppvObject);
+  }
+  return INET_E_DEFAULT_ACTION;
 }
 
 /*-----------------------------------------------------------------------------
@@ -35,7 +65,6 @@ STDMETHODIMP_(void) WptBHO::OnBeforeNavigate2(IDispatch *pDisp, VARIANT * vUrl,
   CString url;
   if (vUrl)
     url = *vUrl;
-
   AtlTrace(_T("[WptBHO] OnBeforeNavigate2 - %s"), url);
   CComPtr<IUnknown> unknown_browser = _web_browser;
   CComPtr<IUnknown> unknown_frame = pDisp;
@@ -70,10 +99,17 @@ STDMETHODIMP_(void) WptBHO::OnNavigateError(IDispatch *pDisp, VARIANT *vUrl,
             VARIANT *TargetFrameName, VARIANT *StatusCode, 
             VARIANT_BOOL *Cancel) {
   DWORD code = 0;
-  if( StatusCode )
+  // if we forcibly dismissed a basic auth dialog, the
+  // returned status code is invalid. Use 401 instead.
+  if (basicAuthDismissed) {
+    code = 401;
+    basicAuthDismissed = true;
+  } else if (StatusCode) {
     code = StatusCode->lVal;
-  if( !code )
+  }
+  if (!code) {
     code = -1;
+  }
   CString url;
   if (vUrl)
     url = *vUrl;
@@ -99,6 +135,7 @@ STDMETHODIMP_(void) WptBHO::OnQuit(VOID) {
 -----------------------------------------------------------------------------*/
 STDMETHODIMP_(void) WptBHO::OnNewWindow2(IDispatch ** pDisp, 
             VARIANT_BOOL *Cancel) {
+
   if (_wpt._active && Cancel) {
     *Cancel = VARIANT_TRUE;
   }
@@ -110,6 +147,7 @@ STDMETHODIMP_(void) WptBHO::OnNewWindow2(IDispatch ** pDisp,
 STDMETHODIMP_(void) WptBHO::OnNewWindow3(IDispatch **ppDisp, 
             VARIANT_BOOL *Cancel, DWORD dwFlags, BSTR bstrUrlContext, 
             BSTR bstrUrl) {
+
   if (_wpt._active && Cancel) 	{
     *Cancel = VARIANT_TRUE;
   }

--- a/agent/browser/ie/wptbho/wptbho.h
+++ b/agent/browser/ie/wptbho/wptbho.h
@@ -76,9 +76,9 @@ public:
   HRESULT STDMETHODCALLTYPE QueryService(REFGUID guid, REFIID iid, void** ppv);
   // IAuthenticate
   HRESULT STDMETHODCALLTYPE Authenticate(
-	  /* [out] */ __RPC__deref_out_opt HWND *phwnd,
-	  /* [out] */ __RPC__deref_out_opt LPWSTR *pszUsername,
-	  /* [out] */ __RPC__deref_out_opt LPWSTR *pszPassword);
+    /* [out] */ __RPC__deref_out_opt HWND *phwnd,
+    /* [out] */ __RPC__deref_out_opt LPWSTR *pszUsername,
+    /* [out] */ __RPC__deref_out_opt LPWSTR *pszPassword);
 
 
 private:

--- a/agent/browser/ie/wptbho/wptbho.h
+++ b/agent/browser/ie/wptbho/wptbho.h
@@ -15,12 +15,13 @@ class ATL_NO_VTABLE WptBHO :
   public CComCoClass<WptBHO, &CLSID_WptBHO>,
   public IObjectWithSiteImpl<WptBHO>,
   public IDispEventImpl<1, WptBHO, &DIID_DWebBrowserEvents2, &LIBID_SHDocVw, 1, 1>,
-  public IDispatchImpl<IWptBHO, &IID_IWptBHO, &LIBID_wptbhoLib, /*wMajor =*/ 1, /*wMinor =*/ 0>
+  public IDispatchImpl<IWptBHO, &IID_IWptBHO, &LIBID_wptbhoLib, /*wMajor =*/ 1, /*wMinor =*/ 0>,
+  public IServiceProvider,
+  public IAuthenticate
 {
 public:
-  WptBHO(){
+  WptBHO(): basicAuthDismissed(false) {
   }
-
 DECLARE_REGISTRY_RESOURCEID(IDR_WPTBHO)
 
 DECLARE_NOT_AGGREGATABLE(WptBHO)
@@ -29,6 +30,8 @@ BEGIN_COM_MAP(WptBHO)
   COM_INTERFACE_ENTRY(IWptBHO)
   COM_INTERFACE_ENTRY(IDispatch)
   COM_INTERFACE_ENTRY(IObjectWithSite)
+  COM_INTERFACE_ENTRY(IServiceProvider)
+  COM_INTERFACE_ENTRY(IAuthenticate)
 END_COM_MAP()
 
   DECLARE_PROTECT_FINAL_CONSTRUCT()
@@ -69,10 +72,19 @@ END_COM_MAP()
 public:
   // IObjectWithSite
   STDMETHOD(SetSite)(IUnknown *pUnkSite);
+  // IServiceProvider
+  HRESULT STDMETHODCALLTYPE QueryService(REFGUID guid, REFIID iid, void** ppv);
+  // IAuthenticate
+  HRESULT STDMETHODCALLTYPE Authenticate(
+	  /* [out] */ __RPC__deref_out_opt HWND *phwnd,
+	  /* [out] */ __RPC__deref_out_opt LPWSTR *pszUsername,
+	  /* [out] */ __RPC__deref_out_opt LPWSTR *pszPassword);
+
 
 private:
   CComQIPtr<IWebBrowser2> _web_browser;
   Wpt   _wpt;
+  bool basicAuthDismissed;
 
 // leave this public empty to support the DECLARE_PROTECT_FINAL_CONSTRUCT macro
 public:

--- a/agent/wpthook/test_server_mock.js
+++ b/agent/wpthook/test_server_mock.js
@@ -26,35 +26,67 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
-// test_server_mock.js - Simulate TestServer responses.
-//
-// This is a node.js server that listens for requests from the wptdriver
-// browser extension.
-//
-//   Linux build instructions:
-//     NODE_NAME=node-v0.4.10
-//     wget http://nodejs.org/dist/${NODE_NAME}.tar.gz
-//     tar xvzf ${NODE_NAME}.tar.gz
-//     cd ${NODE_NAME}
-//     JOBS=10 make
-//     sudo make install
-//
-//   Start a server:
-//     node sample-node-server.js
+
+var buildNavigateTask = function(url) {
+  return task = {
+    statusCode: 200,
+    data: {
+      record: 1,
+      action: "navigate",
+      target: url
+    }
+  };
+}
+
+var usage = function() {
+  console.error("Usage: node " + process.argv[1] + " URL [--repeat]");
+}
+
+if (process.argv.length < 3) {
+  console.error("Missing argument.");
+  usage();
+  process.exit(1);
+}
+
+url = process.argv[2];
+servedOnce = false;
+repeat = false;
+
+if (process.argv.length > 3) {
+  if (process.argv[3] == "--repeat") {
+    repeat = true;
+  }
+  else {
+    console.error("Unkown argument: " + process.argv[3]);
+    usage();
+    process.exit(1);
+  }
+}
+
 
 var http = require('http');
 http.createServer(function (req, res) {
-    if (req.url == '/task') {
-      res.writeHead(200, {'Content-Type': 'text/plain'});
-      res.end('{"statusCode": 200, "data": { "record": 1, "action": ' +
-              '"navigate","target": "http://books.google.com/"} }');
-    } else if (req.url.slice(0, '/event'.length) == '/event') {
-      res.writeHead(200, {'Content-Type': 'text/plain'});
-      res.end('');
+  console.log(req.url);
+  if (req.url == '/task') {
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    if (servedOnce === false || repeat) {
+      var task = buildNavigateTask(url);
+      console.log("Serving task: " + task);
+      res.end(JSON.stringify(buildNavigateTask(url)));
+      servedOnce = true;
     } else {
-      res.writeHead(404, {'Content-Type': 'text/plain'});
-      //res.end('Not Found: <' + req.url + '>\n');
-      res.end('Not Found\n');
+      console.log("No more task to serve");
+      res.end('');
     }
-  }).listen(8888, "127.0.0.1");
+  } else if (req.url.slice(0, '/event'.length) == '/event') {
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.end('');
+  } else {
+    console.log("* endpoint does not exist");
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.end('');
+  }
+}).listen(8888, "127.0.0.1");
+
 console.log('Mock TestServer running at http://127.0.0.1:8888/');
+console.log('Mock TestServer will server navigate to: ' + url);

--- a/agent/wpthook/test_server_mock.js
+++ b/agent/wpthook/test_server_mock.js
@@ -28,7 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 var buildNavigateTask = function(url) {
-  return task = {
+  var task = {
     statusCode: 200,
     data: {
       record: 1,
@@ -36,6 +36,7 @@ var buildNavigateTask = function(url) {
       target: url
     }
   };
+  return JSON.stringify(task);
 }
 
 var usage = function() {
@@ -72,7 +73,7 @@ http.createServer(function (req, res) {
     if (servedOnce === false || repeat) {
       var task = buildNavigateTask(url);
       console.log("Serving task: " + task);
-      res.end(JSON.stringify(buildNavigateTask(url)));
+      res.end(buildNavigateTask(url));
       servedOnce = true;
     } else {
       console.log("No more task to serve");


### PR DESCRIPTION
Measurements on sites with http basic auth for which no credentials have been set will currently timeout. This is caused by the browsers displaying a basic auth credential dialog and halting there indefinitely. While this is somewhat expected, it is confusing for the user as no error is reported, and it slows down the measurement unnecessarily.

This pull request addresses the issue by dismissing the http basic auth dialog in the browser and report a 401 http error immediately. This not only speeds up the (failing) test but also gives a clue to the user as to what needs to be fixed for the test to work.