### PR TITLE
Add Ensighten tag manager as CDN

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -103,6 +103,7 @@ CDN_PROVIDER cdnList[] = {
 	{".rlcdn.com", _T("Reapleaf")},
 	{".wp.com", _T("WordPress Jetpack")},
 	{".incapdns.net", _T("Incapsula"}),
+	{"nexus.ensighten.com", _T("Ensighten"}),
 	{NULL, NULL}
 };
 

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -142,6 +142,7 @@ CDN_PROVIDER cdnList[] = {
   {".cdninstagram.com", "Facebook"},
   {".rlcdn.com", "Reapleaf"},
   {".wp.com", "WordPress Jetpack"},
+  {"nexus.ensighten.com", _T("Ensighten"}),
   {"END_MARKER", "END_MARKER"}
 };
 


### PR DESCRIPTION
When testing http://www.nature.com/nplants/ recently I noticed Ensighten
tag manager was not within the list of CDN's.

As far as I am aware Ensighten are distributing content to different
locations and serving from the relevant one.

Slightly out of date but here is a map of Ensightens global network
https://www.ensighten.com/sites/default/files/Ensighten-Tag-Delivery-Network.pdf