### PR TITLE
send interceptor must honor SOCKET_ERROR return code

### DIFF
--- a/agent/wpthook/hook_winsock.cc
+++ b/agent/wpthook/hook_winsock.cc
@@ -531,7 +531,9 @@ int CWsHook::send(SOCKET s, const char FAR * buf, int len, int flags) {
       _sockets.DataOut(s, chunk, false);
     }
     ret = _send(s, chunk.GetData(), chunk.GetLength(), flags);
-    ret = original_len;
+    if (ret != SOCKET_ERROR) {
+        ret = original_len;
+    }
   }
   _sockets.ResetSslFd();
   return ret;


### PR DESCRIPTION
Under some circumstances _send can return an SOCKET_ERROR. This error
should be propagated to the caller. Returning the original data length
in this case is not appropriated.