### PR TITLE
Add benchmark and context links

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -245,6 +245,45 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
                 echo '<b>Scripted test</b><br>';
             if( strlen($blockString) )
                 echo "Blocked: <b>$blockString</b><br>";
+            if (isset($test['testinfo']['benchmark']) && strlen($test['testinfo']['benchmark'])) {
+                echo 'Benchmark: ';
+                $benchmark = $test['testinfo']['benchmark'];
+                if (isset($test['testinfo']['epoch'])) {
+                    $epochStr = $test['testinfo']['epoch'];
+                    $epoch = (int)$epochStr + ($tz_offset * 60);
+                    $epochTime = strftime('%x %X', $epoch);
+                    $benchmarkStr = "$benchmark - <span class=\"jsdate\" date=\"$epochStr\">$epochTime</span>";
+                } else {
+                    $benchmarkStr = $benchmark;
+                }
+                if ($settings['nolinks']) {
+                    echo "<span class=\"medium colored\">$benchmarkStr</span>";
+                } else {
+                    if (isset($test['testinfo']['epoch'])) {
+                        $benchmarkUrl = "/benchmarks/viewtest.php?benchmark=$benchmark&metric=docTime&time=$epoch";
+                    } else {
+                        $benchmarkUrl = "/benchmarks/view.php?benchmark=$benchmark&aggregate=median";
+                    }
+                    echo "<a class=\"url\" rel=\"nofollow\" title=\"$benchmarkUrl\" href=\"$benchmarkUrl\">$benchmarkStr</a>";
+                }
+                echo '<br>';
+            }
+            if (isset($test['testinfo']['context']) && strlen($test['testinfo']['context']))
+            {
+                echo 'Context: ';
+                $contextText = htmlspecialchars($test['testinfo']['context']);
+                if (isset($test['testinfo']['context_url']) && strlen($test['testinfo']['context_url'])) {
+                    $contextUrl = $test['testinfo']['context_url'];
+                    if ($settings['nolinks']) {
+                        echo "<span class=\"medium colored\">$contextText</span>";
+                    } else {
+                        echo "<a class=\"url\" rel=\"nofollow\" title=\"$contextUrl\" href=\"$contextUrl\">$contextText</a>";
+                    }
+                } else {
+                    echo $contextText;
+                }
+                echo '<br>';
+            }
         echo '</div>';
         echo '</div>';
         


### PR DESCRIPTION
E.g., if the testinfo.json contains:

    "benchmark": "foo",
    "epoch": 1459446420,
    "context": "bar",
    "context_url": "http://example.com",

then the results view will show:

    Benchmark: <a href="/benchmarks/view...">foo - 3/31/2016, 1:47:00 PM</a>
    Context: <a href="http://example.com">bar</a>`