### PR TITLE
Include 'mobile' test in result header

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -217,7 +217,12 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
             }
             echo "</h2>";
             
-            echo "<p class=\"heading_details\"><strong>From:</strong> {$test['test']['location']}<br>";
+            echo "<p class=\"heading_details\"><strong>From:</strong> {$test['test']['location']}";
+            if (isset($test['testinfo']['mobile']) && $test['testinfo']['mobile'] === 1)
+            {
+            	echo " - Mobile";
+            }
+            echo "<br />\n";
             if (isset($test['testinfo']) && (isset($test['testinfo']['completed']) || isset($test['testinfo']['started'])) )
             {
                 if (isset($test['testinfo']['completed'])) {


### PR DESCRIPTION
When looking at the results of a mobile test there is no indication in the information about the test that it was done with mobile settings, commonly the Chrome mobile device emulator.  This patch adds 'mobile' to the 'From:' line in the header for mobile tests:

From: My Awesome Test Location - Chrome - 2GFast - Mobile