### PR TITLE
Added akamaized.net CDN domain for Akamai.

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -55,6 +55,7 @@ typedef struct {
 
 CDN_PROVIDER cdnList[] = {
   {".akamai.net", "Akamai"},
+  {".akamaized.net", "Akamai"},
   {".akamaiedge.net", "Akamai"},
   {".akamaihd.net", "Akamai"},
   {".edgesuite.net", "Akamai"},


### PR DESCRIPTION
Hi,

There's a missing Akamai hostname, akamaized.net, I work for an Akamai reseller and we have some customers using that domain.