### PR TITLE
Fix/allow unicode test labels

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -109,7 +109,7 @@
             $test['video'] = $req_video;
             $test['keepvideo'] = isset($req_keepvideo) && $req_keepvideo ? 1 : 0;
             $test['continuousVideo'] = isset($req_continuousVideo) && $req_continuousVideo ? 1 : 0;
-            $test['label'] = preg_replace('/[^a-zA-Z0-9 \-_\.]/', '', trim($req_label));
+            $test['label'] = preg_replace('/[^\w\d \-_\.]/', '', trim($req_label));
             $test['industry'] = trim($req_ig);
             $test['industry_page'] = trim($req_ip);
             $test['median_video'] = (int)$req_mv;

--- a/www/testlog.php
+++ b/www/testlog.php
@@ -309,8 +309,9 @@ else
                                                       $link = $guid;
 
                                                   $labelTxt = $label;
-                                                  if( strlen($labelTxt) > 30 )
-                                                      $labelTxt = substr($labelTxt, 0, 27) . '...';
+                                                  if( mb_strlen($labelTxt) > 30 ) {
+                                                      $labelTxt = mb_substr($labelTxt, 0, 27) . '...';
+                                                  }
 
                                                   echo "<td title=\"$label\" class=\"label\">";
                                                   echo "<a href=\"$link\" id=\"label_$guid\">$labelTxt</a>&nbsp;";


### PR DESCRIPTION
Change regexp for this and at testlog.php change strlen and substr to mb_ versions.
Test it on a private instance with cyrillic labels.