### PR TITLE
Initialise _max_test_time

### DIFF
--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -160,6 +160,7 @@ void WptTest::Reset(void) {
   _has_test_timed_out = false;
   _user_agent_modifier = "PTST";
   _append_user_agent.Empty();
+  _max_test_time = 0;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
If _max_test_time is not configured or initialised the test has a very very very long timeout