### PR TITLE
Multistep support for waterfall & optimization checklist images

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -90,6 +90,16 @@
     RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&type=connection
     RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&type=connection
 
+    # waterfals with multistep support
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5&step=$6
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&step=$7
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&step=$6
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&step=$6&type=connection
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&step=$7&type=connection
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&step=$6&type=connection
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7&type=connection
+
     # optimization checklists
     RewriteRule ^results/old/([a-zA-Z0-9_]+)/([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1&run=$2
     RewriteRule ^results/old/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1&run=$2&cached=1

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -64,6 +64,14 @@
     RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&file=$2_optimization.png
     RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&file=$2_Cached_optimization.png
 
+    #thumbnails with multistep support
+    RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&step=$3&file=$2_$3_screen.jpg
+    RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_screen.jpg
+    RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall_thumb.png$ /thumbnail.php?test=$1&run=$2&step=$3&file=$2_$3_waterfall.png
+    RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_waterfall.png
+    RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&step=$3&file=$2_$3_optimization.png
+    RewriteRule ^result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_optimization.png
+
     #old direct thumbnail paths
     RewriteRule ^results/old/([a-zA-Z0-9_]+)/([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&file=$2_screen.jpg
     RewriteRule ^results/old/([a-zA-Z0-9_]+)/([0-9]+)_Cached_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&cached=1&file=$2_Cached_screen.jpg

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -110,6 +110,13 @@
     RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&cached=1
     RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&cached=1
 
+    #optimization checklists with multistep support
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&step=$6
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&step=$7
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&cached=1&step=$6
+    RewriteRule ^results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7
+
+
     #location cookie dropping
     RewriteRule ^loc/([a-zA-Z0-9_]+)$ /util/setloc.php?location=$1 
     RewriteRule ^loc/([a-zA-Z0-9_]+)$/ /util/setloc.php?location=$1 

--- a/www/common.inc
+++ b/www/common.inc
@@ -248,6 +248,7 @@ if (strlen($id)) {
     if (!$run) {
         $run = (int)1;
     }
+    $step = max(1, @(int)$_REQUEST['step']); // default is step=1
     $cached = @(int)$_REQUEST['cached'];  // define a global used in other files
     if (array_key_exists('run', $_REQUEST) && !strcasecmp($_REQUEST['run'], 'median')) {
       require_once('page_data.inc');

--- a/www/devtools.inc.php
+++ b/www/devtools.inc.php
@@ -7,7 +7,7 @@ if(extension_loaded('newrelic')) {
     newrelic_add_custom_tracer('GetDevToolsRequests');
     newrelic_add_custom_tracer('GetDevToolsEventsForStep');
     newrelic_add_custom_tracer('DevToolsGetConsoleLog');
-    newrelic_add_custom_tracer('DevToolsGetCPUSlices');
+    newrelic_add_custom_tracer('DevToolsGetCPUSlicesForStep');
     newrelic_add_custom_tracer('GetDevToolsCPUTime');
     newrelic_add_custom_tracer('ParseDevToolsEvents');
     newrelic_add_custom_tracer('DevToolsMatchEvent');
@@ -1027,20 +1027,9 @@ function DevToolsGetVideoOffset($testPath, $run, $cached, &$endTime) {
 }
 
 /**
-* If we have a timeline, figure out what each thread was doing at each point in time.
-* Basically CPU utilization from the timeline.
-* 
-* returns an array of threads with each thread being an array of slices (one for
-* each time period).  Each slice is an array of events and the fraction of that
-* slice that they consumed (with a total maximum of 1 for any slice).
-*/
-function DevToolsGetCPUSlices($testPath, $run, $cached) {
-  // TODO: remove this version once not needed anymore and use the one below
-  $localPaths = new TestPaths($testPath, $run, $cached);
-  return DevToolsGetCPUSlicesForStep($localPaths);
-}
-
-/**
+ * If we have a timeline, figure out what each thread was doing at each point in time.
+ * Basically CPU utilization from the timeline.
+ *
  * @param TestPaths $localPaths Paths related to this run/step
  * @return array|null An array of threads with each thread being an array of slices (one for
  * each time period).  Each slice is an array of events and the fraction of that

--- a/www/google/google_lib.inc
+++ b/www/google/google_lib.inc
@@ -11,17 +11,15 @@ function ParseCsiInfo($id, $testPath, $run, $cached, $getAll, $generate = true) 
   if (!isset($testPath) || !strlen($testPath))
     $testPath = './' . GetTestPath($id);
   $localPaths = new TestPaths($testPath, $run, $cached);
-  $rootUrlGenerator = UrlGenerator::create(false, "", $id, $run, $cached);
-  return ParseCsiInfoForStep($rootUrlGenerator, $localPaths, $getAll);
+  return ParseCsiInfoForStep($localPaths, $getAll);
 }
 
 /**
- * @param UrlGenerator $rootUrlGenerator To generate root URLS (without protocol & host) for this run / step
  * @param TestPaths $localPaths Paths of run or step to get the CSI Info for
  * @param $getAll
  * @return array|null
  */
-function ParseCsiInfoForStep($rootUrlGenerator, $localPaths, $getAll) {
+function ParseCsiInfoForStep($localPaths, $getAll) {
   $params = null;
   $cacheFile = $localPaths->csiCacheFile(CSI_CACHE_VERSION);
   $cacheKey = $localPaths->cacheKey();
@@ -42,7 +40,7 @@ function ParseCsiInfoForStep($rootUrlGenerator, $localPaths, $getAll) {
 	    // Secure and haveLocations are not used but required by getRequests function.
 	    $secure = null;
 	    $haveLocations = null;
-	    $requests = getRequestsForStep($localPaths, $rootUrlGenerator, $secure, $haveLocations, false);
+	    $requests = getRequestsForStep($localPaths, null, $secure, $haveLocations, false);
       $params = array();
 	    foreach ( $requests as &$request ) {
 		    // Parse the individual url parts.

--- a/www/include/ResultProcessing.php
+++ b/www/include/ResultProcessing.php
@@ -61,7 +61,7 @@ class ResultProcessing {
       }
       if (is_dir(__DIR__ . '/../google') && is_file(__DIR__ . '/../google/google_lib.inc')) {
         require_once(__DIR__ . '/../google/google_lib.inc');
-        ParseCsiInfoForStep($rootUrls, $stepPaths, true);
+        ParseCsiInfoForStep($stepPaths, true);
       }
       GetDevToolsCPUTimeForStep($stepPaths);
     }

--- a/www/include/TestResults.php
+++ b/www/include/TestResults.php
@@ -95,8 +95,7 @@ class TestResults {
    * @return string Returns the URL from the first step of the first view of the first run
    */
   public function getUrlFromRun() {
-    $rawData = $this->getRunResult(1, false)->getStepResult(1)->getRawResults();
-    return empty($rawData['URL']) ? "" : $rawData['URL'];
+    return $this->getRunResult(1, false)->getStepResult(1)->getUrl();
   }
 
   /**

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -107,6 +107,13 @@ class TestStepResult {
   }
 
   /**
+   * @return string The URL of this step
+   */
+  public function getUrl() {
+    return isset($this->rawData["URL"]) ? $this->rawData["URL"] : null;
+  }
+
+  /**
    * @var string $metric The metric to return
    * @return mixed|null The metric value or null if not set
    */

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -134,8 +134,20 @@ class TestStepResult {
     return $this->rawData["eventName"];
   }
 
+  /**
+   * @return bool True if a custom event name was set for this step, false otherwise
+   */
   public function hasCustomEventName() {
     return (!empty($this->rawData["eventName"]) && $this->rawData["eventName"] != $this->standardEventName());
+  }
+
+  /**
+   * @param string $default Optional. A default value if no custom event name or URL is set
+   * @return string A readable identifier for this step (EIther custom event name, URL, or $default)
+   */
+  public function readableIdentifier($default = "") {
+    $nameOrUrl = $this->hasCustomEventName() ? $this->getEventName() : $this->getUrl();
+    return empty($nameOrUrl) ? $default : $nameOrUrl;
   }
 
   /**

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -134,6 +134,10 @@ class TestStepResult {
     return $this->rawData["eventName"];
   }
 
+  public function hasCustomEventName() {
+    return (!empty($this->rawData["eventName"]) && $this->rawData["eventName"] != $this->standardEventName());
+  }
+
   /**
    * @return string The score
    */
@@ -202,5 +206,9 @@ class TestStepResult {
       return 0;
     }
     return intval(round($this->rawData['testStartOffset']));
+  }
+
+  private function standardEventName() {
+    return "Step " . $this->step;
   }
 }

--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -128,6 +128,17 @@ rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&type=connection last;
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&type=connection last;
 
+# waterfalls with multistep support
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5&step=$6 last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&step=$7 last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&step=$6 last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7 last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&step=$6&type=connection last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&step=$7&type=connection last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&step=$6&type=connection last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7&type=connection last;
+
+
 # optimization checklists
 rewrite ^/results/old/([a-zA-Z0-9_]+)/([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1&run=$2 last;
 rewrite ^/results/old/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1&run=$2&cached=1 last;

--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -149,6 +149,13 @@ rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&cached=1 last;
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&cached=1 last;
 
+# optimization checklists with multistep support
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&step=$6 last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&step=$7 last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&cached=1&step=$6 last;
+rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7 last;
+
+
 #location cookie dropping
 rewrite ^/loc/([a-zA-Z0-9_]+)$ /util/setloc.php?location=$1 last;
 rewrite ^/loc/([a-zA-Z0-9_]+)$/ /util/setloc.php?location=$1 last;

--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -102,6 +102,14 @@ rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_waterfall_thumb.png$ /thumbnail
 rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&file=$2_optimization.png last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&file=$2_Cached_optimization.png last;
 
+#thumbnails with multistep support
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&step=$3&file=$2_$3_screen.jpg last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_screen.jpg last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall_thumb.png$ /thumbnail.php?test=$1&run=$2&step=$3&file=$2_$3_waterfall.png last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_waterfall.png last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&step=$3&file=$2_$3_optimization.png last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_optimization.png last;
+
 #old direct thumbnail paths
 rewrite ^/results/old/([a-zA-Z0-9_]+)/([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&file=$2_screen.jpg last;
 rewrite ^/results/old/([a-zA-Z0-9_]+)/([0-9]+)_Cached_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&cached=1&file=$2_Cached_screen.jpg last;

--- a/www/object_detail.inc
+++ b/www/object_detail.inc
@@ -68,10 +68,12 @@ function getRequestsForStep($localPaths, $rootUrlGenerator, &$has_secure_request
     foreach ($requests as $index => &$request) {
         $request['index'] = $index;
         $request['number'] = $index + 1;
-        if (isset($request['body_id']) && $request['body_id'] > 0) {
+        if ($rootUrlGenerator) {
+          if (isset($request['body_id']) && $request['body_id'] > 0) {
             $request['body_url'] = $rootUrlGenerator->responseBodyWithBodyId($request['body_id']);
-        } elseif (@$request['body']) {
+          } elseif (@$request['body']) {
             $request['body_url'] = $rootUrlGenerator->responseBodyWithRequestNumber($request['number']);
+          }
         }
         if ($request['is_secure'])
             $has_secure_requests = true;

--- a/www/optimizationChecklist.php
+++ b/www/optimizationChecklist.php
@@ -1,17 +1,18 @@
 <?php
 header ("Content-type: image/png");
-include 'common.inc';
-require_once('object_detail.inc'); 
-require_once('optimizationChecklist.inc');
-require_once('page_data.inc');
-$pageData = loadPageRunData($testPath, $run, $cached, null, $test['testinfo']);
+include __DIR__ . '/common.inc';
+require_once __DIR__ . '/optimizationChecklist.inc';
+require_once __DIR__ . '/include/TestInfo.php';
+require_once __DIR__ . '/include/TestStepResult.php';
 
-// get all of the requests
-$secure = false;
-$haveLocations = false;
-$requests = getRequests($id, $testPath, $run, $cached, $secure, $haveLocations, false);
+// not functional, but to declare what to expect from common.inc
+global $testPath, $run, $cached, $step, $id, $url, $test;
 
-$im = drawChecklist($url, $requests, $pageData);
+$testInfo = TestInfo::fromFiles($testPath);
+$testStepResult = TestStepResult::fromFiles($testInfo, $run, $cached, $step);
+$requests = $testStepResult->getRequests();
+
+$im = drawChecklist($testStepResult->readableIdentifier($url), $requests, $testStepResult->getRawResults());
 
 // spit the image out to the browser
 imagepng($im);

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -109,8 +109,7 @@ function loadPageStepData($localPaths, $runCompleted, $options = null, $testInfo
     // see if we have CSI metrics to load
     if (is_dir(__DIR__ . '/google') && is_file(__DIR__ . '/google/google_lib.inc')) {
       require_once(__DIR__ . '/google/google_lib.inc');
-      $urlGenerator = UrlGenerator::create(false, "", 0, $localPaths->getRunNumber(), $localPaths->isCachedResult());
-      $csi = ParseCsiInfoForStep($urlGenerator, $localPaths, true);
+      $csi = ParseCsiInfoForStep($localPaths, true);
       if (isset($csi) && is_array($csi) && count($csi)) {
         $ret['CSI'] = array();
         foreach($csi as $metric => $value) {

--- a/www/tests/TestStepResultTest.php
+++ b/www/tests/TestStepResultTest.php
@@ -26,9 +26,11 @@ class TestStepResultTest extends PHPUnit_Framework_TestCase {
     $firstStep = TestStepResult::fromFiles($testInfo, 1, false, 1);
     $this->assertEquals("google", $firstStep->getEventName());
     $this->assertNotEmpty($firstStep->getRawResults());
+    $this->assertEquals("http://google.com", $firstStep->getUrl());
 
-    $firstStep = TestStepResult::fromFiles($testInfo, 1, true, 2);
-    $this->assertEquals("Step 2", $firstStep->getEventName());
-    $this->assertNotEmpty($firstStep->getRawResults());
+    $secondStep = TestStepResult::fromFiles($testInfo, 1, true, 2);
+    $this->assertEquals("Step 2", $secondStep->getEventName());
+    $this->assertNotEmpty($secondStep->getRawResults());
+    $this->assertEquals("http://duckduckgo.com", $secondStep->getUrl());
   }
 }

--- a/www/tests/TestStepResultTest.php
+++ b/www/tests/TestStepResultTest.php
@@ -28,11 +28,13 @@ class TestStepResultTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue($firstStep->hasCustomEventName());
     $this->assertNotEmpty($firstStep->getRawResults());
     $this->assertEquals("http://google.com", $firstStep->getUrl());
+    $this->assertEquals("google", $firstStep->readableIdentifier());
 
     $secondStep = TestStepResult::fromFiles($testInfo, 1, true, 2);
     $this->assertEquals("Step 2", $secondStep->getEventName());
     $this->assertFalse($secondStep->hasCustomEventName());
     $this->assertNotEmpty($secondStep->getRawResults());
     $this->assertEquals("http://duckduckgo.com", $secondStep->getUrl());
+    $this->assertEquals("http://duckduckgo.com", $secondStep->readableIdentifier());
   }
 }

--- a/www/tests/TestStepResultTest.php
+++ b/www/tests/TestStepResultTest.php
@@ -25,11 +25,13 @@ class TestStepResultTest extends PHPUnit_Framework_TestCase {
 
     $firstStep = TestStepResult::fromFiles($testInfo, 1, false, 1);
     $this->assertEquals("google", $firstStep->getEventName());
+    $this->assertTrue($firstStep->hasCustomEventName());
     $this->assertNotEmpty($firstStep->getRawResults());
     $this->assertEquals("http://google.com", $firstStep->getUrl());
 
     $secondStep = TestStepResult::fromFiles($testInfo, 1, true, 2);
     $this->assertEquals("Step 2", $secondStep->getEventName());
+    $this->assertFalse($secondStep->hasCustomEventName());
     $this->assertNotEmpty($secondStep->getRawResults());
     $this->assertEquals("http://duckduckgo.com", $secondStep->getUrl());
   }

--- a/www/waterfall.inc
+++ b/www/waterfall.inc
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/draw.inc';
 require_once __DIR__ . '/contentColors.inc';
+require_once __DIR__ . '/include/TestPaths.php';
 
 /**
 * Regroup requests into connection rows.
@@ -167,10 +168,11 @@ function _GetMapOrImage($rows, $url, $page_events, $options, $is_image_map, &$pa
     $data_height = $height;
     $use_cpu = (bool)@$options['use_cpu'];
     $use_bw = (bool)@$options['use_bw'];
+    $stepId = array_key_exists('step_id', $options) ? (int) $options['step_id'] : 1;
+    $isCached = array_key_exists('is_cached', $options) ? $options['is_cached'] : false;
+    $localPaths = new TestPaths($options['path'], $options['run_id'], $isCached, $stepId);
     if ($use_cpu || $use_bw) {
-        $cached = ((bool)@$options['is_cached']) ? '_Cached' : '';
-        $perf_file = ("{$options['path']}/" .
-                      "{$options['run_id']}{$cached}_progress.csv");
+        $perf_file = $localPaths->utilizationFile();
         $max_bw = 0;
         if (isset($options) && array_key_exists('max_bw', $options)) {
             $max_bw = $options['max_bw'];
@@ -190,12 +192,9 @@ function _GetMapOrImage($rows, $url, $page_events, $options, $is_image_map, &$pa
             }
         }
     }
-    if ($use_cpu && !$is_image_map && isset($options) && is_array($options) &&
-        array_key_exists('path', $options) &&
-        array_key_exists('run_id', $options) &&
-        array_key_exists('is_cached', $options)) {
+    if ($use_cpu && !$is_image_map) {
       require_once('devtools.inc.php');
-      $cpu_slices = DevToolsGetCPUSlices($options['path'], $options['run_id'], $options['is_cached']);
+      $cpu_slices = DevToolsGetCPUSlicesForStep($localPaths);
       if (isset($cpu_slices) && is_array($cpu_slices) && isset($cpu_slices['main_thread'])) {
         $perf_height = $is_thumbnail ? 16 : 50;
         $cpu_slice_info = array();
@@ -249,9 +248,8 @@ function _GetMapOrImage($rows, $url, $page_events, $options, $is_image_map, &$pa
             $filter = array();
         }
         $use_all = false;
-        $csi_params = ParseCsiInfo($options['id'], $options['path'],
-                                   $options['run_id'], $options['is_cached'],
-                                   $use_all);
+        $rootUrlGenerator = UrlGenerator::create(false, "", "", $options['run_id'], $isCached, $stepId);
+        $csi_params = ParseCsiInfoForStep($rootUrlGenerator, $localPaths, $use_all);
         $csi_info = TailorRtParamsForVisualization($csi_params, $filter);
     }
     // get any user timings

--- a/www/waterfall.inc
+++ b/www/waterfall.inc
@@ -248,8 +248,7 @@ function _GetMapOrImage($rows, $url, $page_events, $options, $is_image_map, &$pa
             $filter = array();
         }
         $use_all = false;
-        $rootUrlGenerator = UrlGenerator::create(false, "", "", $options['run_id'], $isCached, $stepId);
-        $csi_params = ParseCsiInfoForStep($rootUrlGenerator, $localPaths, $use_all);
+        $csi_params = ParseCsiInfoForStep($localPaths, $use_all);
         $csi_info = TailorRtParamsForVisualization($csi_params, $filter);
     }
     // get any user timings

--- a/www/waterfall.inc
+++ b/www/waterfall.inc
@@ -1,6 +1,6 @@
 <?php
-require_once('draw.inc');
-require_once('contentColors.inc');
+require_once __DIR__ . '/draw.inc';
+require_once __DIR__ . '/contentColors.inc';
 
 /**
 * Regroup requests into connection rows.

--- a/www/waterfall.php
+++ b/www/waterfall.php
@@ -51,7 +51,8 @@ $options = array(
     'rowcount' => $rowcount
     );
 
-$stepUrl = $testStepResult->getUrl();
+// use the EventName for the waterfall, if it's specifically set. Otherwise the step's URL
+$stepUrl = $testStepResult->hasCustomEventName() ? $testStepResult->getEventName() : $testStepResult->getUrl();
 $url = $stepUrl ? $stepUrl : $url; // use step url if exists
 
 $im = GetWaterfallImage($rows, $url, $page_events, $options, $testStepResult->getRawResults());

--- a/www/waterfall.php
+++ b/www/waterfall.php
@@ -1,9 +1,9 @@
 <?php
 header ("Content-type: image/png");
 include 'common.inc';
-require_once('object_detail.inc');
-require_once('page_data.inc');
-require_once('waterfall.inc');
+require_once __DIR__ . '/object_detail.inc';
+require_once __DIR__ . '/page_data.inc';
+require_once __DIR__ . '/waterfall.inc';
 
 $page_data = loadPageRunData($testPath, $run, $cached, null, $test['testinfo']);
 

--- a/www/waterfall.php
+++ b/www/waterfall.php
@@ -51,9 +51,7 @@ $options = array(
   'rowcount' => $rowcount
 );
 
-// use the EventName for the waterfall, if it's specifically set. Otherwise the step's URL
-$stepUrl = $testStepResult->hasCustomEventName() ? $testStepResult->getEventName() : $testStepResult->getUrl();
-$url = $stepUrl ? $stepUrl : $url; // use step url if exists
+$url = $testStepResult->readableIdentifier($url);
 
 $im = GetWaterfallImage($rows, $url, $page_events, $options, $testStepResult->getRawResults());
 

--- a/www/waterfall.php
+++ b/www/waterfall.php
@@ -23,33 +23,33 @@ $rowcount = array_key_exists('rowcount', $_REQUEST) ? $_REQUEST['rowcount'] : 0;
 $requests = $testStepResult->getRequests();
 
 if (@$_REQUEST['type'] == 'connection') {
-    $is_state = true;
-    $rows = GetConnectionRows($requests, $show_labels);
+  $is_state = true;
+  $rows = GetConnectionRows($requests, $show_labels);
 } else {
-    $rows = GetRequestRows($requests, $use_dots, $show_labels);
+  $rows = GetRequestRows($requests, $use_dots, $show_labels);
 }
 $page_events = GetPageEvents($testStepResult->getRawResults());
 $bwIn=0;
 if (isset($test) && array_key_exists('testinfo', $test) && array_key_exists('bwIn', $test['testinfo'])) {
-    $bwIn = $test['testinfo']['bwIn'];
+  $bwIn = $test['testinfo']['bwIn'];
 } else if(isset($test) && array_key_exists('test', $test) && array_key_exists('bwIn', $test['test'])) {
-    $bwIn = $test['test']['bwIn'];
+  $bwIn = $test['test']['bwIn'];
 }
 
 $options = array(
-    'id' => $id,
-    'path' => $testPath,
-    'run_id' => $run,
-    'is_cached' => $cached,
-    'step_id' => $step,
-    'use_cpu' =>     (!isset($_REQUEST['cpu'])    || $_REQUEST['cpu'] != 0),
-    'use_bw' =>      (!isset($_REQUEST['bw'])     || $_REQUEST['bw'] != 0),
-    'show_labels' => $show_labels,
-    'max_bw' => $bwIn,
-    'is_mime' => $is_mime,
-    'is_state' => $is_state,
-    'rowcount' => $rowcount
-    );
+  'id' => $id,
+  'path' => $testPath,
+  'run_id' => $run,
+  'is_cached' => $cached,
+  'step_id' => $step,
+  'use_cpu' =>     (!isset($_REQUEST['cpu'])    || $_REQUEST['cpu'] != 0),
+  'use_bw' =>      (!isset($_REQUEST['bw'])     || $_REQUEST['bw'] != 0),
+  'show_labels' => $show_labels,
+  'max_bw' => $bwIn,
+  'is_mime' => $is_mime,
+  'is_state' => $is_state,
+  'rowcount' => $rowcount
+);
 
 // use the EventName for the waterfall, if it's specifically set. Otherwise the step's URL
 $stepUrl = $testStepResult->hasCustomEventName() ? $testStepResult->getEventName() : $testStepResult->getUrl();


### PR DESCRIPTION
This pull request is part of the multistep implementation discussed in #618.
The branch is parallel to #651, they don't interfere.

Multistep support for waterfall, optimization checklist, and thumbnails is included.

The corresponding rewrite rules support a step number now.
New data structures and methods are used to get the correct step data for generating the images.

Waterfall generation:	7f3dae9 .. dc205a8
Optimization checklist:	6ab787a .. a433cde
Thumbnails:			419c2b1 .. a8d3062