### PR TITLE
Clarify "Host Rules" as "Host Resolver Rules"

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -503,7 +503,7 @@ $loc = ParseLocations($locations);
                                     ?>
                                     <li>
                                         <label for="hostResolverRules" style="width: auto;">
-                                        <a href="https://github.com/atom/electron/blob/master/docs/api/chrome-command-line-switches.md#--host-rulesrules">Host Rules</a><br>
+                                        <a href="https://github.com/atom/electron/blob/master/docs/api/chrome-command-line-switches.md#--host-rulesrules">Host Resolver Rules</a><br>
                                         <small>i.e. MAP * 1.2.3.4</small>
                                         </label>
                                         <input type="text" name="hostResolverRules" id="hostResolverRules" class="text" style="width: 400px;">


### PR DESCRIPTION
From the label I had assumed this field set --host-rules rather than --host-resolver-rules.