### PR TITLE
Update Twitter CDNs

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -150,7 +150,7 @@ CDN_PROVIDER cdnList[] = {
   {".revcn.net", "Rev Software"},
   {".revdn.net", "Rev Software"},
   {".caspowa.com", "Caspowa"},
-  {".twimg.net", "Twitter"},
+  {".twimg.com", "Twitter"},
   {".facebook.com", "Facebook"},
   {".facebook.net", "Facebook"},
   {".fbcdn.net", "Facebook"},


### PR DESCRIPTION
Twitter uses `twimg.com` not `twimg.net`. See [these screenshots](http://imgur.com/a/Vsq0n) from the network panel for a request to https://twitter.com/jfsiii

Also, note the `X-Cache: HIT` and `X-CDN: FAST` headers from the requests below:

```
‣ curl -v https://pbs.twimg.com/profile_images/2623986414/hdc0in4m5mm1ehd21jke_normal.jpeg > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 72.21.91.66...
* Connected to pbs.twimg.com (72.21.91.66) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: *.twimg.com
* Server certificate: DigiCert High Assurance CA-3
* Server certificate: DigiCert High Assurance EV Root CA
> GET /profile_images/2623986414/hdc0in4m5mm1ehd21jke_normal.jpeg HTTP/1.1
> Host: pbs.twimg.com
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< content-md5: ZlQljDaHFAr1sotjyJPrDA==
< Content-Type: image/jpeg
< Date: Thu, 11 Feb 2016 00:29:00 GMT
< Last-Modified: Thu, 04 Nov 2010 01:42:54 GMT
< Server: ECS (sjc/4E66)
< surrogate-key: profile_images profile_images/bucket/3 profile_images/2623986414
< X-Cache: HIT
< x-connection-hash: 826467a5643aa1c93d76226afdd4e961
< x-content-type-options: nosniff
< x-response-time: 7
< Content-Length: 999
<
{ [999 bytes data]
100   999  100   999    0     0  11473      0 --:--:-- --:--:-- --:--:-- 11616
* Connection #0 to host pbs.twimg.com left intact

‣ curl -v https://abs.twimg.com/a/1455124137/img/t1/web_heart_animation.png > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 104.244.43.167...
* Connected to abs.twimg.com (104.244.43.167) port 443 (#0)
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: *.twimg.com
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> GET /a/1455124137/img/t1/web_heart_animation.png HTTP/1.1
> Host: abs.twimg.com
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Thu, 11 Feb 2016 00:30:25 GMT
< Server: Apache
< content-type: image/png
< etag: "MTZW1G1mE7LSX1CnhTYeHA=="
< expires: Thu, 09 Feb 2017 18:17:26 GMT
< last-modified: Wed, 10 Feb 2016 17:12:47 GMT
< x-connection-hash: bd0e1f6536cfbb7f7c9f54ab8a821f5f
< x-response-time: 7
< x-ton-expected-size: 11695
< Content-Length: 11695
< Accept-Ranges: bytes
< X-Served-By: cache-tw-sjc1-cr1-20-TWSJC1
< X-Cache: HIT
< X-Content-Type-Options: nosniff
< X-CDN: FAST
<
{ [7527 bytes data]
100 11695  100 11695    0     0  20475      0 --:--:-- --:--:-- --:--:-- 20445
* Connection #0 to host abs.twimg.com left intact
± ~/workspace/source/responsive-web [master @ b597780] ✓ ‣
```