### PR TITLE
KeyCDN's domain (kxcdn.com) added to the list

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -93,6 +93,7 @@ CDN_PROVIDER cdnList[] = {
   {".netdna-cdn.com", "NetDNA"},
   {".netdna-ssl.com", "NetDNA"},
   {".netdna.com", "NetDNA"},
+  {".kxcdn.com", "KeyCDN"},
   {".cotcdn.net", "Cotendo CDN"},
   {".cachefly.net", "Cachefly"},
   {"bo.lt", "BO.LT"},


### PR DESCRIPTION
All content from KeyCDN is delivered through the kxcdn.com domain.