### PR TITLE
Multistep: Result processing on server

### DIFF
--- a/www/TestPaths.inc
+++ b/www/TestPaths.inc
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Takes the responsibilty for creating file names and paths for test-related files.
+ * This way, the logic of file names and the file names itself get encapsulated and can get tested.
+ */
+class TestPaths {
+  const UNDERSCORE_FILE_PATTERN = "/^(?P<run>[0-9]+)_(?P<cached>Cached_)?((?P<step>[0-9]+)_)?(?P<name>[\S]+)$/";
+
+  protected $testRoot;
+
+  protected $run;
+  protected $cached;
+  protected $step;
+
+  protected $parsedBaseName;
+
+  /**
+   * TestPaths constructor.
+   * @param string $testRoot The path where all data of the test is stored in
+   * @param int $run Number of the run (>= 1)
+   * @param bool $cached If this is a cached run or not
+   * @param int $step The number of the step (>= 1)
+   */
+  public function __construct($testRoot = ".", $run = 1, $cached = false, $step = 1) {
+    $this->testRoot = strval($testRoot);
+    $this->run = intval($run);
+    $this->cached = $cached ? true : false;
+    $this->step = intval($step);
+  }
+
+  /**
+   * @param string $testRoot The path where all data of the test is stored in
+   * @param $fileName string File name to instantiate the object from
+   * @return TestPaths A new instance or NULL
+   */
+  public static function fromUnderscoreFileName($testRoot, $fileName) {
+    if (!preg_match(self::UNDERSCORE_FILE_PATTERN, $fileName, $matches)) {
+      return NULL;
+    }
+    $step = empty($matches["step"]) ? 1 : intval($matches["step"]);
+    $instance = new self($testRoot, $matches["run"], !empty($matches["cached"]), $step);
+    $instance->parsedBaseName = $matches["name"];
+    return $instance;
+  }
+
+  /**
+   * @return string The base name of the file (without run information), e.g. when instantiated by from*Name methods
+   */
+  public function getParsedBaseName() {
+    return $this->parsedBaseName;
+  }
+
+  /**
+   * @return string Directory name to store video data in
+   */
+  public function videoDir() {
+    return $this->testRoot . "/video_" . strtolower($this->underscoreIdentifier());
+  }
+
+  protected function underscoreIdentifier() {
+    return $this->run . ($this->cached ? "_Cached" : "") . ($this->step > 1 ? "_" . $this->step : "");
+  }
+}
+

--- a/www/tests/TestPathsTest.php
+++ b/www/tests/TestPathsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once '../TestPaths.inc';
+
+class TestPathsTest extends PHPUnit_Framework_TestCase {
+
+  public function  testConstructor() {
+    $fn = new TestPaths("test", 2, true, 3);
+    $this->assertEquals("test/video_2_cached_3", $fn->videoDir());
+
+    $fn = new TestPaths("test", 1, false, 3);
+    $this->assertEquals("test/video_1_3", $fn->videoDir());
+
+    $fn = new TestPaths("test", 4, true, 1);
+    $this->assertEquals("test/video_4_cached", $fn->videoDir());
+
+    $fn = new TestPaths("test", 5, false, 1);
+    $this->assertEquals("test/video_5", $fn->videoDir());
+  }
+
+  public function testUnderscoreFilenameParse() {
+    $fn = TestPaths::fromUnderscoreFileName("test", "3_Cached_2_my_base_12.ext");
+    $this->assertNotNull($fn);
+    $this->assertEquals("my_base_12.ext", $fn->getParsedBaseName());
+    $this->assertEquals("test/video_3_cached_2", $fn->videoDir());
+
+    $fn = TestPaths::fromUnderscoreFileName("test", "3_Cached_ab_4");
+    $this->assertNotNull($fn);
+    $this->assertEquals("ab_4", $fn->getParsedBaseName());
+    $this->assertEquals("test/video_3_cached", $fn->videoDir());
+
+    $fn = TestPaths::fromUnderscoreFileName("test", "3_2_x");
+    $this->assertNotNull($fn);
+    $this->assertEquals("x", $fn->getParsedBaseName());
+    $this->assertEquals("test/video_3_2", $fn->videoDir());
+  }
+
+
+}

--- a/www/work/workdone.php
+++ b/www/work/workdone.php
@@ -200,7 +200,7 @@ if (ValidateTestId($id)) {
             $expected_runs = $expected_runs * 2;
           $files = scandir($testPath);
           foreach ($files as $file) {
-            if (stripos($file, 'IEWPG'))
+            if (preg_match('/^[0-9]+_(Cached_)?IEWPG.txt/', $file) === true)
               $available_runs++;
             if ($file == 'test.job')
               $testfile = "$testPath/$file";


### PR DESCRIPTION
Part of the multistep implementation as planned in #618.

These commits care about the correct locations for multistep results reported by wptdriver.
This mostly affects the uplaoded image files which are now saved in `video_<run><cached><step>` subfolders for each step, where the suffix for the step 1 is omitted for compatibility reasons.

I started to use OOP to make at least new code testable and easier to understand.
The idea of `TestPaths` is to care about filename parsing and creation, since it's getting even more complicated with an optional step suffix.

I plan to use and extend this class in further modifications for multistep support.

Note: Results from other agents, as the nodejs agent, will be handled correctly after the agent itself got multistep support.