### PR TITLE
Export group name from getLocations.php

### DIFF
--- a/www/getLocations.php
+++ b/www/getLocations.php
@@ -195,6 +195,9 @@ function LoadLocations()
 
                         if( $default == $loc['locations'][$i] && $def == $group[$j] )
                             $locations[$group[$j]]['default'] = true;
+
+                        if( isset($group['group']) )
+                            $locations[$group[$j]]['group'] = $group['group'];
                     }
                 }
                 $j++;


### PR DESCRIPTION
Small change to export the 'group' value as defined from [locations.ini](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/locations.ini.sample#L15). So from `<webpagetest_server>/getLocations.php?f=json`, groups are visible now. 

We are using group to divide locations by device type (Desktop, Mobile, Tablet) and the change here makes this attribute usable elsewhere.