### PR TITLE
Update CDN list link to point at Github

### DIFF
--- a/www/optimization.inc
+++ b/www/optimization.inc
@@ -547,7 +547,7 @@ function dumpOptimizationGlossary(&$settings)
         </tr>
         <tr>
             <td class="nowrap">What is checked</td>
-            <td >Checked to see if it is hosted on a known CDN (CNAME mapped to a known CDN network).  80% of the static resources need to be served from a CDN for the overall page to be considered using a CDN. The current list of known CDN's is <a href="http://webpagetest.googlecode.com/svn/trunk/agent/wpthook/cdn.h">here</a></td>
+            <td >Checked to see if it is hosted on a known CDN (CNAME mapped to a known CDN network).  80% of the static resources need to be served from a CDN for the overall page to be considered using a CDN. The current list of known CDN's is <a href="https://github.com/WPO-Foundation/webpagetest/blob/master/agent/wpthook/cdn.h">here</a></td>
         </tr>
 
     </table>


### PR DESCRIPTION
Just a tiny PR to fix the link the CDN list at the bottom of the page, it was pointing at Google Code