### PR TITLE
Add new Akamai domain for China CDN detection

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -13,6 +13,7 @@ CDN_PROVIDER cdnList[] = {
 	{".srip.net", _T("Akamai")},
 	{".akamaitechnologies.com", _T("Akamai")},
 	{".akamaitechnologies.fr", _T("Akamai")},
+	{".tl88.net", _T("Akamai China CDN")},
 	{".llnwd.net", _T("Limelight")},
 	{"edgecastcdn.net", _T("Edgecast")},
 	{".systemcdn.net", _T("Edgecast")},

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -63,6 +63,7 @@ CDN_PROVIDER cdnList[] = {
   {".srip.net", "Akamai"},
   {".akamaitechnologies.com", "Akamai"},
   {".akamaitechnologies.fr", "Akamai"},
+  {".tl88.net", "Akamai China CDN"},
   {".llnwd.net", "Limelight"},
   {"edgecastcdn.net", "Edgecast"},
   {".systemcdn.net", "Edgecast"},


### PR DESCRIPTION
Currently there is no detection of [Akamai's China CDN](https://www.akamai.com/de/de/multimedia/documents/product-brief/akamai-china-cdn-product-brief.pdf), which is an additional product by Akamai offering POPs in China. Here is it in use for www.akamai.com itself:

http://www.webpagetest.org/result/160718_V0_PPE/

```
$ dig +noall +answer www.akamai.com @61.155.18.36
www.akamai.com.		33	IN	CNAME	www.akamai.com.edgekey.net.
www.akamai.com.edgekey.net. 12277 IN	CNAME	www.akamai.com.edgekey.net.globalredir.akadns.net.
www.akamai.com.edgekey.net.globalredir.akadns.net. 3333	IN CNAME e1699.dscca.s.tl88.net.
e1699.dscca.s.tl88.net.	30	IN	A	23.38.178.195
```

I think it does make sense to not just add it as _Akamai_ but _Akamai China CDN_, since (a) the same differentiation is also used by Akamai and (b) the information to end up on a POP in China or not is very useful for performance investigations and considerations.