### PR TITLE
AppVeyor configuration with builds for 32bit and 64bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 2.19.{build}
+configuration: Release
+shallow_clone: true
+environment:
+  matrix:
+  - DUMMYNETARCH: 32bit
+  - DUMMYNETARCH: 64bit
+build:
+  project: webpagetest.sln
+  verbosity: normal
+after_build:
+- ps: >-
+    Rename-Item $Env:CONFIGURATION wptdriver
+
+    Copy-Item -r dist\webpagetest\agent\dummynet\$env:DUMMYNETARCH wptdriver\dummynet
+
+    Copy-Item -r agent\browser\chrome\extension\release wptdriver\extension
+artifacts:
+- path: wptdriver


### PR DESCRIPTION
As proposed in #655.

The build matrix is set up to create two builds Release builds with dummynet for 32bit and 64bit.