### PR TITLE
Multistep support for compare/filmstrip view and filmstrip/frame export

### DIFF
--- a/www/details.php
+++ b/www/details.php
@@ -271,8 +271,8 @@ $page_description = "Website performance test details$testLabel";
                         echo "<td><a href='#connection_view_$stepSuffix'>Connection View</a></td>";
                         echo "<td><a href='#request_details_$stepSuffix'>Request Details</a></td>";
                         echo "<td><a href='#request_headers_$stepSuffix'>Request Headers</a></td>";
-                        echo "<td><a href='" . $urlGenerator->resultPage("customWaterfall", "width=930") . "'>Customize Waterfall</a></td>";
-                        echo "<td><a href='" . $urlGenerator->resultPage("pageimages") . "'>All Images</a></td>";
+                        echo "<td><a href='" . $urlGenerator->stepDetailPage("customWaterfall", "width=930") . "'>Customize Waterfall</a></td>";
+                        echo "<td><a href='" . $urlGenerator->stepDetailPage("pageimages") . "'>All Images</a></td>";
                         echo "</tr>";
                     }
                     echo "</table>\n<br>\n";

--- a/www/header.inc
+++ b/www/header.inc
@@ -175,7 +175,7 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
               $urlGenerator = UrlGenerator::create(FRIENDLY_URLS, "", $id, $gradeRun, false);
               $pageSpeedScore = $gradeRunResults->averagePageSpeedScore();
               if ($pageSpeedScore !== null) {
-                $pageSpeedUrl = $urlGenerator->resultPage("pagespeed");
+                $pageSpeedUrl = $urlGenerator->stepDetailPage("pagespeed");
                 $pageSpeedVersion = $gradeRunResults->getPageSpeedVersion();
                 echo "<span id=\"headerPagespeedScore\"><a href=\"$pageSpeedUrl\">PageSpeed $pageSpeedVersion Score</a>: <b>$pageSpeedScore/100</b></span>";
               }

--- a/www/include/TestStepResult.php
+++ b/www/include/TestStepResult.php
@@ -185,12 +185,12 @@ class TestStepResult {
     return null;
   }
 
-  public function getVisualProgress() {
+  public function getVisualProgress($end = null) {
     // TODO: move implementation to this method
     if (!$this->fileHandler->dirExists($this->localPaths->videoDir())) {
       return array();
     }
-    return GetVisualProgressForStep($this->localPaths, $this->testInfo->isRunComplete($this->run), null, null,
+    return GetVisualProgressForStep($this->localPaths, $this->testInfo->isRunComplete($this->run), null, $end,
       $this->getStartOffset());
   }
 

--- a/www/include/UrlGenerator.php
+++ b/www/include/UrlGenerator.php
@@ -118,6 +118,16 @@ abstract class UrlGenerator {
   }
 
   /**
+   * @param string $frame The thumbnail name
+   * @param int $fit Maximum size of the thumbnail
+   * @return string The URL for a thumbnail of the video frame
+   */
+  public function videoFrameThumbnail($frame, $fit) {
+    $file = "video_" . rtrim(strtolower($this->underscorePrefix()), "_") . "/" . $frame;
+    return $this->baseUrl . "/thumbnail.php?test=" . $this->testId . "&fit=" . $fit . "&file=" . $file;
+  }
+
+  /**
    * @return string The generated URL to download all video frames
    */
   public function downloadVideoFrames() {

--- a/www/include/UrlGenerator.php
+++ b/www/include/UrlGenerator.php
@@ -134,6 +134,16 @@ abstract class UrlGenerator {
     return $this->baseUrl . "/video/downloadFrames.php?" . $this->urlParams();
   }
 
+  /**
+   * @param string $page Step-independent Result page to generate the URL for
+   * @param string $extraParams|null Extra parameters to append (without '?' or '&' at start)
+   * @return string The generated URL
+   */
+  public function stepDetailPage($page, $extraParams = null) {
+    $extraParams = $extraParams ? ("&" . $extraParams) : "";
+    return $this->baseUrl . "/" . $page . ".php?" . $this->urlParams() . $extraParams;
+  }
+
   protected function underscorePrefix() {
     $stepSuffix = $this->step > 1 ? ($this->step . "_") : "";
     return strval($this->run) . "_" . ($this->cached ? "Cached_" : "") . $stepSuffix;
@@ -151,9 +161,6 @@ class FriendlyUrlGenerator extends UrlGenerator {
     $url = $this->baseUrl . "/result/" . $this->testId . "/" . $this->run . "/" . $page . "/";
     if ($this->cached) {
       $url .= "cached/";
-    }
-    if ($this->step > 1) {
-      $url .= $this->step . "/";
     }
     if ($extraParams != null) {
       $url .= "?" . $extraParams;

--- a/www/include/WaterfallViewHtmlSnippet.php
+++ b/www/include/WaterfallViewHtmlSnippet.php
@@ -31,8 +31,8 @@ class WaterfallViewHtmlSnippet {
       '', $this->stepResult->getStepNumber());
 
     $urlGenerator = $this->stepResult->createUrlGenerator("", false);
-    $out .=  "<br><a href=\"" . $urlGenerator->resultPage("customWaterfall", "width=930") . "\">customize waterfall</a> &#8226; ";
-    $out .=  "<a id=\"view-images\" href=\"" . $urlGenerator->resultPage("pageimages") . "\">View all Images</a>";
+    $out .=  "<br><a href=\"" . $urlGenerator->stepDetailPage("customWaterfall", "width=930") . "\">customize waterfall</a> &#8226; ";
+    $out .=  "<a id=\"view-images\" href=\"" . $urlGenerator->stepDetailPage("pageimages") . "\">View all Images</a>";
     return $out;
   }
 

--- a/www/tests/UrlGeneratorTest.php
+++ b/www/tests/UrlGeneratorTest.php
@@ -221,4 +221,10 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expected, $ug->waterfallImage(true, 90, true));
   }
 
+  public function testVideoFramesThumbnail() {
+    $expected = "https://test/thumbnail.php?test=160609_a7_b8&fit=1234&file=video_3_cached_2/myframe.png";
+    $ug = UrlGenerator::create(false, "https://test/", "160609_a7_b8", 3, true, 2);
+    $this->assertEquals($expected, $ug->videoFrameThumbnail("myframe.png", 1234));
+  }
+
 }

--- a/www/tests/UrlGeneratorTest.php
+++ b/www/tests/UrlGeneratorTest.php
@@ -76,8 +76,9 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testResultPageFriendlyUrlWithStep() {
-    $expected = "https://test/result/qwerty/3/details/2/";
-    $expectedCached = "https://test/result/qwerty/3/details/cached/2/";
+    // step should actually be in the URL
+    $expected = "https://test/result/qwerty/3/details/";
+    $expectedCached = "https://test/result/qwerty/3/details/cached/";
 
     $ug = UrlGenerator::create(true, "https://test/", "qwerty", 3, false, 2);
     $this->assertEquals($expected, $ug->resultPage("details"));
@@ -86,6 +87,19 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expectedCached, $ug->resultPage("details"));
 
     $this->assertEquals($expectedCached . "?param=value", $ug->resultPage("details", "param=value"));
+  }
+
+  public function testStepDetailPage() {
+    $expected = "https://test/stepDetail.php?test=qwerty&run=3&step=2";
+    $expectedCached = "https://test/stepDetail.php?test=qwerty&run=3&cached=1&step=2";
+
+    $ug = UrlGenerator::create(false, "https://test/", "qwerty", 3, false, 2);
+    $this->assertEquals($expected, $ug->resultPage("stepDetail"));
+
+    $ug = UrlGenerator::create(false, "https://test/", "qwerty", 3, true, 2);
+    $this->assertEquals($expectedCached, $ug->resultPage("stepDetail"));
+
+    $this->assertEquals($expectedCached . "&param=value", $ug->resultPage("stepDetail", "param=value"));
   }
 
   public function testThumbStandardUrl() {

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -633,6 +633,8 @@ function ScreenShotTable()
             http://www.webpagetest.org/video/compare.php?tests=110606_MJ_RZEY-l:Original,110606_AE_RZN5-l:No+JS</li>
             <li><b>Compare First vs. Repeat view:</b>
             http://www.webpagetest.org/video/compare.php?tests=110606_MJ_RZEY, 110606_MJ_RZEY-c:1</li>
+            <li><b>Second step of first run vs. Second step of second run:</b>
+            http://www.webpagetest.org/video/compare.php?tests=110606_MJ_RZEY-r:1-s:2,110606_MJ_RZEY-r:2-s:2</li>
             <li><b>White background with black text:</b>
             http://www.webpagetest.org/video/compare.php?tests=110606_MJ_RZEY, 110606_MJ_RZEY-c:1&bg=ffffff&text=000000</li>
             </ul>

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -721,10 +721,9 @@ function DisplayGraphs() {
                         'render' => 'Time to Start Render',
                         'fullyLoadedCPUms' => 'CPU Busy Time');
     $progress_end = 0;
-    $testCount = count($tests);
     foreach($tests as &$test) {
-        $requests;
-        $test['breakdown'] = getBreakdown($test['id'], $test['path'], $test['run'], $test['cached'], $requests);
+        $hasStepResult = array_key_exists('stepResult', $test) && is_a($test['stepResult'], "TestStepResult");
+        $test['breakdown'] = $hasStepResult ? $test['stepResult']->getMimeTypeBreakdown() : array();
         if (array_key_exists('progress', $test['video'])
             && array_key_exists('frames', $test['video']['progress'])) {
             foreach ($test['video']['progress']['frames'] as $ms => &$data) {

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -26,6 +26,7 @@ if( !isset($_REQUEST['tests']) && isset($_REQUEST['t']) )
 }
 else
 {
+    require_once __DIR__ . '/../include/UrlGenerator.php';
     chdir('..');
     include 'common.inc';
     require_once('page_data.inc');
@@ -387,23 +388,13 @@ function ScreenShotTable()
             if( !strpos($test['name'], ' ') )
                 $break = ' style="word-break: break-all;"';
             echo "<tr width=10% height={$height}px ><td$break class=\"pagelinks\">";
-            $name = urlencode($test['name']);
-            $cached = 0;
-            if( $test['cached'] )
-                $cached = 1;
 
             // Print the index outside of the link tag
             echo $test['index'] . ': ';
 
             if (!defined('EMBED')) {
-                $cached = '';
-                if( $test['cached'] )
-                    $cached = 'cached/';
-                if( FRIENDLY_URLS )
-                    $href = "/result/{$test['id']}/{$test['run']}/details/$cached";
-                else
-                    $href = "/details.php?test={$test['id']}&run={$test['run']}&cached={$test['cached']}";
-
+                $urlGenerator = UrlGenerator::create(FRIENDLY_URLS, "", $test['id'], $test['run'], $test['cached'], $test['step']);
+                $href = $urlGenerator->resultPage("details");
                 echo "<a class=\"pagelink\" id=\"label_{$test['id']}\" href=\"$href\">" . WrapableString(htmlspecialchars($test['name'])) . '</a>';
             } else {
                 echo WrapableString(htmlspecialchars($test['name']));

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -458,6 +458,8 @@ function ScreenShotTable()
             $frameCount = 0;
             $progress = null;
             $ms = 0;
+            $localPaths = new TestPaths(GetTestPath($test['id']), $test['run'], $test['cached'], $test['step']);
+            $urlGenerator = UrlGenerator::create(false, "", $test['id'], $test['run'], $test['cached'], $test['step']);
             while( $ms < $filmstrip_end_time ) {
                 $ms = $frameCount * $interval;
                 // find the closest video frame <= the target time
@@ -477,11 +479,9 @@ function ScreenShotTable()
                     $lastThumb = $path;
 
                 echo '<td>';
+
                 if ($ms <= $testEnd) {
-                    $cached = '';
-                    if( $test['cached'] )
-                        $cached = '_cached';
-                    $imgPath = GetTestPath($test['id']) . "/video_{$test['run']}$cached/$path";
+                    $imgPath = $localPaths->videoDir() . "/" . $path;
                     echo "<a href=\"/$imgPath\">";
                     echo "<img title=\"" . htmlspecialchars($test['name']) . "\"";
                     $class = 'thumb';
@@ -494,7 +494,8 @@ function ScreenShotTable()
                     echo " width=\"$width\"";
                     if( $height )
                         echo " height=\"$height\"";
-                    echo " src=\"/thumbnail.php?test={$test['id']}&fit=$thumbSize&file=video_{$test['run']}$cached/$path\"></a>";
+                    $imgUrl = $urlGenerator->videoFrameThumbnail($path, $thumbSize);
+                    echo " src=\"$imgUrl\"></a>";
                     if (isset($progress))
                         echo "<br>$progress%";
                     $lastThumb = $path;

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -600,11 +600,11 @@ function ScreenShotTable()
         // display the waterfall if there is only one test
         $end_seconds = $filmstrip_end_time / 1000;
         if( count($tests) == 1 ) {
-            $data = loadPageRunData($tests[0]['path'], $tests[0]['run'], $tests[0]['cached']);
-            $secure = false;
-            $haveLocations = false;
-            $requests = getRequests($tests[0]['id'], $tests[0]['path'], $tests[0]['run'], $tests[0]['cached'], $secure, $haveLocations, true, true);
-            InsertWaterfall('', $requests, $tests[0]['id'], $tests[0]['run'], $tests[0]['cached'], $data, "&max=$end_seconds&mime=1&state=1&cpu=1&bw=1" );
+            /* @var TestStepResult $stepResult */
+            $stepResult = $tests[0]["stepResult"];
+            $requests = $stepResult->getRequestsWithInfo(true, true)->getRequests();
+            echo CreateWaterfallHtml('', $requests, $tests[0]['id'], $tests[0]['run'], $tests[0]['cached'], $data,
+                                     "&max=$end_seconds&mime=1&state=1&cpu=1&bw=1", $tests[0]['step']);
             echo '<br><br>';
         } else {
           $waterfalls = array();
@@ -612,6 +612,7 @@ function ScreenShotTable()
             $waterfalls[] = array('id' => $test['id'],
                                   'label' => $test['name'],
                                   'run' => $test['run'],
+                                  'step' => $test['step'],
                                   'cached' => $test['cached']);
           }
           $labels='';
@@ -630,6 +631,7 @@ function ScreenShotTable()
             <tr><td>Custom label</td><td>-l:&lt;label&gt;</td><td>110606_MJ_RZEY-l:Original</td></tr>
             <tr><td>Specific run</td><td>-r:&lt;run&gt;</td><td>110606_MJ_RZEY-r:3</td></tr>
             <tr><td>Repeat view</td><td>-c:1</td><td>110606_MJ_RZEY-c:1</td></tr>
+            <tr><td>Specific step</td><td>-s:3</td><td>110606_MJ_RZEY-s:3</td></tr>
             <tr><td>Specific End Time</td><td>-e:&lt;seconds&gt;</td><td>110606_MJ_RZEY-e:1.1</td></tr>
             </table>
             <br>

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -808,14 +808,9 @@ function DisplayGraphs() {
                 echo "dataTimes.setValue($row, 0, '$label');\n";
                 $column = 1;
                 foreach($tests as &$test) {
-                    if (array_key_exists('pageData', $test) &&
-                        array_key_exists('run', $test) &&
-                        array_key_exists($test['run'], $test['pageData']) &&
-                        array_key_exists('cached', $test) &&
-                        array_key_exists($test['cached'], $test['pageData'][$test['run']]) &&
-                        array_key_exists($metric, $test['pageData'][$test['run']][$test['cached']]) &&
-                        strlen($test['pageData'][$test['run']][$test['cached']][$metric]))
-                      echo "dataTimes.setValue($row, $column, {$test['pageData'][$test['run']][$test['cached']][$metric]});\n";
+                    $hasStepResult = array_key_exists('stepResult', $test) && is_a($test['stepResult'], "TestStepResult");
+                    if ($hasStepResult && $test['stepResult']->getMetric($metric) !== null)
+                      echo "dataTimes.setValue($row, $column, {$test['stepResult']->getMetric($metric)});\n";
                     $column++;
                 }
                 $row++;
@@ -830,17 +825,13 @@ function DisplayGraphs() {
             echo "dataBytes.setValue(0, 0, 'Total');\n";
             $column = 1;
             foreach($tests as &$test) {
-                if (array_key_exists('pageData', $test) &&
-                    array_key_exists('run', $test) &&
-                    array_key_exists($test['run'], $test['pageData']) &&
-                    array_key_exists('cached', $test) &&
-                    array_key_exists($test['cached'], $test['pageData'][$test['run']])) {
-                    if (array_key_exists('requests', $test['pageData'][$test['run']][$test['cached']]) &&
-                        strlen($test['pageData'][$test['run']][$test['cached']]['requests']))
-                        echo "dataRequests.setValue(0, $column, {$test['pageData'][$test['run']][$test['cached']]['requests']});\n";
-                    if (array_key_exists('bytesIn', $test['pageData'][$test['run']][$test['cached']]) &&
-                        strlen($test['pageData'][$test['run']][$test['cached']]['bytesIn']))
-                        echo "dataBytes.setValue(0, $column, {$test['pageData'][$test['run']][$test['cached']]['bytesIn']});\n";
+                if (array_key_exists('stepResult', $test) && is_a($test['stepResult'], "TestStepResult")) {
+                    $requests = $test['stepResult']->getMetric('requests');
+                    if ($requests !== null)
+                        echo "dataRequests.setValue(0, $column, $requests);\n";
+                    $bytesIn = $test['stepResult']->getMetric('bytesIn');
+                    if ($bytesIn !== null)
+                        echo "dataBytes.setValue(0, $column, $bytesIn);\n";
                 }
                 $column++;
             }

--- a/www/video/downloadFrames.php
+++ b/www/video/downloadFrames.php
@@ -1,11 +1,11 @@
 <?php
+require_once __DIR__ . '/../include/TestPaths.php';
 chdir('..');
 include 'common.inc';
 require_once('video.inc');
 
-$dir = "$testPath/video_$run";
-if( $cached )
-    $dir .= "_cached";
+$localPaths = new TestPaths($testPath, $run, $cached, $step);
+$dir = $localPaths->videoDir();
 $ok = false;
 
 if( is_dir($dir) )

--- a/www/video/filmstrip.php
+++ b/www/video/filmstrip.php
@@ -2,6 +2,7 @@
 header('Content-disposition: attachment; filename=filmstrip.png');
 header ("Content-type: image/png");
 
+require_once __DIR__ . '/../include/TestPaths.php';
 chdir('..');
 include 'common.inc';
 require_once('page_data.inc');
@@ -139,6 +140,8 @@ foreach( $tests as &$test ) {
     }
     $frameCount = 0;
     $ms = 0;
+    $localPaths = new TestPaths(GetTestPath($test['id']), $test['run'], $test['cached'], $test['step']);
+    $videoDir = $localPaths->videoDir();
     while( $ms < $filmstrip_end_time ) {
         $ms = $frameCount * $interval;
         $frameCount++;
@@ -158,7 +161,7 @@ foreach( $tests as &$test ) {
             $cached = '';
             if( $test['cached'] )
                 $cached = '_cached';
-            $imgPath = GetTestPath($test['id']) . "/video_{$test['run']}$cached/$path";
+            $imgPath = $videoDir . "/" . $path;
             if( $lastThumb != $path || !$thumb ) {
                 if( $lastThumb != $path )
                     $border = $colChanged;

--- a/www/waterfall.inc
+++ b/www/waterfall.inc
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/common_lib.inc';
 require_once __DIR__ . '/draw.inc';
 require_once __DIR__ . '/contentColors.inc';
 require_once __DIR__ . '/include/TestPaths.php';
@@ -1253,8 +1254,9 @@ function InsertMultiWaterfall(&$waterfalls, $waterfall_options) {
 
   $row_count = 0;
   foreach($waterfalls as $index => &$waterfall) {
-    $test_path = null;
-    $requests = getRequests($waterfall['id'], $test_path, $waterfall['run'], $waterfall['cached'], $has_secure_requests, $has_locations, false, false);
+    $test_path = './' . GetTestPath($waterfall['id']);
+    $localPaths = new TestPaths($test_path, $waterfall['run'], $waterfall['cached'], $waterfall['step']);
+    $requests = getRequestsForStep($localPaths, null, $has_secure_requests, $has_locations, false, false);
     if (isset($requests) && is_array($requests)) {
       $count = count($requests);
       if ($count > $row_count)
@@ -1275,7 +1277,8 @@ function InsertMultiWaterfall(&$waterfalls, $waterfall_options) {
   echo "<div style=\"background-color: #fff;$height_style\" class=\"waterfall-container\">";
   foreach($waterfalls as $index => &$waterfall) {
     $o = $index ? $opacity : '1.0';
-    echo "<img style=\"display:block;opacity:$o;position:absolute;top:0;left:0;\" class=\"waterfall-image\" alt=\"\" id=\"waterfall-$index\" src=\"/waterfall.php?test={$waterfall['id']}&run={$waterfall['run']}&cached={$waterfall['cached']}&rowcount=$row_count$waterfall_options\">";
+    $waterfallUrl = "/waterfall.php?test={$waterfall['id']}&run={$waterfall['run']}&cached={$waterfall['cached']}&step={$waterfall['step']}&rowcount=$row_count$waterfall_options";
+    echo "<img style=\"display:block;opacity:$o;position:absolute;top:0;left:0;\" class=\"waterfall-image\" alt=\"\" id=\"waterfall-$index\" src=\"$waterfallUrl\">";
   }
   echo '<div class="waterfall_marker"></div>';
   echo '</div>';


### PR DESCRIPTION
Part of multistep support as discussed in #618.

The compare page can now compare specific steps and is not limited to the first step of a run.
Same for exporting the filmstrip or video frames.