### PR TITLE
git: Ignore specific wptdriver configuration files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ agent/js/5c2.sh
 /www/dat
 /www/settings/uniqueId.dat
 /www/ec2/log
+
+# specific wptdriver settings
+agent/wptdriver/*.ini


### PR DESCRIPTION
The wptdriver project file has a PostBuildEvent copying all *.ini files in the build folder which is handy for debugging.

As we only provide *.ini.sample files, the specific configuration files can be ignored.