### PR TITLE
Add GoCache as a known CDN

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -102,7 +102,8 @@ CDN_PROVIDER cdnList[] = {
 	{".cdninstagram.com", _T("Facebook")},
 	{".rlcdn.com", _T("Reapleaf")},
 	{".wp.com", _T("WordPress Jetpack")},
-	{".incapdns.net", _T("Incapsula"}),
+	{".incapdns.net", _T("Incapsula")},
+	{".cdn.gocache.net", _T("GoCache")},
 	{NULL, NULL}
 };
 
@@ -138,5 +139,6 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"server", "Golfe2", _T("Google")},
 	{"server", "tsa_b", _T("Twitter")},
 	{"X-CDN", "Incapsula", _T("Incapsula")},
-	{"X-Iinfo", "", _T("Incapsula")}
+	{"X-Iinfo", "", _T("Incapsula")},
+	{"server", "gocache", _T("GoCache")}
 };

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -142,6 +142,7 @@ CDN_PROVIDER cdnList[] = {
   {".cdninstagram.com", "Facebook"},
   {".rlcdn.com", "Reapleaf"},
   {".wp.com", "WordPress Jetpack"},
+  {".cdn.gocache.net", "GoCache"},
   {"END_MARKER", "END_MARKER"}
 };
 
@@ -172,5 +173,6 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "Golfe2", "Google"},
   {"server", "tsa_b", "Twitter"},
   {"X-CDN", "Incapsula", "Incapsula"},
-  {"X-Iinfo", "", "Incapsula"}
+  {"X-Iinfo", "", "Incapsula"},
+  {"server", "gocache", "GoCache"}
 };


### PR DESCRIPTION
GoCache is a next-gen CDN platform to speed up and protect any website in a smart in simple way.