### PR TITLE
Expose 'mobile' status in JSON results

### DIFF
--- a/www/jsonResult.php
+++ b/www/jsonResult.php
@@ -75,6 +75,8 @@ function GetTestResult($id) {
             $ret['latency'] = $testInfo['latency'];
         if (array_key_exists('plr', $testInfo))
             $ret['plr'] = $testInfo['plr'];
+        if (array_key_exists('mobile', $testInfo))
+            $ret['mobile'] = $testInfo['mobile'];
         if (array_key_exists('label', $testInfo) && strlen($testInfo['label']))
             $ret['label'] = $testInfo['label'];
         if (array_key_exists('completed', $testInfo))


### PR DESCRIPTION
When looking at JSON test results there is nothing to indicate if the test was run as mobile or not.  This patch adds 'mobile' to the JSON results ( mobile = 1 ) when the test info indicates it was a mobile test.