### PR TITLE
Expose 'mobile' status in XML results

### DIFF
--- a/www/xmlResult.php
+++ b/www/xmlResult.php
@@ -90,6 +90,8 @@ else
             }
             if( @strlen($test['testinfo']['mobile']) )
                 echo "<mobile>" . xml_entities($test['testinfo']['mobile']) .   "</mobile>\n";
+            if( isset($test['testinfo']['mobile']) )
+                echo "<mobile>" . xml_entities($test['testinfo']['mobile']) .   "</mobile>\n";
             if( @strlen($test['testinfo']['label']) )
                 echo "<label>" . xml_entities($test['testinfo']['label']) . "</label>\n";
             if( @strlen($test['testinfo']['completed']) )

--- a/www/xmlResult.php
+++ b/www/xmlResult.php
@@ -88,6 +88,8 @@ else
                 echo "<latency>{$test['testinfo']['latency']}</latency>\n";
                 echo "<plr>{$test['testinfo']['plr']}</plr>\n";
             }
+            if( @strlen($test['testinfo']['mobile']) )
+                echo "<mobile>" . xml_entities($test['testinfo']['mobile']) .   "</mobile>\n";
             if( @strlen($test['testinfo']['label']) )
                 echo "<label>" . xml_entities($test['testinfo']['label']) . "</label>\n";
             if( @strlen($test['testinfo']['completed']) )


### PR DESCRIPTION
When looking at XML test results there is nothing to indicate if the test was run as mobile or not. This patch adds 'mobile' to the XML results ( `<mobile>1</mobile>` ) when the test info indicates it was a mobile test.