### PR TITLE
Adding option to not downlaod consoleLog

### DIFF
--- a/www/jsonResult.php
+++ b/www/jsonResult.php
@@ -286,9 +286,22 @@ function GetSingleRunData($id, $testPath, $run, $cached, &$pageData, $testInfo) 
         	$ret['requests'] = $requests;
         }
         
-        $console_log = DevToolsGetConsoleLog($testPath, $run, $cached);
-        if (isset($console_log))
-            $ret['consoleLog'] = $console_log;
+        // Check to see if we're adding the console log
+        $addConsole = 1;
+        if(isset($_GET['console'])){
+            if($_GET['console'] == 0){
+               $addConsole = 0;
+            }
+        }
+
+        // add requests
+        if($addConsole == 1) {
+            $console_log = DevToolsGetConsoleLog($testPath, $run, $cached);
+            if (isset($console_log)) {
+                $ret['consoleLog'] = $console_log;
+            }
+        }
+
         if (gz_is_file("$testPath/$run{$cachedText}_status.txt")) {
             $ret['status'] = array();
             $lines = gz_file("$testPath/$run{$cachedText}_status.txt");

--- a/www/xmlResult.php
+++ b/www/xmlResult.php
@@ -599,6 +599,9 @@ function StatusMessages($id, $testPath, $run, $cached) {
 * @param mixed $cached
 */
 function ConsoleLog($id, $testPath, $run, $cached) {
+    if(isset($_GET['console']) && $_GET['console'] == 0) {
+        return;
+    }
     $consoleLog = DevToolsGetConsoleLog($testPath, $run, $cached);
     if (isset($consoleLog) && is_array($consoleLog) && count($consoleLog)) {
         echo "<consoleLog>\n";


### PR DESCRIPTION
This adds a new setting to not download the consoleLog in both the json and xml formats. It defaults to on (to maintain backwards compatibility). I haven't seen any docs in github, but those will need to be update (and I'll gladly do that, I just need to know how/where). 