### PR TITLE
Multistep changes for Screen Shot page and header

### DIFF
--- a/www/devtools.inc.php
+++ b/www/devtools.inc.php
@@ -935,11 +935,6 @@ function DevToolsMatchEvent($filter, &$event, $startTime = null, $endTime = null
   return $match;
 }
 
-function DevToolsGetConsoleLog($testPath, $run, $cached) {
-  $localPaths = new TestPaths($testPath, $run, $cached);
-  return DevToolsGetConsoleLogForStep($localPaths);
-}
-
 /**
  * @param TestPaths $localPaths The paths for the run or step to get the console log for
  * @return array|null The console log or null, if it couldn't be retrieved

--- a/www/footer.inc
+++ b/www/footer.inc
@@ -131,6 +131,7 @@
     <?php
     if (!isset($site_js_loaded) || !$site_js_loaded) {
         echo "<script type=\"text/javascript\" src=\"{$GLOBALS['cdnPath']}/js/site.js?v=" . VER_JS . "\"></script>\n";
+        $hasJquery = true;
     }
     if (!array_key_exists('HTTP_CACHE_CONTROL', $_SERVER) &&    // skip manual browser refreshes
         is_file('./js/experiment.js')) {

--- a/www/header.inc
+++ b/www/header.inc
@@ -190,7 +190,7 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
                       if( count($grades) > 6 )
                         $smaller = ' smaller';
                       echo "<ul class=\"grades$smaller\">";
-                      $optlink = FRIENDLY_URLS ? "/result/$id/$gradeRun/performance_optimization/" : "performance_optimization.php?test=$id&run=$gradeRun";
+                      $optlink = $urlGenerator->resultPage("performance_optimization");
                       foreach( $grades as $check => &$grade )
                           echo "<li class=\"$check\"><a href=\"$optlink#$check\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
                       echo '</ul>';
@@ -202,12 +202,16 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
         }
         
         echo "<div id=\"header_data\"$data_class>";
-            $shortUrl = str_replace('http://', '',  FitText($url, 180));
+        // for multistep, link the first URL and show additional text. Otherwise take the test URL
+        $isMultistep = $gradeRunResults->countSteps() > 1;
+        $showUrl = $isMultistep ? $gradeRunResults->getStepResult(1)->getUrl() : $url;
+        $shortUrl = str_replace('http://', '',  FitText($showUrl, 180));
+        $shortUrl = $isMultistep ? ($shortUrl . " (multiple steps)") : $shortUrl;
             echo "<h2 class=\"alternate cufon-dincond_regular\">Web Page Performance Test for<br>";
             if ($settings['nolinks']) {
                 echo "<span class=\"medium colored\">$shortUrl</span>";
             } else {
-                echo "<a class=\"url cufon-dincond_black\"  rel=\"nofollow\" title=\"$url\" href=\"$url\">$shortUrl</a>";
+                echo "<a class=\"url cufon-dincond_black\"  rel=\"nofollow\" title=\"$showUrl\" href=\"$showUrl\">$shortUrl</a>";
             }
             echo "</h2>";
             
@@ -234,7 +238,7 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
             if( array_key_exists('authenticated', $test['test']) && (int)$test['test']['authenticated'] == 1)
                 echo '<b>Authenticated: ' . $login . '</b><br>';
             if( (int)$test['test']['connections'] !== 0)
-                 echo '<b>' . $test[test][connections] . ' Browser connections</b><br>';
+                 echo '<b>' . $test['test']['connections'] . ' Browser connections</b><br>';
             if( array_key_exists('script', $test['test']) && strlen($test['test']['script']) ) 
                 echo '<b>Scripted test</b><br>';
             if( strlen($blockString) )
@@ -285,44 +289,32 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
 
         echo '<div id="test-1" class="test_results">';
         echo '<ul class="test_menu">';
-        
+
         if( !$run )
             $run = $gradeRun;
-        
-        $cTxt = '';
-        if( $cached )
-            $cTxt = 'cached/';
+        $useFriendlyUrls = !isset($_REQUEST['end']) && FRIENDLY_URLS;
+        $menuUrlGenerator = UrlGenerator::create($useFriendlyUrls, "", $id, $run, !empty($cached));
+        $endParams = isset($_REQUEST['end']) ? ("end=" . $_REQUEST['end']) : "";
 
-        $resultUrl = "/results.php?test=$id";
-        $details = "/details.php?test=$id&run=$gradeRun&cached=$cached";
-        $domains = "/domains.php?test=$id&run=$gradeRun&cached=$cached";
-        $end = '';
-        if (array_key_exists('end', $_REQUEST)) {
-            $resultUrl .= "&end={$_REQUEST['end']}";
-            $details .= "&end={$_REQUEST['end']}";
-            $end = "&end={$_REQUEST['end']}";
-        } elseif (FRIENDLY_URLS) {
-            $resultUrl = "/result/$id/";
-            $details = "/result/$id/$gradeRun/details/$cTxt";
+        $tabs = array( 'Summary' => $menuUrlGenerator->resultSummary($endParams),
+                       'Details' => $menuUrlGenerator->resultPage("details", $endParams));
+        $gradedRunResults = $testResults->getRunResult($gradeRun, !empty($cached));
+
+        if ($gradedRunResults->isOptimizationChecked())
+            $tabs['Performance Review'] = $menuUrlGenerator->resultPage("performance_optimization", $endParams);
+
+        if ($gradedRunResults->averagePageSpeedScore() !== null)
+            $tabs['PageSpeed'] = $menuUrlGenerator->resultPage("pagespeed", $endParams);
+        $tabs['Content Breakdown'] = $menuUrlGenerator->resultPage("breakdown", $endParams);
+        $tabs['Domains'] = $menuUrlGenerator->resultPage("domains", $endParams);
+        if ($gradedRunResults->hasBreakdownTimeline()) {
+          // currently only supported by standard urls
+          $menuStandardUrlGenerator = UrlGenerator::create(false, "", $id, $run, !empty($cached));
+          $tabs['Processing Breakdown'] = $menuStandardUrlGenerator->resultPage("breakdownTimeline");
         }
-        $tabs = array( 'Summary' => $resultUrl, 'Details' => $details);
-                    
-        if( $testResults->getRunResult($gradeRun, $cached)->isOptimizationChecked())
-            $tabs['Performance Review'] = "/performance_optimization.php?test=$id&run=$gradeRun&cached=$cached$end";
-        
-        $cTxt2 = '';
-        if( $cached )
-            $cTxt2 = '_Cached';
-        if( gz_is_file("$testPath/$gradeRun{$cTxt2}_pagespeed.txt") )
-            $tabs['PageSpeed'] = "/pagespeed.php?test=$id&run=$gradeRun&cached=$cached$end";
-        $tabs['Content Breakdown'] = "/breakdown.php?test=$id&run=$gradeRun&cached=$cached$end";
-        $tabs['Domains'] = "/domains.php?test=$id&run=$gradeRun&cached=$cached$end";
-        if (isset($test['testinfo']) && $test['testinfo']['timeline'] &&
-            (gz_is_file("$testPath/$gradeRun{$cTxt2}_devtools.json") || gz_is_file("$testPath/$gradeRun{$cTxt2}_trace.json")))
-            $tabs['Processing Breakdown'] = "/breakdownTimeline.php?test=$id&run=$gradeRun&cached=$cached$end";
-        
+
         if( !isset($test['testinfo']) || !$test['testinfo']['noimages'] )
-            $tabs['Screen Shot'] = "/screen_shot.php?test=$id&run=$gradeRun&cached=$cached$end";
+            $tabs['Screen Shot'] = $menuUrlGenerator->resultPage("screen_shot", $endParams);
         //$tabs['More Checks'] = "/moreChecks.php?test=$id";
 
         foreach( $tabs as $tabName => $tabUrl )

--- a/www/header.inc
+++ b/www/header.inc
@@ -1,46 +1,23 @@
 <?php
-require_once('page_data.inc');
-if( !isset($pageData) && isset($id) && isset($testPath) ) {
+require_once __DIR__ . '/page_data.inc';
+require_once __DIR__ . '/include/TestInfo.php';
+require_once __DIR__ . '/include/TestResults.php';
+
+if(isset($testPath) ) {
   $options = null;
   if (array_key_exists('end', $_REQUEST))
     $options = array('end' => $_REQUEST['end']);
-  $pageData = loadAllPageData($testPath, $options);
+  $testInfo = TestInfo::fromFiles($testPath);
+  $testResults = TestResults::fromFiles($testInfo, null, $options);
 }
-if (isset($pageData) && is_array($pageData)) {
+if (isset($testResults)) {
   $adultKeywords = array();
   if (is_file('./settings/adult.txt'))
     $adultKeywords = file('./settings/adult.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-  $isAdult = false;
-  if (isset($url)) {
-    foreach ($adultKeywords as $keyword) {
-      if (stripos($url, $keyword) !== false) {
-        $isAdult = true;
-        define('ADULT_SITE', true);
-        $adult_site = true;
-        break;
-      }
-    }
-  }
-  if (!$isAdult) {
-    foreach($pageData as &$run_data) {
-      foreach($run_data as &$test_data) {
-        if (array_key_exists('URL', $test_data)) {
-          foreach ($adultKeywords as $keyword) {
-            if ((stripos($test_data['URL'], $keyword) !== false) ||
-                (array_key_exists('title', $test_data) &&
-                stripos($test_data['title'], $keyword) !== false)) {
-              $isAdult = true;
-              break;
-            }
-          }
-        }
-        if ($isAdult || (array_key_exists('adult_site', $test_data) && $test_data['adult_site'])) {
-          define('ADULT_SITE', true);
-          $adult_site = true;
-          break 2;
-        }
-      }
-    }
+  $isAdult = $testResults->isAdultSite($adultKeywords);
+  if ($isAdult) {
+    define('ADULT_SITE', true);
+    $adult_site = true;
   }
 }
 

--- a/www/header.inc
+++ b/www/header.inc
@@ -149,18 +149,21 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
     // make sure the test is actually complete
     if( (isset($test['test']) && isset($test['test']['completeTime'])) )
     {
-        if( !isset($pageData) )
-            $pageData = loadAllPageData($testPath);
+        if (!isset($testResults) || !isset($testInfo)) {
+          $testInfo = TestInfo::fromFiles($testPath);
+          $testResults = TestResults::fromFiles($testInfo);
+        }
             
         $gradeRun = 1;
         if( array_key_exists('run', $_GET) && $_GET["run"] )
             $gradeRun = intval($_GET["run"]);
         else
         {
-            $medianRun = GetMedianRun($pageData, 0, $median_metric);
+            $medianRun = $testResults->getMedianRunNumber($median_metric, false);
             if( $medianRun )
                 $gradeRun = $medianRun;
         }
+        $gradeRunResults = $testResults->getRunResult($gradeRun, false);
 
         echo '<div id="header_container">';
         // Only include optimization data for normal tests
@@ -168,20 +171,19 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
         if (!isset($test['testinfo']['type']) || !strlen($test['testinfo']['type'])) {
           echo '<div id="optimization">';
               echo '<div id="optimization_header">';
-              if( gz_is_file("$testPath/{$gradeRun}_pagespeed.txt") )
-              {
-                  $score = GetPageSpeedScore("$testPath/{$gradeRun}_pagespeed.txt");
-                  if( strlen($score) )
-                  {
-                      $pageSpeedUrl = FRIENDLY_URLS ? "/result/$id/$gradeRun/pagespeed/" : "pagespeed.php?test=$id&run=$gradeRun";
-                      echo "<span id=\"headerPagespeedScore\"><a href=\"$pageSpeedUrl\">PageSpeed {$pageData[$gradeRun][0]['pageSpeedVersion']} Score</a>: <b>$score/100</b></span>";
-                  }
+              $localPaths = new TestPaths($testPath, $gradeRun, false);
+              $urlGenerator = UrlGenerator::create(FRIENDLY_URLS, "", $id, $gradeRun, false);
+              $pageSpeedScore = $gradeRunResults->averagePageSpeedScore();
+              if ($pageSpeedScore !== null) {
+                $pageSpeedUrl = $urlGenerator->resultPage("pagespeed");
+                $pageSpeedVersion = $gradeRunResults->getPageSpeedVersion();
+                echo "<span id=\"headerPagespeedScore\"><a href=\"$pageSpeedUrl\">PageSpeed $pageSpeedVersion Score</a>: <b>$pageSpeedScore/100</b></span>";
               }
               
               echo "<div id=\"opthelp\"><a href=\"https://sites.google.com/a/webpagetest.org/docs/other-resources/optimization-resources\" title=\"Optimization Resources\" target=\"_blank\">Need help improving?</a></div>\n";
               echo '</div>';
               echo '<div id="grades">';
-                  $grades = GetGrades($pageData[$gradeRun][0], $test, $id, $gradeRun);
+                  $grades = GetGrades($testInfo, $gradeRunResults);
                   if( count($grades) )
                   {
                       $smaller = '';
@@ -305,7 +307,7 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
         }
         $tabs = array( 'Summary' => $resultUrl, 'Details' => $details);
                     
-        if( $pageData[$gradeRun][$cached]['optimization_checked'] )
+        if( $testResults->getRunResult($gradeRun, $cached)->isOptimizationChecked())
             $tabs['Performance Review'] = "/performance_optimization.php?test=$id&run=$gradeRun&cached=$cached$end";
         
         $cTxt2 = '';
@@ -360,19 +362,19 @@ if( !strcasecmp('Test Result', $tab) || (array_key_exists('compare', $_COOKIE) &
 
 /**
 * Calculate the grades for the given test
-* 
+* @param TestInfo $testInfo Information about the test
+* @param TestRunResults $testRunResults Run results to compute the grades for
+* @return array An array with the different grades
 */
-function GetGrades(&$pageData, &$test, $id, $run)
+function GetGrades($testInfo, $testRunResults)
 {
-    global $test;
     $grades = array();
-    if($pageData['optimization_checked'])
-    {
+    if ($testRunResults->isOptimizationChecked()) {
         require_once('optimization_detail.inc.php');
 
-        $opt = getOptimizationGrades($pageData, $test, $id, $run);
-
-        if( $test['testinfo']['view'] != 'simple' && $test['testinfo']['view'] != 'pss' )
+        $opt = getOptimizationGradesForRun($testRunResults);
+        $infoArray = $testInfo->getInfoArray();
+        if( $infoArray['view'] != 'simple' && $infoArray['view'] != 'pss' )
             $grades['first_byte_time'] = array( 'class' => $opt['ttfb']['class'], 'grade' => $opt['ttfb']['grade'], 'description' => $opt['ttfb']['label']);
         $grades['keep_alive_enabled'] = array( 'class' => $opt['keep-alive']['class'], 'grade' => $opt['keep-alive']['grade'], 'description' => $opt['keep-alive']['label']);
         $grades['compress_text'] = array( 'class' => $opt['gzip']['class'], 'grade' => $opt['gzip']['grade'], 'description' => $opt['gzip']['label']);

--- a/www/include/TestInfo.php
+++ b/www/include/TestInfo.php
@@ -135,4 +135,21 @@ class TestInfo {
       $tester = $this->rawData['testinfo']['test_runs'][$run]['tester'];
     return $tester;
   }
+
+  /**
+   * @param string[] $keywords Keywords to check the info for
+   * @return True if the TestInfo matches the keywords, false otherwise
+   */
+  public function isAdultSite($keywords) {
+    $url = $this->getUrl();
+    if (!$url) {
+      return false;
+    }
+    foreach ($keywords as $keyword) {
+      if (stripos($url, $keyword) !== false) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/www/include/TestInfo.php
+++ b/www/include/TestInfo.php
@@ -9,11 +9,11 @@ class TestInfo {
   private $rawData;
 
 
-  private function __construct($id, $rootDirectory, &$testInfo) {
+  private function __construct($id, $rootDirectory, $testInfo) {
     // This isn't likely to stay the standard constructor, so we name it explicitly as a static function below
     $this->id = $id;
     $this->rootDirectory = $rootDirectory;
-    $this->rawData = &$testInfo;
+    $this->rawData = $testInfo;
   }
 
   /**
@@ -22,7 +22,7 @@ class TestInfo {
    * @param array $testInfo Array with information about the test
    * @return TestInfo The created instance
    */
-  public static function fromValues($id, $rootDirectory, &$testInfo) {
+  public static function fromValues($id, $rootDirectory, $testInfo) {
     return new self($id, $rootDirectory, $testInfo);
   }
 

--- a/www/include/TestPaths.php
+++ b/www/include/TestPaths.php
@@ -167,7 +167,7 @@ class TestPaths {
    * @return string Path for the additional screenshot file
    */
   public function additionalScreenShotFile($type) {
-    return $this->testRoot . $this->underscoreIdentifier() . "_screen_ ". $type . ".jpg";
+    return $this->testRoot . $this->underscoreIdentifier() . "_screen_". $type . ".jpg";
   }
 
   public function aftDiagnosticImageFile() {

--- a/www/include/TestPaths.php
+++ b/www/include/TestPaths.php
@@ -163,6 +163,18 @@ class TestPaths {
   }
 
   /**
+   * @param string $type One of 'render', 'dom', 'doc', 'responsive'
+   * @return string Path for the additional screenshot file
+   */
+  public function additionalScreenShotFile($type) {
+    return $this->testRoot . $this->underscoreIdentifier() . "_screen_ ". $type . ".jpg";
+  }
+
+  public function aftDiagnosticImageFile() {
+    return $this->testRoot . $this->underscoreIdentifier() . "_aft.png";
+  }
+
+  /**
    * @return string Path for status file
    */
   public function statusFile() {

--- a/www/include/TestResults.php
+++ b/www/include/TestResults.php
@@ -190,6 +190,25 @@ class TestResults {
     return $runNumbers[$medianIndex];
   }
 
+  /**
+   * @param string[] $keywords Keywords to use for the check
+   * @return bool True if the checked site is an adult site, false otherwise
+   */
+  public function isAdultSite($keywords) {
+    if ($this->testInfo->isAdultSite($keywords)) {
+      return true;
+    }
+    for ($i = 0; $i < $this->numRuns; $i++) {
+      if (isset($this->runResults[$i][0]) && $this->runResults[$i][0]->isAdultSite($keywords)) {
+        return true;
+      }
+      if (isset($this->runResults[$i][1]) && $this->runResults[$i][0]->isAdultSite($keywords)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private function calculateAverages($cached) {
     $avgResults = array();
     $loadTimes = array();

--- a/www/include/TestResults.php
+++ b/www/include/TestResults.php
@@ -39,9 +39,10 @@ class TestResults {
    * Constructs a TestResults object by loading the information from result files
    * @param TestInfo $testInfo Test information used to load the data
    * @param FileHandler $fileHandler FileHandler to use
+   * @param array $options Options to load the TestRunResults
    * @return TestResults The new instance
    */
-  public static function fromFiles($testInfo, $fileHandler = null) {
+  public static function fromFiles($testInfo, $fileHandler = null, $options = null) {
     $runResults = array();
     $numRuns = $testInfo->getRuns();
     $firstViewOnly = $testInfo->isFirstViewOnly();
@@ -50,8 +51,8 @@ class TestResults {
       if (!$testComplete && !$testInfo->isRunComplete($runNumber)) {
         continue;
       }
-      $firstView = TestRunResults::fromFiles($testInfo, $runNumber, false, $fileHandler);
-      $repeatView = $firstViewOnly ? null : TestRunResults::fromFiles($testInfo, $runNumber, true, $fileHandler);
+      $firstView = TestRunResults::fromFiles($testInfo, $runNumber, false, $fileHandler, $options);
+      $repeatView = $firstViewOnly ? null : TestRunResults::fromFiles($testInfo, $runNumber, true, $fileHandler, $options);
       $runResults[] = array($firstView, $repeatView);
     }
 

--- a/www/include/TestRunResults.php
+++ b/www/include/TestRunResults.php
@@ -225,4 +225,13 @@ class TestRunResults {
     }
     return false;
   }
+
+  public function hasBreakdownTimeline() {
+    foreach ($this->stepResults as $stepResult) {
+      if ($stepResult->hasBreakdownTimeline()) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/www/include/TestRunResults.php
+++ b/www/include/TestRunResults.php
@@ -213,4 +213,16 @@ class TestRunResults {
     }
     return $sum / $numValues;
   }
+
+  /**
+   * @return bool True if any step si optimization checked, false otherwise
+   */
+  public function isOptimizationChecked() {
+    foreach ($this->stepResults as $stepResult) {
+      if ($stepResult->getMetric("optimization_checked")) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/www/include/TestRunResults.php
+++ b/www/include/TestRunResults.php
@@ -193,4 +193,24 @@ class TestRunResults {
     }
     return false;
   }
+
+  /**
+   * @param string $metric The metric to compute the average of all steps
+   * @return float|null The average metric for all steps having it set or null if not set in any step
+   */
+  public function averageMetric($metric) {
+    $sum = 0.0;
+    $numValues = 0;
+    foreach ($this->stepResults as $stepResult) {
+      $value = $stepResult->getMetric($metric);
+      if (isset($value)) {
+        $numValues++;
+        $sum += floatval($value);
+      }
+    }
+    if ($numValues == 0) {
+      return null;
+    }
+    return $sum / $numValues;
+  }
 }

--- a/www/include/TestRunResults.php
+++ b/www/include/TestRunResults.php
@@ -39,13 +39,14 @@ class TestRunResults {
    * @param int $runNumber The run number
    * @param bool $isCached False for first view, true for repeat view (cached)
    * @param FileHandler $fileHandler The FileHandler to use
+   * @param array $options Options for loading the TestStepData
    * @return TestRunResults|null The initialized object or null if it failed
    */
-  public static function fromFiles($testInfo, $runNumber, $isCached, $fileHandler = null) {
+  public static function fromFiles($testInfo, $runNumber, $isCached, $fileHandler = null, $options = null) {
     $stepResults = array();
     $isValid = false;
     for ($stepNumber = 1; $stepNumber <= $testInfo->stepsInRun($runNumber); $stepNumber++) {
-      $stepResult = TestStepResult::fromFiles($testInfo, $runNumber, $isCached, $stepNumber, $fileHandler);
+      $stepResult = TestStepResult::fromFiles($testInfo, $runNumber, $isCached, $stepNumber, $fileHandler, $options);
       $stepResults[] = $stepResult;
       $isValid = $isValid || ($stepResult !== null);
     }

--- a/www/include/TestRunResults.php
+++ b/www/include/TestRunResults.php
@@ -146,6 +146,9 @@ class TestRunResults {
     return $foundMetric ? $aggregated : null;
   }
 
+  /**
+   * @return float|null The average page speed score of all steps (if set)
+   */
   public function averagePageSpeedScore() {
     $numScores = 0;
     $scoreSum = 0.0;
@@ -160,6 +163,19 @@ class TestRunResults {
       return null;
     }
     return ceil($scoreSum / $numScores);
+  }
+
+  /**
+   * @return null|string The first valid pageSpeedVersion of a step, or null
+   */
+  public function getPageSpeedVersion() {
+    foreach ($this->stepResults as $step) {
+      $version = $step->getMetric("pageSpeedVersion");
+      if ($version) {
+        return $version;
+      }
+    }
+    return null;
   }
 
   /**

--- a/www/include/TestRunResults.php
+++ b/www/include/TestRunResults.php
@@ -4,6 +4,9 @@ require_once __DIR__ . '/TestStepResult.php';
 
 class TestRunResults {
 
+  /**
+   * @var TestInfo
+   */
   private $testInfo;
   private $runNumber;
   private $isCached;
@@ -141,5 +144,21 @@ class TestRunResults {
       $foundMetric = true;
     }
     return $foundMetric ? $aggregated : null;
+  }
+
+  /**
+   * @param string[] $keywords Keywords to use for the check
+   * @return bool True if the checked site is an adult site, false otherwise
+   */
+  public function isAdultSite($keywords) {
+    if ($this->testInfo->isAdultSite($keywords)) {
+      return true;
+    }
+    foreach ($this->stepResults as $step) {
+      if ($step->isAdultSite($keywords)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/www/include/TestRunResults.php
+++ b/www/include/TestRunResults.php
@@ -146,6 +146,22 @@ class TestRunResults {
     return $foundMetric ? $aggregated : null;
   }
 
+  public function averagePageSpeedScore() {
+    $numScores = 0;
+    $scoreSum = 0.0;
+    foreach ($this->stepResults as $step) {
+      $score = $step->getPageSpeedScore();
+      if ($score) {
+        $numScores += 1;
+        $scoreSum += intval($score);
+      }
+    }
+    if ($numScores == 0) {
+      return null;
+    }
+    return ceil($scoreSum / $numScores);
+  }
+
   /**
    * @param string[] $keywords Keywords to use for the check
    * @return bool True if the checked site is an adult site, false otherwise

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -70,7 +70,7 @@ class TestStepResult {
    * @return UrlGenerator The created URL generator for this step
    */
   public function createUrlGenerator($baseUrl, $friendly = true) {
-    return UrlGenerator::create($friendly, $baseUrl, $this->testInfo->getId(), $this->run, $this->cached);
+    return UrlGenerator::create($friendly, $baseUrl, $this->testInfo->getId(), $this->run, $this->cached, $this->step);
   }
 
   /**

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -43,7 +43,7 @@ class TestStepResult {
    * @param int $step The step number
    * @return TestStepResult The created instance
    */
-  public static function fromPageData($testInfo, &$pageData, $run, $cached, $step) {
+  public static function fromPageData($testInfo, $pageData, $run, $cached, $step) {
     return new self($testInfo, $pageData, $run, $cached, $step);
   }
 

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -64,8 +64,22 @@ class TestStepResult {
     return new self($testInfo, $pageData, $runNumber, $isCached, $stepNumber);
   }
 
-  public function getUrlGenerator($baseUrl, $friendly = true) {
-    return UrlGenerator::create($friendly, $baseUrl, $this->testInfo->getRootDirectory(), $this->run, $this->cached);
+  /**
+   * @param string $baseUrl The base URL to use for the UrlGenerator
+   * @param bool $friendly Optional. True for friendly URLS (default), false for standard URLs
+   * @return UrlGenerator The created URL generator for this step
+   */
+  public function createUrlGenerator($baseUrl, $friendly = true) {
+    return UrlGenerator::create($friendly, $baseUrl, $this->testInfo->getId(), $this->run, $this->cached);
+  }
+
+  /**
+   * @param string $testRoot Optional. A different test root path. If null, it's set to the default test root for local paths.
+   * @return TestPaths The created TestPaths object for this step
+   */
+  public function createTestPaths($testRoot = null) {
+    $testRoot = ($testRoot === null) ? $this->testInfo->getRootDirectory() : $testRoot;
+    return new TestPaths($testRoot, $this->run, $this->cached, $this->step);
   }
 
   /**
@@ -171,7 +185,7 @@ class TestStepResult {
 
   public function getRequests() {
     // TODO: move implementation to this method
-    return getRequestsForStep($this->localPaths, $this->getUrlGenerator(""), $secure, $haveLocations, false, true);
+    return getRequestsForStep($this->localPaths, $this->createUrlGenerator(""), $secure, $haveLocations, false, true);
   }
 
   public function getDomainBreakdown() {
@@ -182,7 +196,7 @@ class TestStepResult {
   public function getMimeTypeBreakdown() {
     // TODO: move implementation to this method
     $requests = null;
-    return getBreakdownForStep($this->localPaths, $this->getUrlGenerator(""), $requests);
+    return getBreakdownForStep($this->localPaths, $this->createUrlGenerator(""), $requests);
   }
 
   public function getConsoleLog() {

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -174,6 +174,7 @@ class TestStepResult {
     if ($this->fileHandler->gzFileExists($this->localPaths->pageSpeedFile())) {
       return GetPageSpeedScore($this->localPaths->pageSpeedFile());
     }
+    return null;
   }
 
   public function getVisualProgress() {

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -54,13 +54,14 @@ class TestStepResult {
    * @param bool $isCached False for first view, true for repeat view
    * @param int $stepNumber The step number, starting from 1
    * @param FileHandler $fileHandler The FileHandler to use
+   * @param array $options Options for the loadPageStepData
    * @return TestStepResult|null The created instance on success, null otherwise
    */
-  public static function fromFiles($testInfo, $runNumber, $isCached, $stepNumber, $fileHandler = null) {
+  public static function fromFiles($testInfo, $runNumber, $isCached, $stepNumber, $fileHandler = null, $options = null) {
     // no support to use FileHandler so far
     $localPaths = new TestPaths($testInfo->getRootDirectory(), $runNumber, $isCached, $stepNumber);
     $runCompleted = $testInfo->isRunComplete($runNumber);
-    $pageData = loadPageStepData($localPaths, $runCompleted, null, $testInfo->getInfoArray());
+    $pageData = loadPageStepData($localPaths, $runCompleted, $options, $testInfo->getInfoArray());
     return new self($testInfo, $pageData, $runNumber, $isCached, $stepNumber);
   }
 

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -228,6 +228,27 @@ class TestStepResult {
     return $statusMessages;
   }
 
+  /**
+   * @param string[] $keywords Keywords to use for the check
+   * @return bool True if the checked site is an adult site, false otherwise
+   */
+  public function isAdultSite($keywords) {
+    if ($this->testInfo->isAdultSite($keywords)) {
+      return true;
+    }
+    foreach ($keywords as $keyword) {
+      if (!empty($this->rawData["adult_site"])) {
+        return true;
+      }
+      if (!empty($this->rawData["URL"]) && stripos($this->rawData["URL"], $keyword) !== false) {
+        return true;
+      }
+      if (!empty($this->rawData["title"]) && stripos($this->rawData["title"], $keyword) !== false) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   private function getStartOffset() {
     if (!array_key_exists('testStartOffset', $this->rawData)) {

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -157,11 +157,12 @@ class TestStepResult {
 
   /**
    * @param string $default Optional. A default value if no custom event name or URL is set
-   * @return string A readable identifier for this step (EIther custom event name, URL, or $default)
+   * @return string A readable identifier for this step (Either custom event name, URL, $default, or "Step x")
    */
   public function readableIdentifier($default = "") {
-    $nameOrUrl = $this->hasCustomEventName() ? $this->getEventName() : $this->getUrl();
-    return empty($nameOrUrl) ? $default : $nameOrUrl;
+    $identifier = $this->hasCustomEventName() ? $this->getEventName() : $this->getUrl();
+    $identifier = empty($identifier) ? $default : $identifier;
+    return empty($identifier) ? ("Step " . $this->step) : $identifier;
   }
 
   /**

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -41,10 +41,11 @@ class TestStepResult {
    * @param int $run The run to return the data for
    * @param bool $cached False for first view, true for repeat view
    * @param int $step The step number
+   * @param FileHandler $fileHandler The FileHandler to use
    * @return TestStepResult The created instance
    */
-  public static function fromPageData($testInfo, $pageData, $run, $cached, $step) {
-    return new self($testInfo, $pageData, $run, $cached, $step);
+  public static function fromPageData($testInfo, $pageData, $run, $cached, $step, $fileHandler = null) {
+    return new self($testInfo, $pageData, $run, $cached, $step, $fileHandler);
   }
 
   /**
@@ -62,7 +63,7 @@ class TestStepResult {
     $localPaths = new TestPaths($testInfo->getRootDirectory(), $runNumber, $isCached, $stepNumber);
     $runCompleted = $testInfo->isRunComplete($runNumber);
     $pageData = loadPageStepData($localPaths, $runCompleted, $options, $testInfo->getInfoArray());
-    return new self($testInfo, $pageData, $runNumber, $isCached, $stepNumber);
+    return new self($testInfo, $pageData, $runNumber, $isCached, $stepNumber, $fileHandler);
   }
 
   /**
@@ -249,6 +250,17 @@ class TestStepResult {
       }
     }
     return false;
+  }
+
+  /**
+   * @return bool True if the step has a breakdown timeline, false otherwise
+   */
+  public function hasBreakdownTimeline() {
+    if (empty($this->testInfo->getInfoArray()["timeline"])) {
+      return false;
+    }
+    return $this->fileHandler->gzFileExists($this->localPaths->devtoolsFile()) ||
+           $this->fileHandler->gzFileExists($this->localPaths->devtoolsTraceFile());
   }
 
   private function getStartOffset() {

--- a/www/include/UrlGenerator.php
+++ b/www/include/UrlGenerator.php
@@ -91,6 +91,24 @@ abstract class UrlGenerator {
     return $this->baseUrl . "/response_body.php?" . $this->urlParams() . "&bodyid=" . strval($bodyId);
   }
 
+  /**
+   * @return string The generated URL to create a video
+   */
+  public function createVideo() {
+    $testSuffix = ($this->step > 1) ? ("-s:" . $this->step) : "";
+    $idSuffix = ($this->step > 1) ? ("." . $this->step) : "";
+    $tests = $this->testId . "-r:" . $this->run . "-c:" . ($this->cached ? 1 : 0) . $testSuffix;
+    $id = $this->testId . "." . $this->run . "." . ($this->cached ? 1 : 0) . $idSuffix;
+    return $this->baseUrl . "/video/create.php?tests=" . $tests . "&id=" . $id;
+  }
+
+  /**
+   * @return string The generated URL to download all video frames
+   */
+  public function downloadVideoFrames() {
+    return $this->baseUrl . "/video/downloadFrames.php?" . $this->urlParams();
+  }
+
   protected function underscorePrefix() {
     $stepSuffix = $this->step > 1 ? ($this->step . "_") : "";
     return strval($this->run) . "_" . ($this->cached ? "Cached_" : "") . $stepSuffix;

--- a/www/include/UrlGenerator.php
+++ b/www/include/UrlGenerator.php
@@ -38,9 +38,10 @@ abstract class UrlGenerator {
 
   /**
    * @param string $page Result page to generate the URL for
+   * @param string $extraParams|null Extra parameters to append (without '?' or '&' at start)
    * @return string The generated URL
    */
-  public abstract function resultPage($page);
+  public abstract function resultPage($page, $extraParams = null);
 
   /**
    * @param string $image Image name to generate the thumbnail URL for
@@ -50,9 +51,15 @@ abstract class UrlGenerator {
 
   /**
    * @param string $image Generated image name to generate the URL for
-   * @return mixed The generated URL
+   * @return string The generated URL
    */
   public abstract function generatedImage($image);
+
+  /**
+   * @param string $extraParams|null Extra parameters to append (without '?' or '&' at start)
+   * @return string The generated URL
+   */
+  public abstract function resultSummary($extraParams = null);
 
   /**
    * @param string $file The name of the file to get with the URL
@@ -122,13 +129,16 @@ abstract class UrlGenerator {
 
 class FriendlyUrlGenerator extends UrlGenerator {
 
-  public function resultPage($page) {
+  public function resultPage($page, $extraParams = null) {
     $url = $this->baseUrl . "/result/" . $this->testId . "/" . $this->run . "/" . $page . "/";
     if ($this->cached) {
       $url .= "cached/";
     }
     if ($this->step > 1) {
       $url .= $this->step . "/";
+    }
+    if ($extraParams != null) {
+      $url .= "?" . $extraParams;
     }
     return $url;
   }
@@ -154,15 +164,20 @@ class FriendlyUrlGenerator extends UrlGenerator {
     return $this->baseUrl . "/results/" . $testPath . "/" . $this->underscorePrefix() . $image . ".png";
   }
 
-  public function resultSummary() {
-    return $this->baseUrl . "/result/" . $this->testId . "/";
+  public function resultSummary($extraParams = null) {
+    $url = $this->baseUrl . "/result/" . $this->testId . "/";
+    if ($extraParams != null) {
+      $url .= "?" . $extraParams;
+    }
+    return $url;
   }
 }
 
 class StandardUrlGenerator extends UrlGenerator {
 
-  public function resultPage($page) {
-    return $this->baseUrl . "/" . $page . ".php?" . $this->urlParams();
+  public function resultPage($page, $extraParams = null) {
+    $extraParams = $extraParams ? ("&" . $extraParams) : "";
+    return $this->baseUrl . "/" . $page . ".php?" . $this->urlParams() . $extraParams;
   }
 
   public function thumbnail($image) {
@@ -173,7 +188,8 @@ class StandardUrlGenerator extends UrlGenerator {
     return $this->baseUrl . "/" . $image . ".php?" . $this->urlParams();
   }
 
-  public function resultSummary() {
-    return $this->baseUrl . "/results.php?test=" . $this->testId;
+  public function resultSummary($extraParams = null) {
+    $extraParams = $extraParams ? ("&" . $extraParams) : "";
+    return $this->baseUrl . "/results.php?test=" . $this->testId . $extraParams;
   }
 }

--- a/www/js/jk-navigation.js
+++ b/www/js/jk-navigation.js
@@ -1,0 +1,30 @@
+
+function addJKNavigation(selector) {
+    $(document).keydown(function (e) {
+        var JKey = 74;
+        var KKey = 75;
+        if (e.keyCode != JKey && e.keyCode != KKey) {
+            return;
+        }
+        var elements = $(selector);
+        var active = $(selector + '.jkActive');
+        var curPos = elements.index(active);
+
+        var newActive = undefined;
+        if (curPos < 0) {
+            newActive = elements.first();
+        } else if (e.keyCode == JKey && curPos < (elements.length -1)) {
+            newActive = elements.eq(curPos + 1);
+        } else if (e.keyCode == KKey && curPos > 0) {
+            newActive = elements.eq(curPos - 1);
+        }
+
+        if (newActive !== undefined) {
+            if (active.length > 0) {
+                active.removeClass('jkActive');
+            }
+            newActive.addClass('jkActive');
+            $('html, body').animate({scrollTop: newActive.offset().top + 'px'}, 'fast');
+        }
+    });
+}

--- a/www/optimization_detail.inc.php
+++ b/www/optimization_detail.inc.php
@@ -155,18 +155,23 @@ function gradeTTFB(&$pageData, &$test, $id, $run, $cached, &$target)
 */
 function getTargetTTFB(&$pageData, &$test, $id, $run, $cached)
 {
-    $target = NULL;
-
+    $testPath = './' . GetTestPath($id);
+    $localPaths = new TestPaths($testPath, $id, $run, $cached, 1);
     $rtt = 0;
     if( isset($test['testinfo']['latency']) )
         $rtt = (int)$test['testinfo']['latency'];
 
+    return getTargetTTFBForStep($localPaths, $rtt);
+}
+
+function getTargetTTFBForStep($localPaths, $rtt) {
+    $target = NULL;
+
     // load the object data (unavoidable, we need the socket connect time to the first host)
     require_once('object_detail.inc');
-    $testPath = './' . GetTestPath($id);
+
     $secure = false;
-    $haveLocations;
-    $requests = getRequests($id, $testPath, $run, $cached, $secure, $haveLocations, false);
+    $requests = getRequestsForStep($localPaths, null, $secure, $haveLocations, false);
     if( count($requests) )
     {
         // figure out what the RTT is to the server (take the connect time from the first request unless it is over 3 seconds)

--- a/www/optimization_detail.inc.php
+++ b/www/optimization_detail.inc.php
@@ -36,97 +36,97 @@ function getOptimizationGrades(&$pageData, &$test, $id, $run)
  */
 function createGradeArray($scores) {
 
-        $opt = array();
+  $opt = array();
 
-        // put them in rank-order
-        $opt['ttfb'] = array();
-        $opt['keep-alive'] = array();
-        $opt['gzip'] = array();
-        $opt['image_compression'] = array();
-        $opt['caching'] = array();
-        $opt['combine'] = array();
-        $opt['cdn'] = array();
-        $opt['cookies'] = array();
-        $opt['minify'] = array();
-        $opt['e-tags'] = array();
+  // put them in rank-order
+  $opt['ttfb'] = array();
+  $opt['keep-alive'] = array();
+  $opt['gzip'] = array();
+  $opt['image_compression'] = array();
+  $opt['caching'] = array();
+  $opt['combine'] = array();
+  $opt['cdn'] = array();
+  $opt['cookies'] = array();
+  $opt['minify'] = array();
+  $opt['e-tags'] = array();
 
-        foreach (array_keys($opt) as $scoreName) {
-          if (array_key_exists($scoreName, $scores) && $scores[$scoreName] >= 0) {
-              $opt[$scoreName]['score'] = $scores[$scoreName];
-          }
-        }
-        if (array_key_exists('progressive_jpeg', $scores) && $scores['progressive_jpeg'] >= 0) {
-          $opt['progressive_jpeg'] = array(
-            'score' => $scores['progressive_jpeg'],
-            'label' => 'Progressive JPEGs',
-            'important' => true
-          );
-        }
+  foreach (array_keys($opt) as $scoreName) {
+    if (array_key_exists($scoreName, $scores) && $scores[$scoreName] >= 0) {
+      $opt[$scoreName]['score'] = $scores[$scoreName];
+    }
+  }
+  if (array_key_exists('progressive_jpeg', $scores) && $scores['progressive_jpeg'] >= 0) {
+    $opt['progressive_jpeg'] = array(
+      'score' => $scores['progressive_jpeg'],
+      'label' => 'Progressive JPEGs',
+      'important' => true
+    );
+  }
 
-        // define the labels for all  of them
-        $opt['ttfb']['label'] = 'First Byte Time';
-        $opt['keep-alive']['label'] = 'Keep-alive Enabled';
-        $opt['gzip']['label'] = 'Compress Transfer';
-        $opt['image_compression']['label'] = 'Compress Images';
-        $opt['caching']['label'] = 'Cache static content';
-        $opt['combine']['label'] = 'Combine js and css files';
-        $opt['cdn']['label'] = 'Effective use of CDN';
-        $opt['cookies']['label'] = 'No cookies on static content';
-        $opt['minify']['label'] = 'Minify javascript';
-        $opt['e-tags']['label'] = 'Disable E-Tags';
+  // define the labels for all  of them
+  $opt['ttfb']['label'] = 'First Byte Time';
+  $opt['keep-alive']['label'] = 'Keep-alive Enabled';
+  $opt['gzip']['label'] = 'Compress Transfer';
+  $opt['image_compression']['label'] = 'Compress Images';
+  $opt['caching']['label'] = 'Cache static content';
+  $opt['combine']['label'] = 'Combine js and css files';
+  $opt['cdn']['label'] = 'Effective use of CDN';
+  $opt['cookies']['label'] = 'No cookies on static content';
+  $opt['minify']['label'] = 'Minify javascript';
+  $opt['e-tags']['label'] = 'Disable E-Tags';
 
-        // flag the important ones
-        $opt['ttfb']['important'] = true;
-        $opt['keep-alive']['important'] = true;
-        $opt['gzip']['important'] = true;
-        $opt['image_compression']['important'] = true;
-        $opt['caching']['important'] = true;
-        $opt['cdn']['important'] = true;
+  // flag the important ones
+  $opt['ttfb']['important'] = true;
+  $opt['keep-alive']['important'] = true;
+  $opt['gzip']['important'] = true;
+  $opt['image_compression']['important'] = true;
+  $opt['caching']['important'] = true;
+  $opt['cdn']['important'] = true;
 
-        // apply grades
-        foreach( $opt as $check => &$item )
-        {
-            $grade = 'N/A';
-            $weight = 0;
-            if( $check == 'cdn' )
-            {
-                if( $item['score'] >= 80 )
-                {
-                    $item['grade'] = "<img src=\"{$GLOBALS['cdnPath']}/images/grade_check.png\" alt=\"yes\">";
-                    $item['class'] = 'A';
-                }
-                else
-                {
-                    $item['grade'] = 'X';
-                    $item['class'] = 'NA';
-                }
-            }
-            else
-            {
-                if( isset($item['score']) )
-                {
-                    $weight = 100;
-                    if( $item['score'] >= 90 )
-                        $grade = 'A';
-                    elseif( $item['score'] >= 80 )
-                        $grade = 'B';
-                    elseif( $item['score'] >= 70 )
-                        $grade = 'C';
-                    elseif( $item['score'] >= 60 )
-                        $grade = 'D';
-                    elseif( $item['score'] >= 0 )
-                        $grade = 'F';
-                    else
-                        $weight = 0;
-                }
-                $item['grade'] = $grade;
-                if( $grade == "N/A" )
-                    $item['class'] = "NA";
-                else
-                    $item['class'] = $grade;
-            }
-            $item['weight'] = $weight;
-        }
+  // apply grades
+  foreach( $opt as $check => &$item )
+  {
+    $grade = 'N/A';
+    $weight = 0;
+    if( $check == 'cdn' )
+    {
+      if( $item['score'] >= 80 )
+      {
+        $item['grade'] = "<img src=\"{$GLOBALS['cdnPath']}/images/grade_check.png\" alt=\"yes\">";
+        $item['class'] = 'A';
+      }
+      else
+      {
+        $item['grade'] = 'X';
+        $item['class'] = 'NA';
+      }
+    }
+    else
+    {
+      if( isset($item['score']) )
+      {
+        $weight = 100;
+        if( $item['score'] >= 90 )
+          $grade = 'A';
+        elseif( $item['score'] >= 80 )
+          $grade = 'B';
+        elseif( $item['score'] >= 70 )
+          $grade = 'C';
+        elseif( $item['score'] >= 60 )
+          $grade = 'D';
+        elseif( $item['score'] >= 0 )
+          $grade = 'F';
+        else
+          $weight = 0;
+      }
+      $item['grade'] = $grade;
+      if( $grade == "N/A" )
+        $item['class'] = "NA";
+      else
+        $item['class'] = $grade;
+    }
+    $item['weight'] = $weight;
+  }
 
     return $opt;
 }
@@ -139,11 +139,11 @@ function createGradeArray($scores) {
 */
 function gradeTTFB(&$pageData, &$test, $id, $run, $cached, &$target)
 {
-    $ttfb = (int)$pageData['TTFB'];
-    $latency = isset($test['testinfo']['latency']) ? $test['testinfo']['latency'] : null;
-    $testPath = './' . GetTestPath($id);
-    $localPaths = new TestPaths($testPath, $id, $run, $cached, 1);
-    return gradeTTFBForStep($ttfb, $latency, $localPaths, $target);
+  $ttfb = (int)$pageData['TTFB'];
+  $latency = isset($test['testinfo']['latency']) ? $test['testinfo']['latency'] : null;
+  $testPath = './' . GetTestPath($id);
+  $localPaths = new TestPaths($testPath, $id, $run, $cached, 1);
+  return gradeTTFBForStep($ttfb, $latency, $localPaths, $target);
 }
 
 /**
@@ -154,28 +154,28 @@ function gradeTTFB(&$pageData, &$test, $id, $run, $cached, &$target)
  * @return int|null The TTFB score or null, if it can't get determined
  */
 function gradeTTFBForStep($ttfb, $latency, $localPaths, &$target) {
-    $score = null;
-    if( $ttfb )
+  $score = null;
+  if( $ttfb )
+  {
+    // see if we can fast-path fail this test without loading the object data
+    if( isset($latency) )
     {
-        // see if we can fast-path fail this test without loading the object data
-        if( isset($latency) )
-        {
-            $rtt = (int)$latency + 100;
-            $worstCase = $rtt * 7 + 1000;  // 7 round trips including dns, socket, request and ssl + 1 second back-end
-            if( $ttfb > $worstCase )
-                $score = 0;
-        } else {
-            $latency = 0;
-        }
-
-        if( !isset($score) )
-        {
-            $target = getTargetTTFBForStep($localPaths, $latency);
-            $score = (int)min(max(100 - (($ttfb - $target) / 10), 0), 100);
-        }
+      $rtt = (int)$latency + 100;
+      $worstCase = $rtt * 7 + 1000;  // 7 round trips including dns, socket, request and ssl + 1 second back-end
+      if( $ttfb > $worstCase )
+        $score = 0;
+    } else {
+      $latency = 0;
     }
 
-    return $score;
+    if( !isset($score) )
+    {
+      $target = getTargetTTFBForStep($localPaths, $latency);
+      $score = (int)min(max(100 - (($ttfb - $target) / 10), 0), 100);
+    }
+  }
+
+  return $score;
 }
 
 /**
@@ -185,50 +185,50 @@ function gradeTTFBForStep($ttfb, $latency, $localPaths, &$target) {
  * @return int|null The target TTFB or null if it can't get determined
  */
 function getTargetTTFBForStep($localPaths, $rtt) {
-    $target = NULL;
+  $target = NULL;
 
-    // load the object data (unavoidable, we need the socket connect time to the first host)
-    require_once('object_detail.inc');
+  // load the object data (unavoidable, we need the socket connect time to the first host)
+  require_once('object_detail.inc');
 
-    $secure = false;
-    $requests = getRequestsForStep($localPaths, null, $secure, $haveLocations, false);
-    if( count($requests) )
-    {
-        // figure out what the RTT is to the server (take the connect time from the first request unless it is over 3 seconds)
-        if (isset($requests[0]['connect_start']) &&
-            $requests[0]['connect_start'] >= 0 &&
-            isset($requests[0]['connect_end']) &&
-            $requests[0]['connect_end'] > $requests[0]['connect_start']) {
-          $rtt = $requests[0]['connect_end'] - $requests[0]['connect_start'];
-        } else {
-          $connect_ms = $requests[0]['connect_ms'];
-          if ($rtt > 0 && (!isset($connect_ms) || $connect_ms > 3000 || $connect_ms < 0))
-            $rtt += 100;    // allow for an additional 100ms to reach the server on top of the traffic-shaped RTT
-          else
-            $rtt = $connect_ms;
-        }
-        
-        // allow for a minimum of 100ms for the RTT
-        $rtt = max($rtt, 100);
-        
-        $ssl_ms = 0;
-        $i = 0;
-        while (isset($requests[$i])) {
-          if (isset($requests[$i]['contentType']) &&
-              (stripos($requests[$i]['contentType'], 'ocsp') !== false ||
-               stripos($requests[$i]['contentType'], 'crl') !== false)) {
-            $i++;
-          } else {
-            if ($requests[$i]['is_secure'])
-              $ssl_ms = $rtt;
-            break;
-          }
-        }
-
-        // RTT's: DNS + Socket Connect + HTTP Request + 100ms allowance
-        $target = ($rtt * 3) + $ssl_ms + 100;
+  $secure = false;
+  $requests = getRequestsForStep($localPaths, null, $secure, $haveLocations, false);
+  if( count($requests) )
+  {
+    // figure out what the RTT is to the server (take the connect time from the first request unless it is over 3 seconds)
+    if (isset($requests[0]['connect_start']) &&
+      $requests[0]['connect_start'] >= 0 &&
+      isset($requests[0]['connect_end']) &&
+      $requests[0]['connect_end'] > $requests[0]['connect_start']) {
+      $rtt = $requests[0]['connect_end'] - $requests[0]['connect_start'];
+    } else {
+      $connect_ms = $requests[0]['connect_ms'];
+      if ($rtt > 0 && (!isset($connect_ms) || $connect_ms > 3000 || $connect_ms < 0))
+        $rtt += 100;    // allow for an additional 100ms to reach the server on top of the traffic-shaped RTT
+      else
+        $rtt = $connect_ms;
     }
 
-    return $target;
+    // allow for a minimum of 100ms for the RTT
+    $rtt = max($rtt, 100);
+
+    $ssl_ms = 0;
+    $i = 0;
+    while (isset($requests[$i])) {
+      if (isset($requests[$i]['contentType']) &&
+        (stripos($requests[$i]['contentType'], 'ocsp') !== false ||
+          stripos($requests[$i]['contentType'], 'crl') !== false)) {
+        $i++;
+      } else {
+        if ($requests[$i]['is_secure'])
+          $ssl_ms = $rtt;
+        break;
+      }
+    }
+
+    // RTT's: DNS + Socket Connect + HTTP Request + 100ms allowance
+    $target = ($rtt * 3) + $ssl_ms + 100;
+  }
+
+  return $target;
 }
 ?>

--- a/www/optimization_detail.inc.php
+++ b/www/optimization_detail.inc.php
@@ -128,6 +128,13 @@ function gradeTTFB(&$pageData, &$test, $id, $run, $cached, &$target)
     return gradeTTFBForStep($ttfb, $latency, $localPaths, $target);
 }
 
+/**
+ * @param int $ttfb The TTFB of this step
+ * @param int|null $latency The latency or null if it's unknown
+ * @param TestPaths $localPaths Paths corresponding to this step
+ * @param int $target Gets set to the target TTFB
+ * @return int|null The TTFB score or null, if it can't get determined
+ */
 function gradeTTFBForStep($ttfb, $latency, $localPaths, &$target) {
     $score = null;
     if( $ttfb )
@@ -154,24 +161,11 @@ function gradeTTFBForStep($ttfb, $latency, $localPaths, &$target) {
 }
 
 /**
-* Determine the target TTFB for the given test
-*
-* @param mixed $pageData
-* @param mixed $test
-* @param mixed $id
-* @param mixed $run
-*/
-function getTargetTTFB(&$pageData, &$test, $id, $run, $cached)
-{
-    $testPath = './' . GetTestPath($id);
-    $localPaths = new TestPaths($testPath, $id, $run, $cached, 1);
-    $rtt = 0;
-    if( isset($test['testinfo']['latency']) )
-        $rtt = (int)$test['testinfo']['latency'];
-
-    return getTargetTTFBForStep($localPaths, $rtt);
-}
-
+ * Determine the target TTFB for the given test step
+ * @param TestPaths $localPaths Paths corresponding to this step
+ * @param int $rtt The latency if set, or null
+ * @return int|null The target TTFB or null if it can't get determined
+ */
 function getTargetTTFBForStep($localPaths, $rtt) {
     $target = NULL;
 

--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -256,4 +256,4 @@ table.pretty td.even { background: whitesmoke; }
 #pagespeed_results {width: 960px; background-color: #fff; padding: 0px 10px 10px; margin: -15px -20px 0px;}
 #pagespeed_results h2 {text-align: center; padding: 10px 0 0 0;}
 
-h1.stepName { border-left: 4px #007 solid; border-right: 4px #007 solid; background: gainsboro; }
+h1.stepName { border-left: 4px #007 solid; border-right: 4px #007 solid; background: gainsboro; margin-top: 1em; }

--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -255,3 +255,5 @@ table.pretty td.even { background: whitesmoke; }
 /*pagespeed results*/
 #pagespeed_results {width: 960px; background-color: #fff; padding: 0px 10px 10px; margin: -15px -20px 0px;}
 #pagespeed_results h2 {text-align: center; padding: 10px 0 0 0;}
+
+h1.stepName { border-left: 4px #007 solid; border-right: 4px #007 solid; background: gainsboro; }

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -126,7 +126,7 @@ function printStep($fileHandler, $testInfo, $testStepResult) {
     $urlPaths = $testStepResult->createTestPaths(substr($testInfo->getRootDirectory(), 1));
     $urlGenerator = $testStepResult->createUrlGenerator("", FRIENDLY_URLS);
 
-    echo "<a name=\"step" . $testStepResult->getStepNumber() . "\">";
+    echo "<a name=\"step_" . $testStepResult->getStepNumber() . "\">";
     echo "<h1 class='stepName'>" . $testStepResult->readableIdentifier() . "</h1>";
     echo "</a>";
 
@@ -156,29 +156,31 @@ function printStep($fileHandler, $testInfo, $testStepResult) {
             echo "\n<br>Last Status Message: \"{$lastMessage['message']}\"\n";
     }
 
+    $stepNumber = $testStepResult->getStepNumber();
+    $linkSuffix = $stepNumber > 1 ? ("_" . $stepNumber) : "";
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("render"))) {
-        echo '<br><br><a name="start_render"><h2>Start Render';
+        echo '<br><br><a name="start_render' . $linkSuffix . '"><h2>Start Render';
         if (isset($pageRunData) && isset($pageRunData['render']))
             echo ' (' . number_format($pageRunData['render'] / 1000.0, 3) . '  sec)';
         echo '</h2></a>';
         echo '<img class="center" alt="Start Render Screen Shot" src="' . $urlPaths->additionalScreenShotFile("render") . '">';
     }
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("dom"))) {
-        echo '<br><br><a name="dom_element"><h2>DOM Element';
+        echo '<br><br><a name="dom_element' . $linkSuffix . '"><h2>DOM Element';
         if (isset($pageRunData) && isset($pageRunData['domTime']))
             echo ' (' . number_format($pageRunData['domTime'] / 1000.0, 3) . '  sec)';
         echo '</h2></a>';
         echo '<img class="center" alt="DOM Element Screen Shot" src="' . $urlPaths->additionalScreenShotFile("dom") . '">';
     }
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("doc"))) {
-        echo '<br><br><a name="doc_complete"><h2>Document Complete';
+        echo '<br><br><a name="doc_complete' . $linkSuffix . '"><h2>Document Complete';
         if (isset($pageRunData) && isset($pageRunData['docTime']))
             echo ' (' . number_format($pageRunData['docTime'] / 1000.0, 3) . '  sec)';
         echo '</h2></a>';
         echo '<img class="center" alt="Document Complete Screen Shot" src="' . $urlPaths->additionalScreenShotFile("doc") . '">';
     }
     if ($fileHandler->fileExists($localPaths->aftDiagnosticImageFile())) {
-        echo '<br><br><a name="aft"><h2>AFT Details';
+        echo '<br><br><a name="aft' . $linkSuffix . '"><h2>AFT Details';
         if (isset($pageRunData) && isset($pageRunData['aft']))
             echo ' (' . number_format($pageRunData['aft'] / 1000.0, 3) . '  sec)';
         echo '</h2></a>';
@@ -192,7 +194,7 @@ function printStep($fileHandler, $testInfo, $testStepResult) {
 
     // display all of the status messages
     if (count($messages)) {
-        echo "\n<br><br><a name=\"status_messages\"><h2>Status Messages</h2></a>\n";
+        echo "\n<br><br><a name=\"status_messages" . $linkSuffix . "\"><h2>Status Messages</h2></a>\n";
         echo "<table id=\"messages\" class=\"translucent\"><tr><th>Time</th><th>Message</th></tr>\n";
         foreach ($messages as $message) {
             $time = $message['time'] / 1000.0;
@@ -206,7 +208,7 @@ function printStep($fileHandler, $testInfo, $testStepResult) {
     $row = 0;
     $console_log = $testStepResult->getConsoleLog();
     if (isset($console_log) && count($console_log)) {
-        echo "\n<br><br><a name=\"console-log\"><h2>Console Log</h2></a>\n";
+        echo "\n<br><br><a name=\"console-log" . $linkSuffix . "\"><h2>Console Log</h2></a>\n";
         echo "<table id=\"console-log\" class=\"translucent\"><tr><th>Source</th><th>Level</th><th>Message</th><th>URL</th><th>Line</th></tr>\n";
         foreach ($console_log as &$log_entry) {
             $row++;

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -1,8 +1,13 @@
 <?php 
-include 'common.inc';
-require_once('video.inc');
-require_once('page_data.inc');
-require_once('devtools.inc.php');
+include __DIR__ . '/common.inc';
+require_once __DIR__ . '/video.inc';
+require_once __DIR__ . '/page_data.inc';
+require_once __DIR__ . '/devtools.inc.php';
+require_once __DIR__ . '/include/FileHandler.php';
+require_once __DIR__ . '/include/TestPaths.php';
+require_once __DIR__ . '/include/UrlGenerator.php';
+
+
 $pageRunData = loadPageRunData($testPath, $run, $cached, null, $test['testinfo']);
 
 $videoPath = "$testPath/video_{$run}";
@@ -107,9 +112,9 @@ function printContent($id, $run, $cached, $testPath, $messages, $pageRunData, $c
     $localPaths = new TestPaths($testPath, $run, $cached, $step);
     $fileHandler = new FileHandler();
     if ($fileHandler->dirExists($localPaths->videoDir())) {
-        $createPath = "/video/create.php?tests=$id-r:$run-c:$cached&id={$id}.{$run}.{$cached}";
-        echo "<a href=\"$createPath\">Create Video</a> &#8226; ";
-        echo "<a href=\"/video/downloadFrames.php?test=$id&run=$run&cached=$cached\">Download Video Frames</a>";
+        $rootUrlGenerator = UrlGenerator::create(FRIENDLY_URLS, "", $id, $run, $cached, $step);
+        echo "<a href=\"" . $rootUrlGenerator->createVideo() . "\">Create Video</a> &#8226; ";
+        echo "<a href=\"" . $rootUrlGenerator->downloadVideoFrames() . "\">Download Video Frames</a>";
     }
     $urlPaths = new TestPaths(substr($testPath, 1), $run, $cached, $step);
 

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -104,19 +104,31 @@ $userImages = true;
 <?php
 
 /**
- * @param FileHandler $fileHandler
- * @param TestInfo $testInfo
- * @param TestRunResults $testRunResults
+ * @param FileHandler $fileHandler FileHandler to use
+ * @param TestInfo $testInfo Information about the test
+ * @param TestRunResults $testRunResults The run results to be printed
  */
 function printContent($fileHandler, $testInfo, $testRunResults) {
-    $testStepResult = $testRunResults->getStepResult(1);
+    for ($i = 1; $i <= $testRunResults->countSteps(); $i++) {
+        printStep($fileHandler, $testInfo, $testRunResults->getStepResult($i));
+    }
+}
+
+/**
+ * @param FileHandler $fileHandler FileHandler to use
+ * @param TestInfo $testInfo Information about the test
+ * @param TestStepResult $testStepResult Results of the specific test
+ */
+function printStep($fileHandler, $testInfo, $testStepResult) {
     $pageRunData = $testStepResult->getRawResults();
 
     $localPaths = $testStepResult->createTestPaths();
     $urlPaths = $testStepResult->createTestPaths(substr($testInfo->getRootDirectory(), 1));
     $urlGenerator = $testStepResult->createUrlGenerator("", FRIENDLY_URLS);
 
+    echo "<a name=\"step" . $testStepResult->getStepNumber() . "\">";
     echo "<h1 class='stepName'>" . $testStepResult->readableIdentifier() . "</h1>";
+    echo "</a>";
 
     if ($fileHandler->dirExists($localPaths->videoDir())) {
         echo "<a href=\"" . $urlGenerator->createVideo() . "\">Create Video</a> &#8226; ";

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -116,6 +116,8 @@ function printContent($fileHandler, $testInfo, $testRunResults) {
     $urlPaths = $testStepResult->createTestPaths(substr($testInfo->getRootDirectory(), 1));
     $urlGenerator = $testStepResult->createUrlGenerator("", FRIENDLY_URLS);
 
+    echo "<h1 class='stepName'>" . $testStepResult->readableIdentifier() . "</h1>";
+
     if ($fileHandler->dirExists($localPaths->videoDir())) {
         echo "<a href=\"" . $urlGenerator->createVideo() . "\">Create Video</a> &#8226; ";
         echo "<a href=\"" . $urlGenerator->downloadVideoFrames() . "\">Download Video Frames</a>";
@@ -128,7 +130,7 @@ function printContent($fileHandler, $testInfo, $testRunResults) {
         $screenShotUrl = $urlPaths->screenShotFile();
     }
     if ($screenShotUrl) {
-        echo '<h1>Fully Loaded</h1>';
+        echo '<h2>Fully Loaded</h2>';
         echo '<a href="' . $screenShotUrl . '">';
         echo '<img class="center" alt="Screen Shot" style="max-width:930px; -ms-interpolation-mode: bicubic;" src="' . $screenShotUrl .'">';
         echo '</a>';
@@ -143,42 +145,42 @@ function printContent($fileHandler, $testInfo, $testRunResults) {
     }
 
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("render"))) {
-        echo '<br><br><a name="start_render"><h1>Start Render';
+        echo '<br><br><a name="start_render"><h2>Start Render';
         if (isset($pageRunData) && isset($pageRunData['render']))
             echo ' (' . number_format($pageRunData['render'] / 1000.0, 3) . '  sec)';
-        echo '</h1></a>';
+        echo '</h2></a>';
         echo '<img class="center" alt="Start Render Screen Shot" src="' . $urlPaths->additionalScreenShotFile("render") . '">';
     }
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("dom"))) {
-        echo '<br><br><a name="dom_element"><h1>DOM Element';
+        echo '<br><br><a name="dom_element"><h2>DOM Element';
         if (isset($pageRunData) && isset($pageRunData['domTime']))
             echo ' (' . number_format($pageRunData['domTime'] / 1000.0, 3) . '  sec)';
-        echo '</h1></a>';
+        echo '</h2></a>';
         echo '<img class="center" alt="DOM Element Screen Shot" src="' . $urlPaths->additionalScreenShotFile("dom") . '">';
     }
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("doc"))) {
-        echo '<br><br><a name="doc_complete"><h1>Document Complete';
+        echo '<br><br><a name="doc_complete"><h2>Document Complete';
         if (isset($pageRunData) && isset($pageRunData['docTime']))
             echo ' (' . number_format($pageRunData['docTime'] / 1000.0, 3) . '  sec)';
-        echo '</h1></a>';
+        echo '</h2></a>';
         echo '<img class="center" alt="Document Complete Screen Shot" src="' . $urlPaths->additionalScreenShotFile("doc") . '">';
     }
     if ($fileHandler->fileExists($localPaths->aftDiagnosticImageFile())) {
-        echo '<br><br><a name="aft"><h1>AFT Details';
+        echo '<br><br><a name="aft"><h2>AFT Details';
         if (isset($pageRunData) && isset($pageRunData['aft']))
             echo ' (' . number_format($pageRunData['aft'] / 1000.0, 3) . '  sec)';
-        echo '</h1></a>';
+        echo '</h2></a>';
         echo 'White = Stabilized Early, Blue = Dynamic, Red = Late Static (failed AFT), Green = AFT<br>';
         echo '<img class="center" alt="AFT Diagnostic image" src="' . $urlPaths->aftDiagnosticImageFile() . '">';
     }
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("responsive"))) {
-        echo '<br><br><h1 id="responsive">Responsive Site Check</h1>';
+        echo '<br><br><h2 id="responsive">Responsive Site Check</h2>';
         echo '<img class="center" alt="Responsive Site Check image" src="' . $urlPaths->additionalScreenShotFile("responsive") . '">';
     }
 
     // display all of the status messages
     if (count($messages)) {
-        echo "\n<br><br><a name=\"status_messages\"><h1>Status Messages</h1></a>\n";
+        echo "\n<br><br><a name=\"status_messages\"><h2>Status Messages</h2></a>\n";
         echo "<table id=\"messages\" class=\"translucent\"><tr><th>Time</th><th>Message</th></tr>\n";
         foreach ($messages as $message) {
             $time = $message['time'] / 1000.0;
@@ -192,7 +194,7 @@ function printContent($fileHandler, $testInfo, $testRunResults) {
     $row = 0;
     $console_log = $testStepResult->getConsoleLog();
     if (isset($console_log) && count($console_log)) {
-        echo "\n<br><br><a name=\"console-log\"><h1>Console Log</h1></a>\n";
+        echo "\n<br><br><a name=\"console-log\"><h2>Console Log</h2></a>\n";
         echo "<table id=\"console-log\" class=\"translucent\"><tr><th>Source</th><th>Level</th><th>Message</th><th>URL</th><th>Line</th></tr>\n";
         foreach ($console_log as &$log_entry) {
             $row++;

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -97,6 +97,14 @@ $userImages = true;
             </div>
 
             <?php include('footer.inc'); ?>
+            <?php
+            if (!empty($hasJquery) && is_file('./js/jk-navigation.js') && $testRunResults->countSteps() > 1) {
+                echo '<script type="text/javascript">';
+                include('./js/jk-navigation.js');
+                echo 'addJKNavigation("h1.stepName")';
+                echo '</script>';
+            }
+            ?>
         </div>
 	</body>
 </html>

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -109,17 +109,41 @@ $userImages = true;
  * @param TestRunResults $testRunResults The run results to be printed
  */
 function printContent($fileHandler, $testInfo, $testRunResults) {
-    for ($i = 1; $i <= $testRunResults->countSteps(); $i++) {
-        printStep($fileHandler, $testInfo, $testRunResults->getStepResult($i));
+    $numSteps = $testRunResults->countSteps();
+    $useQuicklinks = $numSteps > 1;
+    if ($useQuicklinks) {
+        printQuicklinks($testRunResults);
     }
+    for ($i = 1; $i <= $numSteps; $i++) {
+        printStep($fileHandler, $testInfo, $testRunResults->getStepResult($i), $useQuicklinks);
+    }
+}
+
+/**
+ * @param TestRunResults $testRunResults The run results to generate quicklinks for
+ */
+function printQuicklinks($testRunResults) {
+    echo '<a name="quicklinks"><h1>Quicklinks</h1></a>';
+    echo '<div style="text-align: center;"><table class="pretty">';
+    echo '<thead><tr><th>Step Name</th><th>Screen Shots</th></tr></thead>';
+    echo '<tbody>';
+    for ($i = 1; $i <= $testRunResults->countSteps(); $i++) {
+        echo '<tr>';
+        echo '<td>' . $testRunResults->getStepResult($i)->readableIdentifier() . '</td>';
+        echo '<td><a href="#step_' . $i . '">Screen Shots (Step ' . $i . ')</a></td>';
+        echo '</tr>';
+    }
+    echo '</tbody>';
+    echo "</table></div>";
 }
 
 /**
  * @param FileHandler $fileHandler FileHandler to use
  * @param TestInfo $testInfo Information about the test
  * @param TestStepResult $testStepResult Results of the specific test
+ * @param bool $useQuicklinks True if quicklinks are used, false otherwise
  */
-function printStep($fileHandler, $testInfo, $testStepResult) {
+function printStep($fileHandler, $testInfo, $testStepResult, $useQuicklinks) {
     $pageRunData = $testStepResult->getRawResults();
 
     $localPaths = $testStepResult->createTestPaths();
@@ -133,6 +157,12 @@ function printStep($fileHandler, $testInfo, $testStepResult) {
     if ($fileHandler->dirExists($localPaths->videoDir())) {
         echo "<a href=\"" . $urlGenerator->createVideo() . "\">Create Video</a> &#8226; ";
         echo "<a href=\"" . $urlGenerator->downloadVideoFrames() . "\">Download Video Frames</a>";
+        if ($useQuicklinks) {
+            echo " &#8226; ";
+        }
+    }
+    if ($useQuicklinks) {
+        echo '<a href="#quicklinks">Back to Quicklinks</a>';
     }
 
     $screenShotUrl = null;

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -90,106 +90,8 @@ $userImages = true;
             $tab = 'Test Result';
             $subtab = 'Screen Shot';
             include 'header.inc';
-            ?>
-            <?php
-                if( is_dir("./$videoPath") )
-                {
-                    $createPath = "/video/create.php?tests=$id-r:$run-c:$cached&id={$id}.{$run}.{$cached}";
-                    echo "<a href=\"$createPath\">Create Video</a> &#8226; ";
-                    echo "<a href=\"/video/downloadFrames.php?test=$id&run=$run&cached=$cached\">Download Video Frames</a>";
-                }
-                    
-                if($cached == 1)
-                    $cachedText='_Cached';
-                if( is_file($testPath . '/' . $run . $cachedText . '_screen.png') )
-                {
-                    echo '<h1>Fully Loaded</h1>';
-                    echo '<a href="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.png">';
-                    echo '<img class="center" alt="Screen Shot" style="max-width:930px; -ms-interpolation-mode: bicubic;" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.png">';
-                    echo '</a>';
-                }
-                elseif( is_file($testPath . '/' . $run . $cachedText . '_screen.jpg') )
-                {
-                    echo '<h1>Fully Loaded</h1>';
-		            echo '<a href="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.jpg">';
-                    echo '<img class="center" alt="Screen Shot" style="max-width:930px; -ms-interpolation-mode: bicubic;" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.jpg">';
-                    echo '</a>';
-                }
-                // display the last status message if we have one
-                if( count($messages) )
-                {
-                    $lastMessage = end($messages);
-                    if( strlen($lastMessage['message']) )
-                        echo "\n<br>Last Status Message: \"{$lastMessage['message']}\"\n";
-                }
-                
-                if( is_file($testPath . '/' . $run . $cachedText . '_screen_render.jpg') )
-                {
-                    echo '<br><br><a name="start_render"><h1>Start Render';
-                    if( isset($pageRunData) && isset($pageRunData['render']) )
-                        echo ' (' . number_format($pageRunData['render'] / 1000.0, 3) . '  sec)';
-                    echo '</h1></a>';
-                    echo '<img class="center" alt="Start Render Screen Shot" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_render.jpg">';
-                }
-                if( is_file($testPath . '/' . $run . $cachedText . '_screen_dom.jpg') )
-                {
-                    echo '<br><br><a name="dom_element"><h1>DOM Element';
-                    if( isset($pageRunData) && isset($pageRunData['domTime']) )
-                        echo ' (' . number_format($pageRunData['domTime'] / 1000.0, 3) . '  sec)';
-                    echo '</h1></a>';
-                    echo '<img class="center" alt="DOM Element Screen Shot" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_dom.jpg">';
-                }
-                if( is_file($testPath . '/' . $run . $cachedText . '_screen_doc.jpg') )
-                {
-                    echo '<br><br><a name="doc_complete"><h1>Document Complete';
-                    if( isset($pageRunData) && isset($pageRunData['docTime']) )
-                        echo ' (' . number_format($pageRunData['docTime'] / 1000.0, 3) . '  sec)';
-                    echo '</h1></a>';
-                    echo '<img class="center" alt="Document Complete Screen Shot" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_doc.jpg">';
-                }
-                if( is_file($testPath . '/' . $run . $cachedText . '_aft.png') )
-                {
-                    echo '<br><br><a name="aft"><h1>AFT Details';
-                    if( isset($pageRunData) && isset($pageRunData['aft']) )
-                        echo ' (' . number_format($pageRunData['aft'] / 1000.0, 3) . '  sec)';
-                    echo '</h1></a>';
-                    echo 'White = Stabilized Early, Blue = Dynamic, Red = Late Static (failed AFT), Green = AFT<br>';
-                    echo '<img class="center" alt="AFT Diagnostic image" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_aft.png">';
-                }
-                if( is_file($testPath . '/' . $run . $cachedText . '_screen_responsive.jpg') )
-                {
-                    echo '<br><br><h1 id="responsive">Responsive Site Check</h1>';
-                    echo '<img class="center" alt="Responsive Site Check image" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_responsive.jpg">';
-                }
-                
-                // display all of the status messages
-                if( count($messages) )
-                {
-                    echo "\n<br><br><a name=\"status_messages\"><h1>Status Messages</h1></a>\n";
-                    echo "<table id=\"messages\" class=\"translucent\"><tr><th>Time</th><th>Message</th></tr>\n";
-                    foreach( $messages as $message )
-                        echo "<tr><td class=\"time\">{$message['time']} sec.</td><td>{$message['message']}</td></tr>";
-                    echo "</table>\n";
-                }
-                
-                $row = 0;
-                if (isset($console_log) && count($console_log)) {
-                    echo "\n<br><br><a name=\"console-log\"><h1>Console Log</h1></a>\n";
-                    echo "<table id=\"console-log\" class=\"translucent\"><tr><th>Source</th><th>Level</th><th>Message</th><th>URL</th><th>Line</th></tr>\n";
-                    foreach( $console_log as &$log_entry ) {
-                        $row++;
-                        $rowClass = '';
-                        if ($row % 2 == 0)
-                            $rowClass = ' class="even"';
-                        echo "<tr$rowClass><td class=\"source\">" . htmlspecialchars($log_entry['source']) .
-                             "</td><td class=\"level\">" . htmlspecialchars($log_entry['level']) .
-                             "</td><td class=\"message\"><div>" . htmlspecialchars($log_entry['text']) . 
-                             "</div></td><td class=\"url\"><div><a href=\"" . htmlspecialchars($log_entry['url']) . 
-                             "\">" . htmlspecialchars($log_entry['url']) .
-                             "</a></div></td><td class=\"line\">" . htmlspecialchars($log_entry['line']) . "</td></tr>\n";
-                    }
-                    echo "</table>\n";
-                }
+
+            printContent($videoPath, $id, $run, $cached, $testPath, $messages, $pageRunData, $console_log, $log_entry);
             ?>
             
             </div>
@@ -200,6 +102,108 @@ $userImages = true;
 </html>
 
 <?php
+/**
+ * @param $videoPath
+ * @param $id
+ * @param $run
+ * @param $cached
+ * @param $testPath
+ * @param $messages
+ * @param $pageRunData
+ * @param $console_log
+ * @param $log_entry
+ * @return mixed
+ */
+function printContent($videoPath, $id, $run, $cached, $testPath, $messages, $pageRunData, $console_log, $log_entry) {
+    if (is_dir("./$videoPath")) {
+        $createPath = "/video/create.php?tests=$id-r:$run-c:$cached&id={$id}.{$run}.{$cached}";
+        echo "<a href=\"$createPath\">Create Video</a> &#8226; ";
+        echo "<a href=\"/video/downloadFrames.php?test=$id&run=$run&cached=$cached\">Download Video Frames</a>";
+    }
+
+    if ($cached == 1)
+        $cachedText = '_Cached';
+    if (is_file($testPath . '/' . $run . $cachedText . '_screen.png')) {
+        echo '<h1>Fully Loaded</h1>';
+        echo '<a href="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.png">';
+        echo '<img class="center" alt="Screen Shot" style="max-width:930px; -ms-interpolation-mode: bicubic;" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.png">';
+        echo '</a>';
+    } elseif (is_file($testPath . '/' . $run . $cachedText . '_screen.jpg')) {
+        echo '<h1>Fully Loaded</h1>';
+        echo '<a href="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.jpg">';
+        echo '<img class="center" alt="Screen Shot" style="max-width:930px; -ms-interpolation-mode: bicubic;" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen.jpg">';
+        echo '</a>';
+    }
+    // display the last status message if we have one
+    if (count($messages)) {
+        $lastMessage = end($messages);
+        if (strlen($lastMessage['message']))
+            echo "\n<br>Last Status Message: \"{$lastMessage['message']}\"\n";
+    }
+
+    if (is_file($testPath . '/' . $run . $cachedText . '_screen_render.jpg')) {
+        echo '<br><br><a name="start_render"><h1>Start Render';
+        if (isset($pageRunData) && isset($pageRunData['render']))
+            echo ' (' . number_format($pageRunData['render'] / 1000.0, 3) . '  sec)';
+        echo '</h1></a>';
+        echo '<img class="center" alt="Start Render Screen Shot" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_render.jpg">';
+    }
+    if (is_file($testPath . '/' . $run . $cachedText . '_screen_dom.jpg')) {
+        echo '<br><br><a name="dom_element"><h1>DOM Element';
+        if (isset($pageRunData) && isset($pageRunData['domTime']))
+            echo ' (' . number_format($pageRunData['domTime'] / 1000.0, 3) . '  sec)';
+        echo '</h1></a>';
+        echo '<img class="center" alt="DOM Element Screen Shot" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_dom.jpg">';
+    }
+    if (is_file($testPath . '/' . $run . $cachedText . '_screen_doc.jpg')) {
+        echo '<br><br><a name="doc_complete"><h1>Document Complete';
+        if (isset($pageRunData) && isset($pageRunData['docTime']))
+            echo ' (' . number_format($pageRunData['docTime'] / 1000.0, 3) . '  sec)';
+        echo '</h1></a>';
+        echo '<img class="center" alt="Document Complete Screen Shot" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_doc.jpg">';
+    }
+    if (is_file($testPath . '/' . $run . $cachedText . '_aft.png')) {
+        echo '<br><br><a name="aft"><h1>AFT Details';
+        if (isset($pageRunData) && isset($pageRunData['aft']))
+            echo ' (' . number_format($pageRunData['aft'] / 1000.0, 3) . '  sec)';
+        echo '</h1></a>';
+        echo 'White = Stabilized Early, Blue = Dynamic, Red = Late Static (failed AFT), Green = AFT<br>';
+        echo '<img class="center" alt="AFT Diagnostic image" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_aft.png">';
+    }
+    if (is_file($testPath . '/' . $run . $cachedText . '_screen_responsive.jpg')) {
+        echo '<br><br><h1 id="responsive">Responsive Site Check</h1>';
+        echo '<img class="center" alt="Responsive Site Check image" src="' . substr($testPath, 1) . '/' . $run . $cachedText . '_screen_responsive.jpg">';
+    }
+
+    // display all of the status messages
+    if (count($messages)) {
+        echo "\n<br><br><a name=\"status_messages\"><h1>Status Messages</h1></a>\n";
+        echo "<table id=\"messages\" class=\"translucent\"><tr><th>Time</th><th>Message</th></tr>\n";
+        foreach ($messages as $message)
+            echo "<tr><td class=\"time\">{$message['time']} sec.</td><td>{$message['message']}</td></tr>";
+        echo "</table>\n";
+    }
+
+    $row = 0;
+    if (isset($console_log) && count($console_log)) {
+        echo "\n<br><br><a name=\"console-log\"><h1>Console Log</h1></a>\n";
+        echo "<table id=\"console-log\" class=\"translucent\"><tr><th>Source</th><th>Level</th><th>Message</th><th>URL</th><th>Line</th></tr>\n";
+        foreach ($console_log as &$log_entry) {
+            $row++;
+            $rowClass = '';
+            if ($row % 2 == 0)
+                $rowClass = ' class="even"';
+            echo "<tr$rowClass><td class=\"source\">" . htmlspecialchars($log_entry['source']) .
+              "</td><td class=\"level\">" . htmlspecialchars($log_entry['level']) .
+              "</td><td class=\"message\"><div>" . htmlspecialchars($log_entry['text']) .
+              "</div></td><td class=\"url\"><div><a href=\"" . htmlspecialchars($log_entry['url']) .
+              "\">" . htmlspecialchars($log_entry['url']) .
+              "</a></div></td><td class=\"line\">" . htmlspecialchars($log_entry['line']) . "</td></tr>\n";
+        }
+        echo "</table>\n";
+    }
+}
+
 /**
 * Load the status messages into an array
 * 

--- a/www/tests/TestInfoTest.php
+++ b/www/tests/TestInfoTest.php
@@ -58,4 +58,13 @@ class TestInfoTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("Firefox, Internet Explorer and Chrome - <b>Chrome</b> - <b>Cable</b>", $testInfo->getTestLocation());
     $this->assertEquals("ITERAHH-VBOX-01-192.168.188.112", $testInfo->getTester(1));
   }
+
+  public function testIsAdultSite() {
+    $testInfo = TestInfo::fromValues("test", "/test/root", array("testinfo" => array("url" => "http://adultsite.com/test")));
+    $this->assertTrue($testInfo->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($testInfo->isAdultSite(array("bar", "foo")));
+    $testInfo = TestInfo::fromValues("test", "/test/root", array("testinfo" => array("url" => "http://anysite.com/test")));
+    $this->assertFalse($testInfo->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($testInfo->isAdultSite(array("bar", "foo")));
+  }
 }

--- a/www/tests/TestResultsTest.php
+++ b/www/tests/TestResultsTest.php
@@ -6,12 +6,12 @@ require_once __DIR__ . '/../include/TestResults.php';
 class TestResultsTest extends PHPUnit_Framework_TestCase {
 
   public function testCountRuns() {
-    $results = $this->testResultsFromPageData();
+    $results = $this->getTestResultsFromPageData();
     $this->assertEquals(4, $results->countRuns());
   }
 
   public function testGetMedianRunNumber() {
-    $results = $this->testResultsFromPageData();
+    $results = $this->getTestResultsFromPageData();
 
     $this->assertEquals(3, $results->getMedianRunNumber("loadTime", false));
     $this->assertEquals(1, $results->getMedianRunNumber("TTFB", false));
@@ -20,7 +20,7 @@ class TestResultsTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testGetMedianRunNumberFastestMode() {
-    $results = $this->testResultsFromPageData();
+    $results = $this->getTestResultsFromPageData();
 
     $this->assertEquals(4, $results->getMedianRunNumber("loadTime", false, "fastest"));
     $this->assertEquals(3, $results->getMedianRunNumber("TTFB", false, "fastest"));
@@ -30,7 +30,7 @@ class TestResultsTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testGetFirstViewAverage() {
-    $results = $this->testResultsFromPageData();
+    $results = $this->getTestResultsFromPageData();
     $fvAverages = $results->getFirstViewAverage();
     $this->assertEquals(300, $fvAverages["TTFB"]);
     $this->assertEquals(3000, $fvAverages["loadTime"]);
@@ -38,7 +38,7 @@ class TestResultsTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testGetRepeatViewAverage() {
-    $results = $this->testResultsFromPageData();
+    $results = $this->getTestResultsFromPageData();
     $fvAverages = $results->getRepeatViewAverage();
     $this->assertEquals(400, $fvAverages["TTFB"]);
     $this->assertEquals(4000, $fvAverages["loadTime"]);
@@ -46,7 +46,7 @@ class TestResultsTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testGetStandardDeviation() {
-    $results = $this->testResultsFromPageData();
+    $results = $this->getTestResultsFromPageData();
 
     $this->assertEquals(2160, $results->getStandardDeviation("loadTime", false));
     $this->assertEquals(163, $results->getStandardDeviation("TTFB", false));
@@ -69,7 +69,7 @@ class TestResultsTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($results->isAdultSite(array("foo", "bar")));
   }
 
-  public function testResultsFromPageData() {
+  private function getTestResultsFromPageData() {
     $run1 = array('result' => 0, 'TTFB' => 300, 'loadTime' => 6000);
     $run2 = array('result' => 404, 'TTFB' => 200, 'loadTime' => 3000);
     $run3 = array('result' => 0, 'TTFB' => 100, 'loadTime' => 2000);

--- a/www/tests/TestResultsTest.php
+++ b/www/tests/TestResultsTest.php
@@ -54,6 +54,21 @@ class TestResultsTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals(81, $results->getStandardDeviation("TTFB", true));
   }
 
+  public function testIsAdultSite() {
+    $pageData = array(
+      1 => array(array("title" => "normalPage")),
+      2 => array(array("title" => "aduLtpage"))
+    );
+    $results = TestResults::fromPageData(TestInfo::fromValues("testId", "/test/path" , array()), $pageData);
+    $this->assertTrue($results->isAdultSite(array("foo", "adult")));
+    $this->assertFalse($results->isAdultSite(array("foo", "bar")));
+
+    $testInfo = TestInfo::fromValues("testId", "/test/path", array("testinfo" => array("url" => "adultSite")));
+    $results = TestResults::fromPageData($testInfo, array(1 => $pageData[1]));
+    $this->assertTrue($results->isAdultSite(array("foo", "adult")));
+    $this->assertFalse($results->isAdultSite(array("foo", "bar")));
+  }
+
   public function testResultsFromPageData() {
     $run1 = array('result' => 0, 'TTFB' => 300, 'loadTime' => 6000);
     $run2 = array('result' => 404, 'TTFB' => 200, 'loadTime' => 3000);

--- a/www/tests/TestRunResultsTest.php
+++ b/www/tests/TestRunResultsTest.php
@@ -101,6 +101,30 @@ class TestRunResultsTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($runResults->isAdultSite(array("bar", "foo")));
   }
 
+  public function testAggregatePageSpeedScore() {
+    $stepNoScore = $this->getMock("TestStepResult", array(), array(), "", false);
+    $stepNoScore->method('getPageSpeedScore')->willReturn(null);
+    $stepScore55 = $this->getMock("TestStepResult", array(), array(), "", false);
+    $stepScore55->method('getPageSpeedScore')->willReturn("55");
+    $stepScore40 = $this->getMock("TestStepResult", array(), array(), "", false);
+    $stepScore40->method('getPageSpeedScore')->willReturn(40);
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepNoScore, $stepScore55, $stepScore40));
+    $this->assertEquals(48, $runResults->averagePageSpeedScore());
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepNoScore, $stepNoScore, $stepNoScore));
+    $this->assertEquals(null, $runResults->averagePageSpeedScore());
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepNoScore, $stepScore55, $stepNoScore));
+    $this->assertEquals(55, $runResults->averagePageSpeedScore());
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepScore40, $stepScore40, $stepScore40));
+    $this->assertEquals(40, $runResults->averagePageSpeedScore());
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepScore40, $stepScore40, $stepScore55));
+    $this->assertEquals(45, $runResults->averagePageSpeedScore());
+  }
+
   private function getTestStepArray() {
     $step1 = array('result' => 0, 'TTFB' => 300, 'loadTime' => 6000);
     $step2 = array('result' => 0, 'TTFB' => 100, 'loadTime' => 2000);

--- a/www/tests/TestRunResultsTest.php
+++ b/www/tests/TestRunResultsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../include/FileHandler.php';
 require_once __DIR__ . '/../include/TestRunResults.php';
 require_once __DIR__ . '/../include/TestInfo.php';
 require_once __DIR__ . '/../include/TestStepResult.php';
@@ -160,6 +161,19 @@ class TestRunResultsTest extends PHPUnit_Framework_TestCase {
 
     $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array_slice($steps, 0, 1));
     $this->assertNull($runResults->averageMetric("myMetric"));
+  }
+
+  public function testHasBreakdownTimeline() {
+    $stepNoTimeline = $this->getMock("TestStepResult", array(), array(), "", false);
+    $stepNoTimeline->method('hasBreakdownTimeline')->willReturn(false);
+    $stepWithTimeline = $this->getMock("TestStepResult", array(), array(), "", false);
+    $stepWithTimeline->method('hasBreakdownTimeline')->willReturn(true);
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepNoTimeline, $stepWithTimeline));
+    $this->assertTrue($runResults->hasBreakdownTimeline());
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepNoTimeline, $stepNoTimeline));
+    $this->assertFalse($runResults->hasBreakdownTimeline());
   }
 
   private function getTestStepArray() {

--- a/www/tests/TestRunResultsTest.php
+++ b/www/tests/TestRunResultsTest.php
@@ -79,6 +79,28 @@ class TestRunResultsTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($this->getTestRunResultsWithInvalid()->isSuccessful());
   }
 
+  public function testIsAdultSite() {
+    $stepAdult = TestStepResult::fromPageData($this->testInfo, array("title" => "myadUltPage"), 2, false, 1);
+    $stepNonAdult = TestStepResult::fromPageData($this->testInfo, array("title" => "normalSite"), 2, false, 2);
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepAdult, $stepNonAdult));
+    $this->assertTrue($runResults->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($runResults->isAdultSite(array("bar", "foo")));
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepNonAdult, $stepNonAdult));
+    $this->assertFalse($runResults->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($runResults->isAdultSite(array("bar", "foo")));
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array($stepNonAdult, $stepNonAdult));
+    $this->assertFalse($runResults->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($runResults->isAdultSite(array("bar", "foo")));
+
+    $testInfo = TestInfo::fromValues("testId", "/test/path", array("testinfo" => array("url" => "adultSite")));
+    $runResults = TestRunResults::fromStepResults($testInfo, 2, false, array($stepNonAdult, $stepNonAdult));
+    $this->assertTrue($runResults->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($runResults->isAdultSite(array("bar", "foo")));
+  }
+
   private function getTestStepArray() {
     $step1 = array('result' => 0, 'TTFB' => 300, 'loadTime' => 6000);
     $step2 = array('result' => 0, 'TTFB' => 100, 'loadTime' => 2000);

--- a/www/tests/TestRunResultsTest.php
+++ b/www/tests/TestRunResultsTest.php
@@ -135,6 +135,20 @@ class TestRunResultsTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("52.3", $runResults->getPageSpeedVersion());
   }
 
+  public function testIsOptimizationChecked() {
+    $steps = array(
+      TestStepResult::fromPageData($this->testInfo, array(), 2, false, 1),
+      TestStepResult::fromPageData($this->testInfo, array("optimization_checked" => null), 2, false, 2),
+      TestStepResult::fromPageData($this->testInfo, array("optimization_checked" => "2222"), 2, false, 3),
+      TestStepResult::fromPageData($this->testInfo, array(), 2, false, 4)
+    );
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, $steps);
+    $this->assertTrue($runResults->isOptimizationChecked());
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array_slice($steps, 0, 2));
+    $this->assertFalse($runResults->isOptimizationChecked());
+  }
+
   public function testAverageMetric() {
     $steps = array(
       TestStepResult::fromPageData($this->testInfo, array(), 2, false, 1),

--- a/www/tests/TestRunResultsTest.php
+++ b/www/tests/TestRunResultsTest.php
@@ -135,6 +135,19 @@ class TestRunResultsTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("52.3", $runResults->getPageSpeedVersion());
   }
 
+  public function testAverageMetric() {
+    $steps = array(
+      TestStepResult::fromPageData($this->testInfo, array(), 2, false, 1),
+      TestStepResult::fromPageData($this->testInfo, array("myMetric" => "40"), 2, false, 2),
+      TestStepResult::fromPageData($this->testInfo, array("myMetric" => 53), 2, false, 3),
+    );
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, $steps);
+    $this->assertEquals(46.5, $runResults->averageMetric("myMetric"));
+
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, array_slice($steps, 0, 1));
+    $this->assertNull($runResults->averageMetric("myMetric"));
+  }
+
   private function getTestStepArray() {
     $step1 = array('result' => 0, 'TTFB' => 300, 'loadTime' => 6000);
     $step2 = array('result' => 0, 'TTFB' => 100, 'loadTime' => 2000);

--- a/www/tests/TestRunResultsTest.php
+++ b/www/tests/TestRunResultsTest.php
@@ -125,6 +125,16 @@ class TestRunResultsTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals(45, $runResults->averagePageSpeedScore());
   }
 
+  public function testGetPageSpeedVersion() {
+    $steps = array(
+      TestStepResult::fromPageData($this->testInfo, array(), 2, false, 1),
+      TestStepResult::fromPageData($this->testInfo, array("pageSpeedVersion" => "52.3"), 2, false, 2),
+      TestStepResult::fromPageData($this->testInfo, array("pageSpeedVersion" => "2222"), 2, false, 3),
+    );
+    $runResults = TestRunResults::fromStepResults($this->testInfo, 2, false, $steps);
+    $this->assertEquals("52.3", $runResults->getPageSpeedVersion());
+  }
+
   private function getTestStepArray() {
     $step1 = array('result' => 0, 'TTFB' => 300, 'loadTime' => 6000);
     $step2 = array('result' => 0, 'TTFB' => 100, 'loadTime' => 2000);

--- a/www/tests/TestStepResultTest.php
+++ b/www/tests/TestStepResultTest.php
@@ -79,4 +79,26 @@ class TestStepResultTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue($step->isAdultSite(array("adult", "foo")));
     $this->assertTrue($step->isAdultSite(array("bar", "foo")));
   }
+
+  public function testHsBreakdownTimeline() {
+    $fileHandlerExists = $this->getMock("FileHandler");
+    $fileHandlerExists->method("gzFileExists")->willReturn(true);
+    $fileHandlerDoesntExists = $this->getMock("FileHandler");
+    $fileHandlerDoesntExists->method("gzFileExists")->willReturn(false);
+
+    $testInfoWithTimeline = TestInfo::fromValues("testId", "/root/path", array("testinfo" => array("timeline" => "1")));
+    $testInfoWithoutTimeline = TestInfo::fromValues("testId", "/root/path", array("testinfo" => array()));
+
+    $step = TestStepResult::fromPageData($testInfoWithTimeline, array(), 1, 1, 1, $fileHandlerExists);
+    $this->assertTrue($step->hasBreakdownTimeline());
+
+    $step = TestStepResult::fromPageData($testInfoWithTimeline, array(), 1, 1, 1, $fileHandlerDoesntExists);
+    $this->assertFalse($step->hasBreakdownTimeline());
+
+    $step = TestStepResult::fromPageData($testInfoWithoutTimeline, array(), 1, 1, 1, $fileHandlerExists);
+    $this->assertFalse($step->hasBreakdownTimeline());
+
+    $step = TestStepResult::fromPageData($testInfoWithoutTimeline, array(), 1, 1, 1, $fileHandlerDoesntExists);
+    $this->assertFalse($step->hasBreakdownTimeline());
+  }
 }

--- a/www/tests/TestStepResultTest.php
+++ b/www/tests/TestStepResultTest.php
@@ -52,4 +52,31 @@ class TestStepResultTest extends PHPUnit_Framework_TestCase {
     $step = TestStepResult::fromPageData($testInfo, array("eventName" => "Step 1", "URL" => ""), 1, 1, 1);
     $this->assertEquals("Step 1", $step->readableIdentifier(""));
   }
+
+  public function testIsAdultSite() {
+    // testInfo matches
+    $testInfo = TestInfo::fromValues("testId", "/root/path", array("testinfo" => array("url" => "http://adultsite.com")));
+    $step = TestStepResult::fromPageData($testInfo, array("title" => "testEvent", "URL" => "testUrl"), 1, 1, 1);
+    $this->assertTrue($step->isAdultSite(array("adult", "foo")));
+
+    // not an adult site
+    $testInfo = TestInfo::fromValues("testId", "/root/path", array());
+    $step = TestStepResult::fromPageData($testInfo, array("title" => "testEvent", "URL" => "testUrl"), 1, 1, 1);
+    $this->assertFalse($step->isAdultSite(array("adult", "foo")));
+
+    // title matches, adult_site = 0 is ignored
+    $step = TestStepResult::fromPageData($testInfo, array("title" => "the AdulT site", "URL" => "testUrl", "adult_site" => 0), 1, 1, 1);
+    $this->assertTrue($step->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($step->isAdultSite(array("bar", "foo")));
+
+    // URL matches
+    $step = TestStepResult::fromPageData($testInfo, array("title" => "testEvent", "URL" => "http://mysite.com/adults/"), 1, 1, 1);
+    $this->assertTrue($step->isAdultSite(array("adult", "foo")));
+    $this->assertFalse($step->isAdultSite(array("bar", "foo")));
+
+    // explicitly set
+    $step = TestStepResult::fromPageData($testInfo, array("adult_site" => 1), 1, 1, 1);
+    $this->assertTrue($step->isAdultSite(array("adult", "foo")));
+    $this->assertTrue($step->isAdultSite(array("bar", "foo")));
+  }
 }

--- a/www/tests/TestStepResultTest.php
+++ b/www/tests/TestStepResultTest.php
@@ -37,4 +37,19 @@ class TestStepResultTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("http://duckduckgo.com", $secondStep->getUrl());
     $this->assertEquals("http://duckduckgo.com", $secondStep->readableIdentifier());
   }
+
+  public function testReadableIdentifier() {
+    $testInfo = TestInfo::fromValues("testId", "/root/path", array());
+    $step = TestStepResult::fromPageData($testInfo, array("eventName" => "testEvent", "URL" => "testUrl"), 1, 1, 1);
+    $this->assertEquals("testEvent", $step->readableIdentifier("default"));
+
+    $step = TestStepResult::fromPageData($testInfo, array("eventName" => "Step 1", "URL" => "testUrl"), 1, 1, 1);
+    $this->assertEquals("testUrl", $step->readableIdentifier("default"));
+
+    $step = TestStepResult::fromPageData($testInfo, array("eventName" => "Step 1", "URL" => ""), 1, 1, 1);
+    $this->assertEquals("default", $step->readableIdentifier("default"));
+
+    $step = TestStepResult::fromPageData($testInfo, array("eventName" => "Step 1", "URL" => ""), 1, 1, 1);
+    $this->assertEquals("Step 1", $step->readableIdentifier(""));
+  }
 }

--- a/www/tests/UrlGeneratorTest.php
+++ b/www/tests/UrlGeneratorTest.php
@@ -45,6 +45,8 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
     $ug = UrlGenerator::create(false, "https://test/", "qwerty", 3, true);
     $this->assertEquals($expectedCached, $ug->resultPage("details"));
+
+    $this->assertEquals($expectedCached . "&param=value", $ug->resultPage("details", "param=value"));
   }
 
   public function testResultPageStandardUrlWithStep() {
@@ -56,6 +58,8 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
     $ug = UrlGenerator::create(false, "https://test/", "qwerty", 3, true, 2);
     $this->assertEquals($expectedCached, $ug->resultPage("details"));
+
+    $this->assertEquals($expectedCached . "&param=value", $ug->resultPage("details", "param=value"));
   }
 
   public function testResultPageFriendlyUrl() {
@@ -67,6 +71,8 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
     $ug = UrlGenerator::create(true, "https://test/", "qwerty", 3, true);
     $this->assertEquals($expectedCached, $ug->resultPage("details"));
+
+    $this->assertEquals($expectedCached . "?param=value", $ug->resultPage("details", "param=value"));
   }
 
   public function testResultPageFriendlyUrlWithStep() {
@@ -78,6 +84,8 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
     $ug = UrlGenerator::create(true, "https://test/", "qwerty", 3, true, 2);
     $this->assertEquals($expectedCached, $ug->resultPage("details"));
+
+    $this->assertEquals($expectedCached . "?param=value", $ug->resultPage("details", "param=value"));
   }
 
   public function testThumbStandardUrl() {
@@ -161,12 +169,14 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $expected = "https://test/result/160609_a7_b8/";
     $ug = UrlGenerator::create(true, "https://test/", "160609_a7_b8", 3, true, 2);
     $this->assertEquals($expected, $ug->resultSummary());
+    $this->assertEquals($expected . "?param=value", $ug->resultSummary("param=value"));
   }
 
   public function testResultSummaryStandardUrl() {
     $expected = "https://test/results.php?test=160609_a7_b8";
     $ug = UrlGenerator::create(false, "https://test/", "160609_a7_b8", 3, true, 2);
     $this->assertEquals($expected, $ug->resultSummary());
+    $this->assertEquals($expected . "&param=value", $ug->resultSummary("param=value"));
   }
 
   public function testGetGZipUrl() {

--- a/www/tests/UrlGeneratorTest.php
+++ b/www/tests/UrlGeneratorTest.php
@@ -180,4 +180,22 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $ug = UrlGenerator::create(true, "https://test/", "160609_a7_b8", 3, true);
     $this->assertEquals($expected, $ug->getGZip("foobar.txt.gz"));
   }
+
+  public function testCreateVideoUrl() {
+    $expected = "https://test/video/create.php?tests=160609_a7_b8-r:3-c:1&id=160609_a7_b8.3.1";
+    $ug = UrlGenerator::create(false, "https://test/", "160609_a7_b8", 3, true, 1);
+    $this->assertEquals($expected, $ug->createVideo());
+  }
+
+  public function testCreateVideoUrlMultistep() {
+    $expected = "https://test/video/create.php?tests=160609_a7_b8-r:3-c:1-s:2&id=160609_a7_b8.3.1.2";
+    $ug = UrlGenerator::create(false, "https://test/", "160609_a7_b8", 3, true, 2);
+    $this->assertEquals($expected, $ug->createVideo());
+  }
+
+  public function testDownloadVideoFrames() {
+    $expected = "https://test/video/downloadFrames.php?test=160609_a7_b8&run=3&cached=1&step=2";
+    $ug = UrlGenerator::create(false, "https://test/", "160609_a7_b8", 3, true, 2);
+    $this->assertEquals($expected, $ug->downloadVideoFrames());
+  }
 }


### PR DESCRIPTION
First multistep changes for the UI as discussed in #653.
Screenshots/console log/status log of all pages are shown, grouped by step.
A quciklink table and navigation with `j` and `k` keys make it possible to navigate through the steps.

Also the header (used in all pages) was updated. Adult site detection, grades and the shown URL are now based on all steps, not only on the first. The grades are averages of all steps.

(Part of multistep implementation as discussion in #618.)