### PR TITLE
ChinaNetCenter CDN provider additions

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -49,6 +49,9 @@ CDN_PROVIDER cdnList[] = {
 	{".cloudflare.com", _T("Cloudflare")},
 	{".afxcdn.net", _T("afxcdn.net")},
 	{".lxdns.com", _T("ChinaNetCenter")},
+	{".wscdns.com", _T("ChinaNetCenter")},
+	{".wscloudcdn.com", _T("ChinaNetCenter")},
+	{".ourwebpic.com", _T("ChinaNetCenter")},
 	{".att-dsa.net", _T("AT&T")},
 	{".vo.msecnd.net", _T("Windows Azure")},
 	{".voxcdn.net", _T("VoxCDN")},
@@ -138,6 +141,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"server", "GSE", _T("Google")},
 	{"server", "Golfe2", _T("Google")},
 	{"server", "tsa_b", _T("Twitter")},
+	{"X-Cache", "cache.51cdn.com", _T("ChinaNetCenter")},
 	{"X-CDN", "Incapsula", _T("Incapsula")},
 	{"X-Iinfo", "", _T("Incapsula")}
 };

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -99,6 +99,9 @@ CDN_PROVIDER cdnList[] = {
   {".cloudflare.com", "Cloudflare"},
   {".afxcdn.net", "afxcdn.net"},
   {".lxdns.com", "ChinaNetCenter"},
+  {".wscdns.com", "ChinaNetCenter"},
+  {".wscloudcdn.com", "ChinaNetCenter"},
+  {".ourwebpic.com", "ChinaNetCenter"},
   {".att-dsa.net", "AT&T"},
   {".vo.msecnd.net", "Windows Azure"},
   {".voxcdn.net", "VoxCDN"},
@@ -185,6 +188,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "GSE", "Google"},
   {"server", "Golfe2", "Google"},
   {"server", "tsa_b", "Twitter"},
+  {"X-Cache", "cache.51cdn.com", "ChinaNetCenter"},
   {"X-CDN", "Incapsula", "Incapsula"},
   {"X-Iinfo", "", "Incapsula"},
   {"X-Ar-Debug", "", "Aryaka"}


### PR DESCRIPTION
Added ChinaNetCenter CDN domains and header for a better recognition.

DNS Examples : 
```
$ dig www.peugeot.com.cn
;; ANSWER SECTION:
www.peugeot.com.cn.	5777	IN	CNAME	www.peugeot.com.cn.lxdns.com.
www.peugeot.com.cn.lxdns.com. 600 IN	CNAME	1st.ecoma.ourwebpic.com.
1st.ecoma.ourwebpic.com. 120	IN	A	203.130.58.30

$ dig cdn.ceva-china.cn
;; ANSWER SECTION:
cdn.ceva-china.cn.	600	IN	CNAME	ofc4cq5hck5ql5.wscloudcdn.com.
ofc4cq5hck5ql5.wscloudcdn.com. 1800 IN	CNAME	1stcncloud.cloud.ourwebpic.com.
1stcncloud.cloud.ourwebpic.com.	120 IN	A	115.231.84.94
1stcncloud.cloud.ourwebpic.com.	120 IN	A	218.92.226.46
1stcncloud.cloud.ourwebpic.com.	120 IN	A	115.231.84.95
1stcncloud.cloud.ourwebpic.com.	120 IN	A	218.92.226.45

$ dig static.cnstock.com
;; ANSWER SECTION:
static.cnstock.com.	3600	IN	CNAME	static.cnstock.com.wscdns.com.
static.cnstock.com.wscdns.com. 600 IN	CNAME	1st.xdwscache.ourwebpic.com.
1st.xdwscache.ourwebpic.com. 119 IN	A	203.130.58.30
```

Headers example : 
```
$ curl -I http://cdn.ceva-china.cn/bundles/cevacountrysitecommon/images/logo.jpg
HTTP/1.1 200 OK
Expires: Thu, 03 Mar 2016 09:57:58 GMT
Date: Fri, 04 Dec 2015 09:59:13 GMT
Server: nginx
Content-Type: image/jpeg
Content-Length: 6320
Accept-Ranges: bytes
Last-Modified: Fri, 04 Dec 2015 09:58:15 GMT
ETag: W/"PSA-aj-AGqhG0tlJL"
Cache-Control: max-age=7775925
X-Cache: MISS from cache.51cdn.com
X-Via: 1.1 jsycdx41:4 (Cdn Cache Server V2.0)
Connection: keep-alive
```