### PR TITLE
Memory leak; reading of client certificates

### DIFF
--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -328,6 +328,8 @@ void WebPagetest::LoadClientCertificateFromStore(HINTERNET request) {
       CERT_FIND_SUBJECT_ATTR,
       &cert_rdn,
       NULL);
+
+    delete[] pCommonName;
   }
   else {
     // use the first certificate in the store

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -43,7 +43,7 @@ WptSettings::WptSettings(WptStatus &status):
   ,_debug(0)
   ,_status(status)
   ,_software_update(status)
-  ,_requireValidCertificate(false) {
+  ,_requireValidCertificate(true) {
 }
 
 /*-----------------------------------------------------------------------------
@@ -106,10 +106,7 @@ bool WptSettings::Load(void) {
     _key = buff;
   }
 
-  if (GetPrivateProfileInt(_T("WebPagetest"), _T("Valid Certificate"), 
-    _requireValidCertificate, iniFile)) {
-    _requireValidCertificate = true;
-  }
+  _requireValidCertificate = GetPrivateProfileInt(_T("WebPagetest"), _T("Valid Certificate"), _requireValidCertificate, iniFile);
 
   if (GetPrivateProfileString(_T("WebPagetest"), _T("Client Certificate Common Name"), _T(""), buff,
     _countof(buff), iniFile)) {


### PR DESCRIPTION
* Fix memory leak related to loading of client certificates,
* Require valid certificate from WPT server by default,
* Correctly read 'Valid Certificate' setting
