### PR TITLE
Add request details colour key

### DIFF
--- a/www/waterfall_detail.inc
+++ b/www/waterfall_detail.inc
@@ -1,3 +1,14 @@
+<table border="1" bordercolor="silver" cellpadding="2px" cellspacing="0" style="width:auto; font-size:11px; margin-left:auto; margin-right:auto;">
+    <tbody>
+    <tr>
+        <td><table><tbody><tr><td><div class="bar" style="width:15px; background-color:#dfffdf"></div></td><td>Before Start Render</td></tr></tbody></table></td>
+        <td><table><tbody><tr><td><div class="bar" style="width:15px; background-color:#dfdfff"></div></td><td>Before On Load </td></tr></tbody></table></td>
+        <td><table><tbody><tr><td><div class="bar" style="width:15px; background-color:gainsboro"></div></td><td>After On Load</td></tr></tbody></table></td>
+    </tr>
+    </tbody>
+</table>
+<br>
+
 <div class="center">
 <table id="tableDetails" class="details center">
 	<caption>Request Details</caption>


### PR DESCRIPTION
Adding colour key for the 3 phases:

- requests before the start render
- requests before onload
- requests after onload

<img width="517" alt="request-details-colour-key" src="https://cloud.githubusercontent.com/assets/209497/11148890/77f89788-8a17-11e5-938d-684849b78e83.png">

Info from Patrick
http://www.webpagetest.org/forums/showthread.php?tid=14056&pid=27146#pid27146