### PR TITLE
Add section.io (squixa) to the CDN provider lists

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -103,6 +103,7 @@ CDN_PROVIDER cdnList[] = {
 	{".rlcdn.com", _T("Reapleaf")},
 	{".wp.com", _T("WordPress Jetpack")},
 	{".incapdns.net", _T("Incapsula"}),
+	{".squixa.net", _T("section.io"}),
 	{NULL, NULL}
 };
 

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -145,6 +145,7 @@ CDN_PROVIDER cdnList[] = {
   {".aads1.net", "Aryaka"},
   {".aads-cn.net", "Aryaka"},
   {".aads-cng.net", "Aryaka"},
+  {".squixa.net", "section.io"},
   {"END_MARKER", "END_MARKER"}
 };
 


### PR DESCRIPTION
CDN provider [section.io][], formerly known as [Squixa][], are a similar offering to CloudFlare and should be detected as a registered CDN provider during speed tests.

[section.io]: https://www.section.io/
[Squixa]: https://www.section.io/squixa/