### PR TITLE
Enable export.php to produce multistep HARs

### DIFF
--- a/agent/wptdriver/util.cc
+++ b/agent/wptdriver/util.cc
@@ -44,6 +44,12 @@ static const TCHAR * DOCUMENT_WINDOW_CLASSES[] = {
   _T("WebKit2WebViewWindowClass")
 };
 
+// this should be maintained in sync with the capability bitmask constants in common_lib.inc
+// on the server side.
+const DWORD CAPABILITIES[::nCapabilities] = {
+  0x0001    // kMultistepSupport bitmask value
+};
+
 /*-----------------------------------------------------------------------------
   Launch the provided process and wait for it to finish 
   (unless process_handle is provided in which case it will return immediately)
@@ -763,4 +769,14 @@ void Reboot() {
   }
   
   InitiateSystemShutdown(NULL, NULL, 0, TRUE, TRUE);
+}
+
+DWORD GetCapabilities() {
+  DWORD agent_capabilities = 0;
+
+  for (int i = 0; i < ::nCapabilities; i++) {
+    agent_capabilities |= CAPABILITIES[i];
+  }
+
+  return agent_capabilities;
 }

--- a/agent/wptdriver/util.h
+++ b/agent/wptdriver/util.h
@@ -30,6 +30,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <TlHelp32.h>
 
+enum {
+  kMultistepSupport = 0,
+  nCapabilities
+};
+
+extern const DWORD CAPABILITIES[::nCapabilities];
+
 namespace loglevel {
   const int kError = 1;
   const int kWarning = 2;
@@ -76,3 +83,4 @@ void QueryPerfCounter(__int64 &counter);
 void QueryPerfFrequency(__int64 &freq);
 int ElapsedFileTimeSeconds(FILETIME& check, FILETIME& now);
 void Reboot();
+DWORD GetCapabilities(void);

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -135,6 +135,9 @@ bool WebPagetest::GetTest(WptTestDriver& test) {
     buff.Format(_T("&freedisk=%0.3f"), freeDisk);
     url += buff;
   }
+  buff.Format(_T("&capabilities=%d"), ::GetCapabilities());
+  url += buff;
+
   url += has_gpu_ ? _T("&GPU=1") : _T("&GPU=0");
 
   CString test_string, zip_file;

--- a/agent/wptdriver/webpagetest.h
+++ b/agent/wptdriver/webpagetest.h
@@ -38,6 +38,7 @@ public:
   bool DeleteIncrementalResults(WptTestDriver& test);
   bool UploadIncrementalResults(WptTestDriver& test);
   bool TestDone(WptTestDriver& test);
+  DWORD GetCapabilities(void);
 
   bool _exit;
   bool has_gpu_;

--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -54,6 +54,7 @@ static const char * DEFAULT_MOBILE_USER_AGENT =
 -----------------------------------------------------------------------------*/
 WptTest::WptTest(void):
   _version(0)
+  , server_capabilities_(0)
   ,_test_timeout(DEFAULT_TEST_TIMEOUT * SECONDS_TO_MS)
   ,_activity_timeout(DEFAULT_ACTIVITY_TIMEOUT)
   ,_measurement_timeout(DEFAULT_TEST_TIMEOUT)
@@ -185,6 +186,9 @@ bool WptTest::Load(CString& test) {
           _id = value.Trim();
         else if (!key.CompareNoCase(_T("url")))
           _url = value.Trim();
+        else if (!key.CompareNoCase(_T("server_caps"))) {
+          server_capabilities_ = _ttoi(value.Trim());
+        }
         else if (!key.CompareNoCase(_T("fvonly")) && _ttoi(value.Trim()))
           _fv_only = true;
         else if (!key.CompareNoCase(_T("run")))
@@ -1116,4 +1120,8 @@ void WptTest::Unlock() {
 -----------------------------------------------------------------------------*/
 bool WptTest::IsLocked() {
   return lock_count_ != 0;
+}
+
+bool WptTest::IsServerMultistepCapable() {
+  return server_capabilities_ & ::CAPABILITIES[::kMultistepSupport];
 }

--- a/agent/wptdriver/wpt_test.h
+++ b/agent/wptdriver/wpt_test.h
@@ -140,6 +140,7 @@ public:
   void Lock();
   void Unlock();
   bool IsLocked();
+  bool IsServerMultistepCapable();
 
   // overall test settings
   CString _id;
@@ -203,7 +204,8 @@ public:
   CStringA _run_error;
   CString _custom_metrics;
   DWORD   _script_timeout_multiplier;
-  
+  DWORD server_capabilities_;
+
   // current state
   int     _run;
   int     _specific_run;

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1837,12 +1837,13 @@ function UnlockTest(&$testLock) {
 *
 * @param mixed $path
 */
-function loadVideo($path, &$frames)
+function loadVideo($path, &$frames, $stepNum = null)
 {
     $ret = false;
     $frames = null;
     if (is_dir($path)) {
-        $files = glob( $path . '/frame_*.jpg', GLOB_NOSORT );
+        $filespec = isset($stepNum) ? '/frame_' . $stepNum . '*.jpg' : '/frame_*.jpg';
+        $files = glob( $path . $filespec, GLOB_NOSORT );
         if ($files && count($files)) {
             $ret = true;
             $frames = array();
@@ -1850,7 +1851,7 @@ function loadVideo($path, &$frames)
                 $file = basename($file);
                 $parts = explode('_', $file);
                 if (count($parts) >= 2) {
-                    $index = intval($parts[1] * 100);
+                    $index = intval($parts[count($parts) - 1] * 100);
                     $frames[$index] = $file;
                 }
             }

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -8,8 +8,29 @@ if(extension_loaded('newrelic')) {
 
 define('VIDEO_CODE_VERSION', 20);
 
+#
+$CAPABILITIES = array(
+  "MULTISTEP_SUPPORT" => 0x0001
+);
+
 require_once(__DIR__ . '/logging.inc');
 
+function GetCapabilities() {
+  global $CAPABILITIES;
+  $capabilities = 0;
+
+  foreach ($CAPABILITIES as $mask) {
+    $capabilities |= $mask;
+  }
+
+  return $capabilities;
+}
+
+function IsMultistepTestResult($testInfo) {
+  global $CAPABILITIES;
+
+  return (isset($testInfo['agent_caps']) && ($testInfo['agent_caps'] & $CAPABILITIES['MULTISTEP_SUPPORT']) !== 0);
+}
 /**
 * Figure out the test path (relative) for the given test id
 *

--- a/www/export.php
+++ b/www/export.php
@@ -10,6 +10,8 @@
 include 'common.inc';
 require_once('har.inc.php');
 
+$testInfo = GetTestInfo($id);
+
 $options = array();
 if (isset($_REQUEST['bodies']))
   $options['bodies'] = $_REQUEST['bodies'];
@@ -20,7 +22,12 @@ if (isset($_REQUEST['pretty']))
   $options['pretty'] = $_REQUEST['pretty'];
 if (isset($_REQUEST['run']))
   $options['run'] = $_REQUEST['run'];
-  
+
+$options['multistep'] = 0;
+if (isset($_REQUEST['multistep']) && IsMultistepTestResult($testInfo)) {
+  $options['multistep'] = 1;
+}
+
 $filename = '';
 if (@strlen($url)) {
     $parts = parse_url($url);

--- a/www/har.inc.php
+++ b/www/har.inc.php
@@ -10,11 +10,12 @@ require_once('lib/json.php');
 */
 function GenerateHAR($id, $testPath, $options) {
   $json = '{}';
+  $multistep = $options['multistep'];
   if( isset($testPath) ) {
     $pageData = null;
     if (isset($options["run"]) && $options["run"]) {
       if (!strcasecmp($options["run"],'median')) {
-        $raw = loadAllPageData($testPath);
+        $raw = loadAllPageData($testPath, null, $multistep);
         $run = GetMedianRun($raw, $options['cached'], $median_metric);
         unset($raw);
       } else {
@@ -24,23 +25,23 @@ function GenerateHAR($id, $testPath, $options) {
         $run = 1;
       $pageData[$run] = array();
       if( isset($options['cached']) ) {
-        $pageData[$run][$options['cached']] = loadPageRunData($testPath, $run, $options['cached']);
+        $pageData[$run][$options['cached']] = loadPageRunData($testPath, $run, $options['cached'], null, $multistep);
         if (!isset($pageData[$run][$options['cached']]))
           unset($pageData);
       } else {
-        $pageData[$run][0] = loadPageRunData($testPath, $run, 0);
+        $pageData[$run][0] = loadPageRunData($testPath, $run, 0, null, $multistep);
         if (!isset($pageData[$run][0]))
           unset($pageData);
-        $pageData[$run][1] = loadPageRunData($testPath, $run, 1);
+        $pageData[$run][1] = loadPageRunData($testPath, $run, 1, null, $multistep);
       }
     }
     
     if (!isset($pageData))
-      $pageData = loadAllPageData($testPath);
+      $pageData = loadAllPageData($testPath, null, $multistep);
 
     // build up the array
     $harData = BuildHAR($pageData, $id, $testPath, $options);
-    
+
     $json_encode_good = version_compare(phpversion(), '5.4.0') >= 0 ? true : false;
     $pretty_print = false;
     if (isset($options['pretty']) && $options['pretty'])
@@ -94,15 +95,223 @@ function durationOfInterval($value) {
   return (int)$value;
 }
 
+function BuildHarPage($testPath, $cached, $run, $data) {
+  $cached_text = '';
+  if ($cached)
+    $cached_text = '_Cached';
+  $pageId = "page_{$run}_{$cached}";
+  if (isset($data['stepName']))
+    $pageId = $pageId . "_" . $data['stepName'];
+  $pd = array();
+  $pd['startedDateTime'] = msdate($data['date']);
+  $pd['title'] = "Run $run, ";
+  if( $cached )
+    $pd['title'] .= "Repeat View";
+  else
+    $pd['title'] .= "First View";
+  $pd['title'] .= " for " . $data['URL'];
+  $pd['id'] = $pageId;
+  $pd['pageTimings'] = array( 'onLoad' => $data['docTime'], 'onContentLoad' => -1, '_startRender' => $data['render'] );
+
+  // dump all of our metrics into the har data as custom fields
+  foreach($data as $name => $value) {
+    if (!is_array($value))
+      $pd["_$name"] = $value;
+  }
+  return $pd;
+}
+
+function BuildHAREntry($data, $pd, $r) {
+  $entry = array();
+  $entry['pageref'] = $pd['id'];
+  $entry['startedDateTime'] = msdate((double)$data['date'] + ($r['load_start'] / 1000.0));
+  $entry['time'] = $r['all_ms'];
+
+  $request = array();
+  $request['method'] = $r['method'];
+  $protocol = ($r['is_secure']) ? 'https://' : 'http://';
+  $request['url'] = $protocol . $r['host'] . $r['url'];
+  $request['headersSize'] = -1;
+  $request['bodySize'] = -1;
+  $request['cookies'] = array();
+  $request['headers'] = array();
+  $ver = '';
+  $headersSize = 0;
+  if( isset($r['headers']) && isset($r['headers']['request']) ) {
+    foreach($r['headers']['request'] as &$header) {
+      $headersSize += strlen($header) + 2; // add 2 for the \r\n that is on the raw headers
+      $pos = strpos($header, ':');
+      if( $pos > 0 ) {
+        $name = trim(substr($header, 0, $pos));
+        $val = trim(substr($header, $pos + 1));
+        if( strlen($name) )
+          $request['headers'][] = array('name' => $name, 'value' => $val);
+
+        // parse out any cookies
+        if( !strcasecmp($name, 'cookie') ) {
+          $cookies = explode(';', $val);
+          foreach( $cookies as &$cookie ) {
+            $pos = strpos($cookie, '=');
+            if( $pos > 0 ) {
+              $name = (string)trim(substr($cookie, 0, $pos));
+              $val = (string)trim(substr($cookie, $pos + 1));
+              if( strlen($name) )
+                $request['cookies'][] = array('name' => $name, 'value' => $val);
+            }
+          }
+        }
+      } else {
+        $pos = strpos($header, 'HTTP/');
+        if( $pos >= 0 )
+          $ver = (string)trim(substr($header, $pos + 5, 3));
+      }
+    }
+  }
+  if ($headersSize)
+    $request['headersSize'] = $headersSize;
+  $request['httpVersion'] = $ver;
+
+  $request['queryString'] = array();
+  $parts = parse_url($request['url']);
+  if( isset($parts['query']) ) {
+    $qs = array();
+    parse_str($parts['query'], $qs);
+    foreach($qs as $name => $val) {
+      if (!mb_detect_encoding($name, 'UTF-8', true)) {
+        // not a valid UTF-8 string. URL encode it again so it can be safely consumed by the client.
+        $name = urlencode($name);
+      }
+      if (!mb_detect_encoding($val, 'UTF-8', true)) {
+        // not a valid UTF-8 string. URL encode it again so it can be safely consumed by the client.
+        $val = urlencode($val);
+      }
+      $request['queryString'][] = array('name' => (string)$name, 'value' => (string)$val);
+    }
+  }
+
+  if( !strcasecmp(trim($request['method']), 'post') ) {
+    $request['postData'] = array();
+    $request['postData']['mimeType'] = '';
+    $request['postData']['text'] = '';
+  }
+
+  $entry['request'] = $request;
+
+  $response = array();
+  $response['status'] = (int)$r['responseCode'];
+  $response['statusText'] = '';
+  $response['headersSize'] = -1;
+  $response['bodySize'] = (int)$r['objectSize'];
+  $response['headers'] = array();
+  $ver = '';
+  $loc = '';
+  $headersSize = 0;
+  if( isset($r['headers']) && isset($r['headers']['response']) ) {
+    foreach($r['headers']['response'] as &$header) {
+      $headersSize += strlen($header) + 2; // add 2 for the \r\n that is on the raw headers
+      $pos = strpos($header, ':');
+      if( $pos > 0 ) {
+        $name = (string)trim(substr($header, 0, $pos));
+        $val = (string)trim(substr($header, $pos + 1));
+        if( strlen($name) )
+          $response['headers'][] = array('name' => $name, 'value' => $val);
+
+        if( !strcasecmp($name, 'location') )
+          $loc = (string)$val;
+      } else {
+        $pos = strpos($header, 'HTTP/');
+        if( $pos >= 0 )
+          $ver = (string)trim(substr($header, $pos + 5, 3));
+      }
+    }
+  }
+  if ($headersSize)
+    $response['headersSize'] = $headersSize;
+  $response['httpVersion'] = $ver;
+  $response['redirectURL'] = $loc;
+
+  $response['content'] = array();
+  $response['content']['size'] = (int)$r['objectSize'];
+  if( isset($r['contentType']) && strlen($r['contentType']))
+    $response['content']['mimeType'] = (string)$r['contentType'];
+  else
+    $response['content']['mimeType'] = '';
+
+  // unsupported fields that are required
+  $response['cookies'] = array();
+
+  $entry['response'] = $response;
+
+  $entry['cache'] = (object)array();
+
+  $timings = array();
+  $timings['blocked'] = -1;
+  $timings['dns'] = (int)$r['dns_ms'];
+  if( !$timings['dns'])
+    $timings['dns'] = -1;
+
+  // HAR did not have an ssl time until version 1.2 .  For
+  // backward compatibility, "connect" includes "ssl" time.
+  // WepbageTest's internal representation does not assume any
+  // overlap, so we must add our connect and ssl time to get the
+  // connect time expected by HAR.
+  $timings['connect'] = (durationOfInterval($r['connect_ms']) +
+      durationOfInterval($r['ssl_ms']));
+  if(!$timings['connect'])
+    $timings['connect'] = -1;
+
+  $timings['ssl'] = (int)$r['ssl_ms'];
+  if (!$timings['ssl'])
+    $timings['ssl'] = -1;
+
+  // TODO(skerner): WebpageTest's data model has no way to
+  // represent the difference between the states HAR calls
+  // send (time required to send HTTP request to the server)
+  // and wait (time spent waiting for a response from the server).
+  // We lump both into "wait".  Issue 24* tracks this work.  When
+  // it is resolved, read the real values for send and wait
+  // instead of using the request's TTFB.
+  // *: http://code.google.com/p/webpagetest/issues/detail?id=24
+  $timings['send'] = 0;
+  $timings['wait'] = (int)$r['ttfb_ms'];
+  $timings['receive'] = (int)$r['download_ms'];
+
+  $entry['timings'] = $timings;
+
+  // The HAR spec defines time as the sum of the times in the
+  // timings object, excluding any unknown (-1) values and ssl
+  // time (which is included in "connect", for backward
+  // compatibility with tools written before "ssl" was defined
+  // in HAR version 1.2).
+  $entry['time'] = 0;
+  foreach ($timings as $timingKey => $duration) {
+    if ($timingKey != 'ssl' && $duration != UNKNOWN_TIME) {
+      $entry['time'] += $duration;
+    }
+  }
+
+  if (array_key_exists('custom_rules', $r)) {
+    $entry['_custom_rules'] = $r['custom_rules'];
+  }
+
+  // dump all of our metrics into the har data as custom fields
+  foreach($r as $name => $value) {
+    if (!is_array($value))
+      $entry["_$name"] = $value;
+  }
+  return $entry;
+}
+
 /**
 * Build the data set
-* 
+*
 * @param mixed $pageData
 */
 function BuildHAR(&$pageData, $id, $testPath, $options) {
   $result = array();
   $entries = array();
-  
+  $multistep = $options['multistep'] != 0;
+
   $result['log'] = array();
   $result['log']['version'] = '1.1';
   $result['log']['creator'] = array(
@@ -113,231 +322,48 @@ function BuildHAR(&$pageData, $id, $testPath, $options) {
   foreach ($pageData as $run => $pageRun) {
     foreach ($pageRun as $cached => $data) {
       $cached_text = '';
-      if ($cached)
+      if ($cached) {
         $cached_text = '_Cached';
+      }
+      $steps = array();
+      if ($multistep) {
+        foreach ($data as $stepName => $stepData) {
+          $steps[] = $stepData;
+        }
+      } else {
+        $steps[] = $data;
+      }
       if (!array_key_exists('browser', $result['log'])) {
         $result['log']['browser'] = array(
-            'name' => $data['browser_name'],
-            'version' => $data['browser_version']
-            );
+            'name' => $steps[0]['browser_name'],
+            'version' => $steps[0]['browser_version']
+        );
       }
-      $pd = array();
-      $pd['startedDateTime'] = msdate($data['date']);
-      $pd['title'] = "Run $run, ";
-      if( $cached )
-        $pd['title'] .= "Repeat View";
-      else
-        $pd['title'] .= "First View";
-      $pd['title'] .= " for " . $data['URL'];
-      $pd['id'] = "page_{$run}_{$cached}";
-      $pd['pageTimings'] = array( 'onLoad' => $data['docTime'], 'onContentLoad' => -1, '_startRender' => $data['render'] );
-      
-      // dump all of our metrics into the har data as custom fields
-      foreach($data as $name => $value) {
-        if (!is_array($value))
-          $pd["_$name"] = $value;
-      }
-      
-      // add the page-level ldata to the result
-      $result['log']['pages'][] = $pd;
-      
-      // now add the object-level data to the result
-      $secure = false;
-      $haveLocations = false;
-      $requests = getRequests($id, $testPath, $run, $cached, $secure, $haveLocations, false, true);
-      foreach( $requests as &$r ) {
-        $entry = array();
-        $entry['pageref'] = $pd['id'];
-        $entry['startedDateTime'] = msdate((double)$data['date'] + ($r['load_start'] / 1000.0));
-        $entry['time'] = $r['all_ms'];
-        
-        $request = array();
-        $request['method'] = $r['method'];
-        $protocol = ($r['is_secure']) ? 'https://' : 'http://';
-        $request['url'] = $protocol . $r['host'] . $r['url'];
-        $request['headersSize'] = -1;
-        $request['bodySize'] = -1;
-        $request['cookies'] = array();
-        $request['headers'] = array();
-        $ver = '';
-        $headersSize = 0;
-        if( isset($r['headers']) && isset($r['headers']['request']) ) {
-          foreach($r['headers']['request'] as &$header) {
-            $headersSize += strlen($header) + 2; // add 2 for the \r\n that is on the raw headers
-            $pos = strpos($header, ':');
-            if( $pos > 0 ) {
-              $name = trim(substr($header, 0, $pos));
-              $val = trim(substr($header, $pos + 1));
-              if( strlen($name) )
-                $request['headers'][] = array('name' => $name, 'value' => $val);
-
-              // parse out any cookies
-              if( !strcasecmp($name, 'cookie') ) {
-                $cookies = explode(';', $val);
-                foreach( $cookies as &$cookie ) {
-                  $pos = strpos($cookie, '=');
-                  if( $pos > 0 ) {
-                    $name = (string)trim(substr($cookie, 0, $pos));
-                    $val = (string)trim(substr($cookie, $pos + 1));
-                    if( strlen($name) )
-                      $request['cookies'][] = array('name' => $name, 'value' => $val);
-                  }
-                }
-              }
-            } else {
-              $pos = strpos($header, 'HTTP/');
-              if( $pos >= 0 )
-                $ver = (string)trim(substr($header, $pos + 5, 3));
-            }
-          }
-        }
-        if ($headersSize)
-          $request['headersSize'] = $headersSize;
-        $request['httpVersion'] = $ver;
-
-        $request['queryString'] = array();
-        $parts = parse_url($request['url']);
-        if( isset($parts['query']) ) {
-          $qs = array();
-          parse_str($parts['query'], $qs);
-          foreach($qs as $name => $val) {
-            if (!mb_detect_encoding($name, 'UTF-8', true)) {
-              // not a valid UTF-8 string. URL encode it again so it can be safely consumed by the client.
-              $name = urlencode($name);
-            }
-            if (!mb_detect_encoding($val, 'UTF-8', true)) {
-              // not a valid UTF-8 string. URL encode it again so it can be safely consumed by the client.
-              $val = urlencode($val);
-            }
-            $request['queryString'][] = array('name' => (string)$name, 'value' => (string)$val);
-          }
-        }
-        
-        if( !strcasecmp(trim($request['method']), 'post') ) {
-          $request['postData'] = array();
-          $request['postData']['mimeType'] = '';
-          $request['postData']['text'] = '';
-        }
-        
-        $entry['request'] = $request;
-
-        $response = array();
-        $response['status'] = (int)$r['responseCode'];
-        $response['statusText'] = '';
-        $response['headersSize'] = -1;
-        $response['bodySize'] = (int)$r['objectSize'];
-        $response['headers'] = array();
-        $ver = '';
-        $loc = '';
-        $headersSize = 0;
-        if( isset($r['headers']) && isset($r['headers']['response']) ) {
-          foreach($r['headers']['response'] as &$header) {
-            $headersSize += strlen($header) + 2; // add 2 for the \r\n that is on the raw headers
-            $pos = strpos($header, ':');
-            if( $pos > 0 ) {
-              $name = (string)trim(substr($header, 0, $pos));
-              $val = (string)trim(substr($header, $pos + 1));
-              if( strlen($name) )
-                $response['headers'][] = array('name' => $name, 'value' => $val);
-              
-              if( !strcasecmp($name, 'location') )
-                $loc = (string)$val;
-            } else {
-              $pos = strpos($header, 'HTTP/');
-              if( $pos >= 0 )
-                $ver = (string)trim(substr($header, $pos + 5, 3));
-            }
-          }
-        }
-        if ($headersSize)
-          $response['headersSize'] = $headersSize;
-        $response['httpVersion'] = $ver;
-        $response['redirectURL'] = $loc;
-
-        $response['content'] = array();
-        $response['content']['size'] = (int)$r['objectSize'];
-        if( isset($r['contentType']) && strlen($r['contentType']))
-          $response['content']['mimeType'] = (string)$r['contentType'];
-        else
-          $response['content']['mimeType'] = '';
-        
-        // unsupported fields that are required
-        $response['cookies'] = array();
-
-        $entry['response'] = $response;
-        
-        $entry['cache'] = (object)array();
-        
-        $timings = array();
-        $timings['blocked'] = -1;
-        $timings['dns'] = (int)$r['dns_ms'];
-        if( !$timings['dns'])
-          $timings['dns'] = -1;
-
-        // HAR did not have an ssl time until version 1.2 .  For
-        // backward compatibility, "connect" includes "ssl" time.
-        // WepbageTest's internal representation does not assume any
-        // overlap, so we must add our connect and ssl time to get the
-        // connect time expected by HAR.
-        $timings['connect'] = (durationOfInterval($r['connect_ms']) +
-                               durationOfInterval($r['ssl_ms']));
-        if(!$timings['connect'])
-          $timings['connect'] = -1;
-
-        $timings['ssl'] = (int)$r['ssl_ms'];
-        if (!$timings['ssl'])
-          $timings['ssl'] = -1;
-
-        // TODO(skerner): WebpageTest's data model has no way to
-        // represent the difference between the states HAR calls
-        // send (time required to send HTTP request to the server)
-        // and wait (time spent waiting for a response from the server).
-        // We lump both into "wait".  Issue 24* tracks this work.  When
-        // it is resolved, read the real values for send and wait
-        // instead of using the request's TTFB.
-        // *: http://code.google.com/p/webpagetest/issues/detail?id=24
-        $timings['send'] = 0;
-        $timings['wait'] = (int)$r['ttfb_ms'];
-        $timings['receive'] = (int)$r['download_ms'];
-
-        $entry['timings'] = $timings;
-
-        // The HAR spec defines time as the sum of the times in the
-        // timings object, excluding any unknown (-1) values and ssl
-        // time (which is included in "connect", for backward
-        // compatibility with tools written before "ssl" was defined
-        // in HAR version 1.2).
-        $entry['time'] = 0;
-        foreach ($timings as $timingKey => $duration) {
-          if ($timingKey != 'ssl' && $duration != UNKNOWN_TIME) {
-            $entry['time'] += $duration;
-          }
-        }
-        
-        if (array_key_exists('custom_rules', $r)) {
-          $entry['_custom_rules'] = $r['custom_rules'];
-        }
-
-        // dump all of our metrics into the har data as custom fields
-        foreach($r as $name => $value) {
-          if (!is_array($value))
-            $entry["_$name"] = $value;
-        }
-        
+      foreach ($steps as $stepData) {
+        // add the page-level ldata to the result
+        $pd = BuildHarPage($testPath, $cached, $run, $stepData);
+        $result['log']['pages'][] = $pd;
+        // now add the object-level data to the result
+        $secure = false;
+        $haveLocations = false;
+        $stepName = isset($stepData['stepName']) ? $stepData['stepName'] : null;
+        $requests = getRequests($id, $testPath, $run, $cached, $secure, $haveLocations, false, true, $stepName);
         // add it to the list of entries
-        $entries[] = $entry;
-      }
-      
-      // add the bodies to the requests
-      if (isset($options['bodies']) && $options['bodies']) {
-        $bodies_file = $testPath . '/' . $run . $cached_text . '_bodies.zip';
-        if (is_file($bodies_file)) {
-          $zip = new ZipArchive;
-          if ($zip->open($bodies_file) === TRUE) {
-            for( $i = 0; $i < $zip->numFiles; $i++ ) {
-              $index = intval($zip->getNameIndex($i), 10) - 1;
-              if (array_key_exists($index, $entries))
-                $entries[$index]['response']['content']['text'] = utf8_encode($zip->getFromIndex($i));
+        foreach ($requests as $r) {
+          $entry = BuildHAREntry($stepData, $pd, $r);
+          $entries[] = $entry;
+        }
+        // add the bodies to the requests
+        if (isset($options['bodies']) && $options['bodies']) {
+          $bodies_file = $testPath . '/' . $run . $cached_text . '_bodies.zip';
+          if (is_file($bodies_file)) {
+            $zip = new ZipArchive;
+            if ($zip->open($bodies_file) === TRUE) {
+              for ($i = 0; $i < $zip->numFiles; $i++) {
+                $index = intval($zip->getNameIndex($i), 10) - 1;
+                if (array_key_exists($index, $entries))
+                  $entries[$index]['response']['content']['text'] = utf8_encode($zip->getFromIndex($i));
+              }
             }
           }
         }

--- a/www/object_detail.inc
+++ b/www/object_detail.inc
@@ -14,7 +14,7 @@ if(extension_loaded('newrelic')) {
 */
 function getRequests($id, $test_path, $run, $is_cached,
                      &$has_secure_requests, &$has_locations,
-                     $use_location_check, $use_raw_headers = false) {
+                     $use_location_check, $use_raw_headers = false, $stepName = null) {
     if (!isset($test_path) || !strlen($test_path))
         $test_path = './' . GetTestPath($id);
     $cached_text = ((bool)@$is_cached) ? '_Cached' : '';
@@ -25,7 +25,7 @@ function getRequests($id, $test_path, $run, $is_cached,
     $custom_rules_file_name = $file_prefix . 'custom_rules.json';
 
     $needHeaders = false;
-    $requests = LoadRequests($request_file_name);
+    $requests = LoadRequests($request_file_name, $stepName);
     if (isset($requests) && is_array($requests) && count($requests)) {
         if ($use_raw_headers)
             $needHeaders = true;
@@ -40,7 +40,7 @@ function getRequests($id, $test_path, $run, $is_cached,
         GetDevToolsRequests($test_path, $run, $is_cached, $requests, $pageData);
     FixUpRequestTimes($requests);
     if ($needHeaders)
-        AddHeaders($requests, $headers_file_name);
+        AddHeaders($requests, $headers_file_name, $stepName);
 
     $has_locations = false;
     if ($use_location_check) {
@@ -125,7 +125,7 @@ function CalculateComponentTimes(&$pageData, &$requests) {
 /**
 * Load the gzipped request file (tab deliminated).
 */
-function LoadRequests($request_file_name) {
+function LoadRequests($request_file_name, $stepName = null) {
     $requests = array();
     $needed_columns = array(
         // tsv_column => request_key
@@ -188,6 +188,11 @@ function LoadRequests($request_file_name) {
             $columns = explode("\t", str_replace("\t", "\t ", $line));
             if (count($columns)) {
                 $request = array();
+                // logAlways("[LoadRequests] request: $columns[7]; $columns[2]; $stepName;");
+                if (isset($stepName) && isset($columns[2]) && strlen($columns[2]) && trim($columns[2]) != $stepName) {
+                    // request doesn't belong to the step that we are interested in. skip this request.
+                    continue;
+                }
                 foreach ($columns as $i => $value) {
                     if (array_key_exists($i + 1, $needed_columns) && strlen(trim($value)))
                         $request[$needed_columns[$i + 1]] = trim($value);
@@ -404,7 +409,7 @@ function _AddHeadersSave(&$requests, &$index, &$headers) {
 /**
 * Load the raw headers if we have them.
 */
-function AddHeaders(&$requests, $headers_file_name) {
+function AddHeaders(&$requests, $headers_file_name, $stepName = null) {
     $header_lines = gz_file($headers_file_name);
     if ($header_lines) {
         $is_started = false;
@@ -414,7 +419,12 @@ function AddHeaders(&$requests, $headers_file_name) {
             if (!$is_started) {
                 $is_started = ($trimmed == 'Request details:');
             } else {
-                if ($trimmed == 'Request Headers:' && isset($index)) {
+                if (isset($stepName) && strpos($trimmed, 'Step name:') !== false) {
+                    $thisStepName = substr($trimmed, 10, strlen($trimmed));
+                    if ($thisStepName != $stepName) {
+                        $is_started = false;
+                    }
+                } elseif ($trimmed == 'Request Headers:' && isset($index)) {
                     $headers_key = 'request';
                 } elseif ($trimmed == 'Response Headers:' && isset($index)) {
                     $headers_key = 'response';

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -1,5 +1,6 @@
 <?php
 require_once('devtools.inc.php');
+include 'common.inc';
 
 /**
 * Load the page results directly from the results files
@@ -9,9 +10,8 @@ require_once('devtools.inc.php');
 * @param mixed $run
 * @param mixed $cached
 */
-function loadAllPageData($testPath, $options = null) {
+function loadAllPageData($testPath, $options = null, $multistep = false) {
   $ret = array();
-  
   // go in order for the number of runs there are supposed to be
   if (is_file("$testPath/testinfo.ini")) {
     $ini = parse_ini_file("$testPath/testinfo.ini", true);
@@ -21,24 +21,23 @@ function loadAllPageData($testPath, $options = null) {
     $completed = true;
     if ($testInfo && (!array_key_exists('completed', $testInfo) || !$testInfo['completed']))
       $completed = false;
-      
+
     for( $run = 1; $run <= $runs; $run++ ) {
       // only load page data for individual runs that are complete (or if the whole test is complete)
       if ($completed || !$testInfo || IsTestRunComplete($run, $testInfo)) {
-        $data = loadPageRunData($testPath, $run, 0, $options);
+        $data = loadPageRunData($testPath, $run, 0, $options, $multistep);
         if( isset($data) )
           $ret[$run][0] = $data;
         
         if( !$fvonly ) {
           unset( $data );
-          $data = loadPageRunData($testPath, $run, 1, $options);
+          $data = loadPageRunData($testPath, $run, 1, $options, $multistep);
           if( isset($data) )
             $ret[$run][1] = $data;
         }
       }
     }
   }
-  
   return $ret;
 }
 
@@ -50,20 +49,21 @@ function loadAllPageData($testPath, $options = null) {
 * @param mixed $fv
 * @param mixed $rv
 */
-function loadPageRunData($testPath, $run, $cached, $options = null)
+function loadPageRunData($testPath, $run, $cached, $options = null, $multistep=false)
 {
     $ret = null;
-
     $cachedText = $cached ? '_Cached' : '';
-    $ret = loadPageData("$testPath/{$run}{$cachedText}_IEWPG.txt", $options);
-    if (!isset($ret) || !is_array($ret) || !count($ret))
+    $ret = loadPageData("$testPath/{$run}{$cachedText}_IEWPG.txt", $options, $multistep);
+    if (!$multistep && (!isset($ret) || !is_array($ret) || !count($ret))) {
+      // Not yet supported for multistep.
       GetDevToolsRequests($testPath, $run, $cached, $requests, $ret);
-    
+    }
     // see if we have video files to calculate a visually complete time from
     $basic_results = false;
     if (array_key_exists('basic', $_REQUEST) && $_REQUEST['basic'])
       $basic_results = true;
-    if (gz_is_file("$testPath/{$run}{$cachedText}_page_data.json")) {
+    if (!$multistep && gz_is_file("$testPath/{$run}{$cachedText}_page_data.json")) {
+      // Not yet supported for multistep.
       $pd = json_decode(gz_file_get_contents("$testPath/{$run}{$cachedText}_page_data.json"), true);
       if ($pd && is_array($pd) && count($pd)) {
         foreach($pd as $key => $value) {
@@ -71,166 +71,184 @@ function loadPageRunData($testPath, $run, $cached, $options = null)
         }
       }
     }
-    
-    if (isset($ret) && !$basic_results) {
-        $startOffset = array_key_exists('testStartOffset', $ret) ? intval(round($ret['testStartOffset'])) : 0;
-        loadUserTimingData($ret, $testPath, $run, $cached);
+    $steps = $multistep ? $ret : array($ret);
+    foreach ($steps as $index => &$step) {
+      if (isset($step) && !$basic_results) {
+        $startOffset = array_key_exists('testStartOffset', $step) ? intval(round($step['testStartOffset'])) : 0;
+        if (!$multistep) {
+          // Not yet supported with multistep
+          loadUserTimingData($step, $testPath, $run, $cached);
 
-        // see if we have custom metrics to load
-        if (gz_is_file("$testPath/{$run}{$cachedText}_metrics.json")) {
-          $custom_metrics = json_decode(gz_file_get_contents("$testPath/{$run}{$cachedText}_metrics.json"), true);
-          if ($custom_metrics && is_array($custom_metrics) && count($custom_metrics)) {
-            $ret["custom"] = array();
-            foreach ($custom_metrics as $metric => $value) {
-              if (preg_match('/^[0-9]+$/', $value))
-                $ret[$metric] = intval($value);
-              elseif (preg_match('/^[0-9]*\.[0-9]+$/', $value))
-                $ret[$metric] = floatval($value);
-              else
-                $ret[$metric] = $value;
-              $ret["custom"][] = $metric;
-            }
-          }
-        }
-        
-        // see if we have CSI metrics to load
-        if (is_dir('./google') && is_file('./google/google_lib.inc')) {
-          require_once('google/google_lib.inc');
-          $csi = ParseCsiInfo(0, $testPath, $run, $cached, true, false);
-          if (isset($csi) && is_array($csi) && count($csi)) {
-            $ret['CSI'] = array();
-            foreach($csi as $metric => $value) {
-              if (preg_match('/^[0-9]+$/', $value))
-                $value = intval($value);
-              elseif (preg_match('/^[0-9\.]+$/', $value))
-                $value = floatval($value);
-              $ret["CSI.$metric"] = $value;
-              $ret['CSI'][] = $metric;
-            }
-          }
-        }
-
-        if (array_key_exists('loadTime', $ret) &&
-            !$ret['loadTime'] &&
-            array_key_exists('fullyLoaded', $ret) &&
-            $ret['fullyLoaded'] > 0)
-            $ret['loadTime'] = $ret['fullyLoaded'];
-        $video_dir = "$testPath/video_$run";
-        if ($cached)
-            $video_dir .= '_cached';
-        if (is_dir($video_dir)) {
-          $frames = null;
-          loadVideo($video_dir, $frames);
-          if( isset($frames) && is_array($frames) && count($frames) ) {
-            if (!array_key_exists('lastVisualChange', $ret) || !$ret['lastVisualChange']) {
-              end($frames);
-              $last = max(key($frames) - $startOffset, 0);
-              reset($frames);
-              if( $last ) {
-                  $ret['lastVisualChange'] = $last;
-                  if (!array_key_exists('visualComplete', $ret))
-                      $ret['visualComplete'] = $ret['lastVisualChange'];
+          // Not yet supported with multistep
+          // see if we have custom metrics to load
+          if (gz_is_file("$testPath/{$run}{$cachedText}_metrics.json")) {
+            $custom_metrics = json_decode(gz_file_get_contents("$testPath/{$run}{$cachedText}_metrics.json"), true);
+            if ($custom_metrics && is_array($custom_metrics) && count($custom_metrics)) {
+              $step["custom"] = array();
+              foreach ($custom_metrics as $metric => $value) {
+                if (preg_match('/^[0-9]+$/', $value))
+                  $step[$metric] = intval($value);
+                elseif (preg_match('/^[0-9]*\.[0-9]+$/', $value))
+                  $step[$metric] = floatval($value);
+                else
+                  $step[$metric] = $value;
+                $step["custom"][] = $metric;
               }
             }
-            if ((!array_key_exists('render', $ret) || !$ret['render']) && count($frames) > 1) {
-              next($frames);
-              $first = max(key($frames) - $startOffset, 0);
-              reset($frames);
-              if ($first)
-                $ret['render'] = $first;
+          }
+
+          // Not yet supported with multistep
+          // see if we have CSI metrics to load
+          if (is_dir('./google') && is_file('./google/google_lib.inc')) {
+            require_once('google/google_lib.inc');
+            $csi = ParseCsiInfo(0, $testPath, $run, $cached, true, false);
+            if (isset($csi) && is_array($csi) && count($csi)) {
+              $step['CSI'] = array();
+              foreach ($csi as $metric => $value) {
+                if (preg_match('/^[0-9]+$/', $value))
+                  $value = intval($value);
+                elseif (preg_match('/^[0-9\.]+$/', $value))
+                  $value = floatval($value);
+                $step["CSI.$metric"] = $value;
+                $step['CSI'][] = $metric;
+              }
             }
+          }
+        }
+
+        if (array_key_exists('loadTime', $step) &&
+            !$step['loadTime'] &&
+            array_key_exists('fullyLoaded', $step) &&
+            $step['fullyLoaded'] > 0
+        ) {
+          $step['loadTime'] = $step['fullyLoaded'];
+        }
+        $stepNum = $multistep ? $index + 1 : null;
+        $video_dir = "$testPath/video_$run";
+        if ($cached)
+          $video_dir .= '_cached';
+        if (is_dir($video_dir)) {
+          $frames = null;
+          loadVideo($video_dir, $frames, $stepNum);
+          if (isset($frames) && is_array($frames) && count($frames)) {
+            if (!array_key_exists('lastVisualChange', $step) || !$step['lastVisualChange'])
+              end($frames);
+            $last = max(key($frames) - $startOffset, 0);
+            reset($frames);
+            if ($last) {
+              $step['lastVisualChange'] = $last;
+              if (!array_key_exists('visualComplete', $step))
+                $step['visualComplete'] = $step['lastVisualChange'];
+            }
+          }
+          if ((!array_key_exists('render', $step) || !$step['render']) && count($frames) > 1) {
+            next($frames);
+            $first = max(key($frames) - $startOffset, 0);
+            reset($frames);
+            if ($first)
+              $step['render'] = $first;
           }
         }
         require_once('./video/visualProgress.inc.php');
-        $progress = GetVisualProgress($testPath, $run, $cached, null, null, $startOffset);
+        $progress = GetVisualProgress($testPath, $run, $cached, null, null, $startOffset, $stepNum);
         if (isset($progress) && is_array($progress)) {
-            if (array_key_exists('SpeedIndex', $progress))
-                $ret['SpeedIndex'] = $progress['SpeedIndex'];
-            if (array_key_exists('visualComplete', $progress))
-                $ret['visualComplete'] = $progress['visualComplete'];
-            if (array_key_exists('startRender', $progress) && (!array_key_exists('render', $ret) || !$ret['render']))
-                $ret['render'] = $progress['startRender'];
-            if ((!array_key_exists('lastVisualChange', $ret) ||
-                 !$ret['lastVisualChange']) &&
-                array_key_exists('visualComplete', $ret))
-                $ret['lastVisualChange'] = $ret['visualComplete'];
+          if (array_key_exists('SpeedIndex', $progress))
+            $step['SpeedIndex'] = $progress['SpeedIndex'];
+          if (array_key_exists('visualComplete', $progress))
+            $step['visualComplete'] = $progress['visualComplete'];
+          if (array_key_exists('startRender', $progress) && (!array_key_exists('render', $step) || !$step['render']))
+            $step['render'] = $progress['startRender'];
+          if ((!array_key_exists('lastVisualChange', $step) ||
+                  !$step['lastVisualChange']) &&
+              array_key_exists('visualComplete', $step)
+          )
+            $step['lastVisualChange'] = $step['visualComplete'];
         }
         // see if we need a custom Speed Index as well
         $end = null;
         if (isset($options) && array_key_exists('end', $options)) {
-            $end = $options['end'];
-            $progress = GetVisualProgress($testPath, $run, $cached, null, $end, $startOffset);
-            if (isset($progress) && is_array($progress)) {
-                if (array_key_exists('SpeedIndex', $progress))
-                    $ret['SpeedIndexCustom'] = $progress['SpeedIndex'];
-                $ret['visualCompleteCustom'] = $progress['visualComplete'];
-            }
+          $end = $options['end'];
+          $progress = GetVisualProgress($testPath, $run, $cached, null, $end, $startOffset);
+          if (isset($progress) && is_array($progress)) {
+            if (array_key_exists('SpeedIndex', $progress))
+              $step['SpeedIndexCustom'] = $progress['SpeedIndex'];
+            $step['visualCompleteCustom'] = $progress['visualComplete'];
+          }
         }
 
-        if (isset($ret) && is_array($ret) && isset($ret['fullyLoaded']) && $ret['fullyLoaded']) {
-          $processing = GetDevToolsCPUTime($testPath, $run, $cached, $ret['fullyLoaded']);
+        if (isset($step) && is_array($step) && isset($step['fullyLoaded']) && $step['fullyLoaded']) {
+          $processing = GetDevToolsCPUTime($testPath, $run, $cached, $step['fullyLoaded']);
           if (isset($processing) && is_array($processing) && count($processing)) {
-            $ret['cpuTimes'] = $processing;
-            if (isset($ret['docTime']) && $ret['docTime']) {
-              $processing = GetDevToolsCPUTime($testPath, $run, $cached, $ret['docTime']);
+            $step['cpuTimes'] = $processing;
+            if (isset($step['docTime']) && $step['docTime']) {
+              $processing = GetDevToolsCPUTime($testPath, $run, $cached, $step['docTime']);
               if (isset($processing) && is_array($processing) && count($processing)) {
-                $ret['cpuTimesDoc'] = $processing;
+                $step['cpuTimesDoc'] = $processing;
               }
             }
           }
         }
-    }
+      }
 
-    if (isset($ret)) {
-        $ret['run'] = $run;
-        $ret['cached'] = $cached;
-        
+      if (isset($step)) {
+        $step['run'] = $run;
+        $step['cached'] = $cached;
+
         // calculate the effective bps
-        if (array_key_exists('fullyLoaded', $ret) &&
-            array_key_exists('TTFB', $ret) &&
-            array_key_exists('bytesIn', $ret) &&
-            $ret['fullyLoaded'] > 0 &&
-            $ret['TTFB'] > 0 &&
-            $ret['bytesIn'] > 0 &&
-            $ret['fullyLoaded'] > $ret['TTFB'])
-            $ret['effectiveBps'] = intval($ret['bytesIn'] / (($ret['fullyLoaded'] - $ret['TTFB']) / 1000.0));
-        if (array_key_exists('docTime', $ret) &&
-            array_key_exists('TTFB', $ret) &&
-            array_key_exists('bytesInDoc', $ret) &&
-            $ret['docTime'] > 0 &&
-            $ret['TTFB'] > 0 &&
-            $ret['bytesInDoc'] > 0 &&
-            $ret['docTime'] > $ret['TTFB'])
-            $ret['effectiveBpsDoc'] = intval($ret['bytesInDoc'] / (($ret['docTime'] - $ret['TTFB']) / 1000.0));
-        // clean up any insane values (from negative numbers as unsigned most likely)
-        if (array_key_exists('firstPaint', $ret) &&
-            array_key_exists('fullyLoaded', $ret) &&
-            $ret['firstPaint'] > $ret['fullyLoaded'])
-          $ret['firstPaint'] = 0;
-        $times = array('loadTime',
-                       'TTFB',
-                       'render',
-                       'fullyLoaded',
-                       'docTime',
-                       'domTime',
-                       'aft',
-                       'titleTime',
-                       'loadEventStart',
-                       'loadEventEnd',
-                       'domContentLoadedEventStart',
-                       'domContentLoadedEventEnd',
-                       'lastVisualChange',
-                       'server_rtt',
-                       'firstPaint');
-        foreach ($times as $key) {
-          if (!array_key_exists($key, $ret) ||
-              $ret[$key] > 3600000 ||
-              $ret[$key] < 0)
-            $ret[$key] = 0;
+        if (array_key_exists('fullyLoaded', $step) &&
+            array_key_exists('TTFB', $step) &&
+            array_key_exists('bytesIn', $step) &&
+            $step['fullyLoaded'] > 0 &&
+            $step['TTFB'] > 0 &&
+            $step['bytesIn'] > 0 &&
+            $step['fullyLoaded'] > $step['TTFB']
+        ) {
+          $step['effectiveBps'] = intval($step['bytesIn'] / (($step['fullyLoaded'] - $step['TTFB']) / 1000.0));
         }
+        if (array_key_exists('docTime', $step) &&
+            array_key_exists('TTFB', $step) &&
+            array_key_exists('bytesInDoc', $step) &&
+            $step['docTime'] > 0 &&
+            $step['TTFB'] > 0 &&
+            $step['bytesInDoc'] > 0 &&
+            $step['docTime'] > $step['TTFB']
+        ) {
+          $step['effectiveBpsDoc'] = intval($step['bytesInDoc'] / (($step['docTime'] - $step['TTFB']) / 1000.0));
+        }
+        // clean up any insane values (from negative numbers as unsigned most likely)
+        if (array_key_exists('firstPaint', $step) &&
+            array_key_exists('fullyLoaded', $step) &&
+            $step['firstPaint'] > $step['fullyLoaded']
+        ) {
+          $step['firstPaint'] = 0;
+        }
+        $times = array('loadTime',
+            'TTFB',
+            'render',
+            'fullyLoaded',
+            'docTime',
+            'domTime',
+            'aft',
+            'titleTime',
+            'loadEventStart',
+            'loadEventEnd',
+            'domContentLoadedEventStart',
+            'domContentLoadedEventEnd',
+            'lastVisualChange',
+            'server_rtt',
+            'firstPaint');
+        foreach ($times as $key) {
+          if (!array_key_exists($key, $step) ||
+              $step[$key] > 3600000 ||
+              $step[$key] < 0
+          )
+            $step[$key] = 0;
+        }
+      }
     }
-    
-    return $ret;
+    unset($step);
+
+    return $multistep ? $steps : $steps[0];
 }
 
 /**
@@ -238,9 +256,9 @@ function loadPageRunData($testPath, $run, $cached, $options = null)
 * 
 * @param mixed $file
 */
-function loadPageData($file, $options = null)
+function loadPageData($file, $options = null, $multistep=false)
 {
-    $ret = null;
+    $steps = array();
     $lines = gz_file($file);
     if( $lines)
     {
@@ -251,8 +269,7 @@ function loadPageData($file, $options = null)
             $fields = explode("\t", $parseLine);
             if( count($fields) > 34 && trim($fields[0]) != 'Date' )
             {
-                $ret = array();
-                $ret = array(   'URL' => @htmlspecialchars(trim($fields[3])),
+                $step = array(   'URL' => @htmlspecialchars(trim($fields[3])),
                                 // 'loadTime' => (int)$fields[4],
                                 'loadTime' => @(int)$fields[32],
                                 'TTFB' => @(int)$fields[5],
@@ -306,27 +323,41 @@ function loadPageData($file, $options = null)
                                 'adult_site' => @(int)trim($fields[87])
                             );
 
-                $ret['fixed_viewport'] = (array_key_exists(88, $fields) && strlen(trim($fields[88]))) ? (int)trim($fields[88]) : -1;
-                $ret['score_progressive_jpeg'] = (array_key_exists(89, $fields) && strlen(trim($fields[89]))) ? (int)trim($fields[89]) : -1;
-                $ret['firstPaint'] = (array_key_exists(90, $fields) && strlen(trim($fields[90]))) ? (int)trim($fields[90]) : 0;
-                //$ret['peakMem'] = (array_key_exists(91, $fields) && strlen(trim($fields[91]))) ? (int)trim($fields[91]) : 0;
-                //$ret['processCount'] = (array_key_exists(92, $fields) && strlen(trim($fields[92]))) ? (int)trim($fields[92]) : 0;
-                $ret['docCPUms'] = (array_key_exists(93, $fields) && strlen(trim($fields[93]))) ? floatval(trim($fields[93])) : 0.0;
-                $ret['fullyLoadedCPUms'] = (array_key_exists(94, $fields) && strlen(trim($fields[94]))) ? floatval(trim($fields[94])) : 0.0;
-                $ret['docCPUpct'] = (array_key_exists(95, $fields) && strlen(trim($fields[95]))) ? floatval(trim($fields[95])) : 0;
-                $ret['fullyLoadedCPUpct'] = (array_key_exists(96, $fields) && strlen(trim($fields[96]))) ? floatval(trim($fields[96])) : 0;
-                $ret['isResponsive'] = (array_key_exists(97, $fields) && strlen(trim($fields[97]))) ? intval(trim($fields[97])) : -1;
-                
-                $ret['date'] = strtotime(trim($fields[0]) . ' ' . trim($fields[1]));
-                if (!strlen($ret['pageSpeedVersion']))
-                    $ret['pageSpeedVersion'] = '1.9';
+                $step['fixed_viewport'] = (array_key_exists(88, $fields) && strlen(trim($fields[88]))) ? (int)trim($fields[88]) : -1;
+                $step['score_progressive_jpeg'] = (array_key_exists(89, $fields) && strlen(trim($fields[89]))) ? (int)trim($fields[89]) : -1;
+                $step['firstPaint'] = (array_key_exists(90, $fields) && strlen(trim($fields[90]))) ? (int)trim($fields[90]) : 0;
+                //$step['peakMem'] = (array_key_exists(91, $fields) && strlen(trim($fields[91]))) ? (int)trim($fields[91]) : 0;
+                //$step['processCount'] = (array_key_exists(92, $fields) && strlen(trim($fields[92]))) ? (int)trim($fields[92]) : 0;
+                $step['docCPUms'] = (array_key_exists(93, $fields) && strlen(trim($fields[93]))) ? floatval(trim($fields[93])) : 0.0;
+                $step['fullyLoadedCPUms'] = (array_key_exists(94, $fields) && strlen(trim($fields[94]))) ? floatval(trim($fields[94])) : 0.0;
+                $step['docCPUpct'] = (array_key_exists(95, $fields) && strlen(trim($fields[95]))) ? floatval(trim($fields[95])) : 0;
+                $step['fullyLoadedCPUpct'] = (array_key_exists(96, $fields) && strlen(trim($fields[96]))) ? floatval(trim($fields[96])) : 0;
+                $step['isResponsive'] = (array_key_exists(97, $fields) && strlen(trim($fields[97]))) ? intval(trim($fields[97])) : -1;
+                $step['date'] = strtotime(trim($fields[0]) . ' ' . trim($fields[1]));
+                $stepName = trim($fields[2]);
+                if (strlen($stepName) && $multistep) {
+                  $step['stepName'] = $stepName;
+                }
+                if (!strlen($step['pageSpeedVersion']))
+                    $step['pageSpeedVersion'] = '1.9';
 
-                break;
+                $steps[] = $step;
+                if (!$multistep) {
+                  // if not multistep, revert to old behavior. only the first page data is preserved.
+                  break;
+                }
             }
         }
     }
-    
-    return $ret;
+    if (count($steps) == 0) {
+      return null;
+    } else {
+      if ($multistep) {
+        return $steps;
+      } else {
+        return $steps[0];
+      }
+    }
 }
 
 /**

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -86,6 +86,7 @@
         if( !isset($test) )
         {
             $test = array();
+            $test['server_caps'] = (int)GetCapabilities();
             $test['url'] = trim($req_url);
             $test['domElement'] = trim($req_domelement);
             $test['login'] = trim($req_login);
@@ -1815,6 +1816,7 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
 
         // write out the ini file
         $testInfo = "[test]\r\n";
+        $testInfo .= "server_caps={$test['server_caps']}\r\n";
         $testInfo .= "fvonly={$test['fvonly']}\r\n";
         $testInfo .= "timeout={$test['timeout']}\r\n";
         $resultRuns = $test['runs'] - $test['discard'];
@@ -1866,6 +1868,9 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
         {
             // build up the actual test commands
             $testFile = '';
+            if (isset($test['server_caps'])) {
+              $testFile .= "\r\nserver_caps={$test['server_caps']}";
+            }
             if( strlen($test['domElement']) )
                 $testFile .= "\r\nDOMElement={$test['domElement']}";
             if( $test['fvonly'] )

--- a/www/work/resultimage.php
+++ b/www/work/resultimage.php
@@ -48,13 +48,21 @@ if (ValidateTestId($id)) {
                 if (count($parts)) {
                   $runNum = $parts[0];
                   $fileBase = $parts[count($parts) - 1];
+                  $stepNum = null;
+                  if (count($parts) > 2 && IsMultistepTestResult($testInfo)) {
+                    $stepNum = $parts[count($parts) - 2];
+                  }
                   $cached = '';
                   if( strpos($fileName, '_Cached') )
                     $cached = '_cached';
                   $path .= "/video_$runNum$cached";
                   if( !is_dir($path) )
                     mkdir($path, 0777, true);
-                  $fileName = 'frame_' . $fileBase;
+                  if (isset($stepNum)) {
+                    $fileName = 'frame_' . $stepNum . '_' . $fileBase;
+                  } else {
+                    $fileName = 'frame_' . $fileBase;
+                  }
                 }
               } elseif (strpos($fileName, '_ms_') !== false) {
                 $parts = explode('_', $fileName);


### PR DESCRIPTION
export.php now has enough information provided by the agent that it can generate multistep HARs. The rest of the UI has not changed, and is completely backward compatible with the older agents. Also, older servers can continue to serve newer agents. There are some features that are not adapted to be multistep -- like custom metrics, user timings, CSI metrics, etc. These will come gradually, but the most important results: basic page, and request details along with visual metrics for each step is now provided in the HAR. This will help tools that can manage their own UI to consume the new HARs and render multipage performance view.

More details can be found in the commit message.

Testing notes:
-- Several tests done with different variations to make sure multistep=0 and multistep=1 works. 
-- Verified that visualComplete, speed-index metrics are correctly computed.
-- Tested backward compatibility with older agent and newer server and vice-versa.