### PR TITLE
Add Aryaka to CDN list

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -143,8 +143,8 @@ CDN_PROVIDER cdnList[] = {
   {".rlcdn.com", "Reapleaf"},
   {".wp.com", "WordPress Jetpack"},
   {".aads1.net", "Aryaka"},
-  {".aadscn.net", "Aryaka"},
-  {".aadscng.net", "Aryaka"},
+  {".aads-cn.net", "Aryaka"},
+  {".aads-cng.net", "Aryaka"},
   {"END_MARKER", "END_MARKER"}
 };
 

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -142,6 +142,9 @@ CDN_PROVIDER cdnList[] = {
   {".cdninstagram.com", "Facebook"},
   {".rlcdn.com", "Reapleaf"},
   {".wp.com", "WordPress Jetpack"},
+  {".aads1.net", "Aryaka"},
+  {".aadscn.net", "Aryaka"},
+  {".aadscng.net", "Aryaka"},
   {"END_MARKER", "END_MARKER"}
 };
 
@@ -172,5 +175,6 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "Golfe2", "Google"},
   {"server", "tsa_b", "Twitter"},
   {"X-CDN", "Incapsula", "Incapsula"},
-  {"X-Iinfo", "", "Incapsula"}
+  {"X-Iinfo", "", "Incapsula"},
+  {"X-Ar-Debug", "", "Aryaka"}
 };


### PR DESCRIPTION
Request to add Aryaka Networks to list of CDN providers.
Aryaka Networks CDN product: http://www.aryaka.com/products-and-services/cdn/cdn-delivery-network/
