### PR TITLE
wptdriver: Adjustments for multistep support

### DIFF
--- a/agent/wpthook/results.h
+++ b/agent/wpthook/results.h
@@ -92,6 +92,7 @@ private:
   DWORD peak_memory_;
   DWORD peak_process_count_;
 
+  void IncrementStep(void);
   void ProcessRequests(void);
   void SavePageData(OptimizationChecks&);
   void SaveRequests(OptimizationChecks&);


### PR DESCRIPTION
First changes to tackle multistep support as discussed in #618.
Does not fix chombineSteps as reported in #625.

The wptdriver basically supports measuring multiple steps, but the old implementation used the same file names for all steps to save.

Now, the first measured step uses the old file names to save the results, whereas all following steps get another prefix to identify the step. Therefore new prefixes starts from `_2` for step 2, etc.

This is backwards-compatible since only more files are being sent to the server, which simply ignores the new files. Executing a multi-step script with this version would result in only seeing the results for the first step.