### PR TITLE
Dockerfile and configs for a docker server image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,80 @@
+FROM php:5.6-apache
+MAINTAINER iteratec WPT Team <wpt@iteratec.de>
+
+ENV PATH=$PATH:/scripts
+
+RUN echo deb http://www.deb-multimedia.org jessie main non-free >> /etc/apt/sources.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -q -y --force-yes \
+    deb-multimedia-keyring \
+    imagemagick \
+    libjpeg-progs \
+    exiftool \
+    unzip \
+    wget \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng12-dev \
+    libcurl4-openssl-dev \
+    python \
+    python-pillow \
+    cron \
+    supervisor && \
+    \
+    DEBIAN_FRONTEND=noninteractive apt-get install -q -y --force-yes\
+    ffmpeg && \
+    apt-get clean && \
+    apt-get autoclean
+
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
+    docker-php-ext-install gd && \
+    docker-php-ext-install zip && \
+    docker-php-ext-install curl && \
+    a2enmod expires headers rewrite
+
+RUN apt-get install -y libmagickwand-6.q16-dev --no-install-recommends && \
+    ln -s /usr/lib/x86_64-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config /usr/bin && \
+    pecl install imagick && \
+    echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini
+
+COPY www /var/www/html
+
+RUN chown -R www-data:www-data /var/www/html && \
+    cd /var/www/html && \
+    chmod 0777 dat && \
+    chmod 0777 -R work && \
+    chmod 0777 logs && \
+    mkdir -p results && \
+    chmod 0777 -R results && \
+    \
+    cd /var/www/html/settings && \
+    mv settings.ini.sample settings.ini && \
+    mv connectivity.ini.sample connectivity.ini && \
+    \
+    mkdir -p /var/log/supervisor && \
+    mkdir -p /scripts/settings
+
+COPY docker/server/config/locations.ini /var/www/html/settings/locations.ini
+COPY docker/server/config/php.ini /usr/local/etc/php/
+COPY docker/server/config/apache2.conf /etc/apache2/apache2.conf
+COPY docker/server/config/crontab /etc/crontab
+
+# config supervisor
+COPY docker/server/config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY docker/server/config/supervisord/supervisord_apache.conf /etc/supervisor/conf.d/supervisord_apache.conf
+COPY docker/server/config/supervisord/supervisord_cron.conf /etc/supervisor/conf.d/supervisord_cron.conf
+
+# Copy scripts
+COPY docker/server/scripts/migrate-settings /scripts/migrate-settings
+COPY docker/server/scripts/start_archiving.sh /scripts/start_archiving.sh
+
+# Set execution bit
+RUN chmod +x /scripts/migrate-settings && \
+    chmod +x /scripts/start_archiving.sh
+
+VOLUME /var/www/html/settings
+VOLUME /var/www/html/results
+
+EXPOSE 80 443
+
+CMD ["/usr/bin/supervisord"]

--- a/docker/server/config/apache2.conf
+++ b/docker/server/config/apache2.conf
@@ -1,0 +1,66 @@
+# see http://sources.debian.net/src/apache2/2.4.10-1/debian/config-dir/apache2.conf
+
+ServerName localhost
+
+Mutex file:/var/lock/apache2 default
+PidFile /var/run/apache2/apache2.pid
+Timeout 300
+KeepAlive On
+MaxKeepAliveRequests 100
+KeepAliveTimeout 5
+User www-data
+Group www-data
+HostnameLookups Off
+ErrorLog /proc/self/fd/2
+LogLevel warn
+
+IncludeOptional mods-enabled/*.load
+IncludeOptional mods-enabled/*.conf
+
+# ports.conf
+Listen 80
+<IfModule ssl_module>
+	Listen 443
+</IfModule>
+<IfModule mod_gnutls.c>
+	Listen 443
+</IfModule>
+
+<Directory />
+	Options FollowSymLinks
+	AllowOverride None
+	Require all denied
+</Directory>
+
+<Directory /var/www/>
+	AllowOverride All
+	Require all granted
+</Directory>
+
+DocumentRoot /var/www/html
+
+AccessFileName .htaccess
+<FilesMatch "^\.ht">
+	Require all denied
+</FilesMatch>
+
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+CustomLog /proc/self/fd/1 combined
+
+<FilesMatch \.php$>
+	SetHandler application/x-httpd-php
+</FilesMatch>
+
+# Multiple DirectoryIndex directives within the same context will add
+# to the list of resources to look for rather than replace
+# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+DirectoryIndex disabled
+DirectoryIndex index.php index.html
+
+IncludeOptional conf-enabled/*.conf
+IncludeOptional sites-enabled/*.conf

--- a/docker/server/config/crontab
+++ b/docker/server/config/crontab
@@ -1,0 +1,8 @@
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7)  OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  *  command to be executed
+  0  0  *  *  *  /scripts/start_archiving.sh

--- a/docker/server/config/locations.ini
+++ b/docker/server/config/locations.ini
@@ -1,0 +1,78 @@
+[locations]
+1=Test_loc
+2=Public_Dulles
+3=Appurify
+default=Test_loc
+
+;
+; These are the top-level locations that are listed in the location dropdown
+; Each one points to one or more browser configurations
+;
+
+[Test_loc]
+1=IE
+2=Test
+label=Test Location
+group=Desktop
+
+[Public_Dulles]
+1=WPT_Dulles_IE8
+label="WebPagetest.org - Dulles, VA"
+group=Public
+
+;
+; Tese are the browser-specific configurations that match the configurations
+; defined in the top-level locations.  Each one of these MUST match the location
+; name configured on the test agent (urlblast.ini or wptdriver.ini)
+;
+
+[IE]
+browser=IE 8
+latency=0
+label="Test Location - IE 8"
+;browserExe=pagetest.exe
+;key=TestKey123
+
+;
+; For a wptdriver configuration (chrome, firefox), the browser labels here
+; MUST match the labels used in wptdriver.ini
+;
+
+[Test]
+browser=Chrome,Firefox
+label="Test Location"
+
+;
+; This is an exaple of a "remote" configuration where tests can be proxied to a remote
+; webpagetest instance.  The test will be run by the remote server but the results
+; will be downloaded to the local server and deleted from the remote agent
+;
+; Each location that you want to use from the remote server needs to be configured
+; individually on the local configuration (location names do not need to match)
+;
+; To use the public webpagetest.org instance you will need an API key
+;
+;
+[WPT_Dulles_IE8]
+browser=IE 8
+label="WebPagetest.org Dulles, VA - IE8"
+relayServer="http://www.webpagetest.org/"
+relayKey=<your API key>
+;relayLocation=Dulles_IE8
+;
+;
+; This is a special location for testing on Appurify mobile devices.
+; Appurify offers mobile device testing as a service.
+;
+[Appurify]
+1=Appurify_Mobile
+label="Appurify Mobile Testing"
+lat=35.682175
+lng=139.752731
+group=Mobile
+
+[Appurify_Mobile]
+type=Appurify
+label="Appurify Mobile"
+key=<API Key>
+secret=<API Secret>

--- a/docker/server/config/php.ini
+++ b/docker/server/config/php.ini
@@ -1,0 +1,3 @@
+upload_max_filesize = 20M
+post_max_size = 20M
+memory_limit = 512M

--- a/docker/server/config/supervisord.conf
+++ b/docker/server/config/supervisord.conf
@@ -1,0 +1,29 @@
+; supervisor config file
+
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+nodaemon=true
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/docker/server/config/supervisord/supervisord_apache.conf
+++ b/docker/server/config/supervisord/supervisord_apache.conf
@@ -1,0 +1,2 @@
+[program:apache]
+command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"

--- a/docker/server/config/supervisord/supervisord_cron.conf
+++ b/docker/server/config/supervisord/supervisord_cron.conf
@@ -1,0 +1,6 @@
+[program:cron]
+command = cron -f -L 15
+startsecs = 5
+stopwaitsecs = 3600
+stopasgroup = false
+killasgroup = true

--- a/docker/server/scripts/migrate-settings
+++ b/docker/server/scripts/migrate-settings
@@ -1,0 +1,16 @@
+#!/bin/bash
+settings_in=/scripts/settings/
+settings_out=/var/www/html/settings/
+
+if [[ ! -d $settings_in ]]; then
+    echo "$settings_in doesn't exist!"
+    exit
+fi
+
+if [[ ! -d $settings_out ]]; then
+    echo "$settings_out doesn't exist!"
+    exit
+fi
+
+find "$settings_in" -type f -exec cp {} $settings_out \;
+echo "Copying settings..."

--- a/docker/server/scripts/start_archiving.sh
+++ b/docker/server/scripts/start_archiving.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if (grep -Fxq "^archive_days=" /var/www/html/settings/settings.ini && grep -Fxq "^archive_dir=" /var/www/html/settings/settings.ini)
+  || grep -Fxq "^media_days=" /var/www/html/settings/settings.ini
+  || grep -Fxq "^clear_archive_days=" /var/www/html/settings/settings.ini
+  then
+  cd $serverDocRoot/cli/ && /usr/bin/php archive.php
+fi


### PR DESCRIPTION
What should we set as MAINTAINER? I will update the pull request accordingly.

Overview over the image:
* Based on official php 5.6 image
* Adds basic dependencies for image processing, git, cron
* Adds ffmpeg
* Installs php extensions
* Adds current `www` folder as http root folder
* Sets permissions
* Adds sample WPT configurations as configs
* Adds apache, cron, supervisord configurations
* Adds scripts to easily migrate settings and trigger archiving
* Adds volumes for settings and result data, so they can be mounted into the container
* Sets supervisord with cron and apache2 as entrypoint

With this file, dockerhub integration can easily be set up (see #661). But also a private CI server can use it to build images and push them somewhere.

Feel free to suggest improvements.