### PR TITLE
Add allowNonFQDN setting, useful for corporate intranets

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -1448,7 +1448,7 @@ function ValidateURL(&$url, &$error, &$settings)
 
     if( strpos($url, ' ') !== FALSE || strpos($url, '>') !== FALSE || strpos($url, '<') !== FALSE )
         $error = "Please enter a Valid URL.  <b>" . htmlspecialchars($url) . "</b> is not a valid URL";
-    elseif( strpos($host, '.') === FALSE && !$settings['allowNonFQDN'] )
+    elseif( strpos($host, '.') === FALSE && !GetSetting('allowNonFQDN') )
         $error = "Please enter a Valid URL.  <b>" . htmlspecialchars($host) . "</b> is not a valid Internet host name";
     elseif( (!strcmp($host, "127.0.0.1") || !strncmp($host, "192.168.", 8)  || !strncmp($host, "169.254.", 8) || !strncmp($host, "10.", 3)) && !$settings['allowPrivate'] )
         $error = "You can not test <b>$host</b> from the public Internet.  Your web site needs to be hosted on the public Internet for testing";

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -1448,7 +1448,7 @@ function ValidateURL(&$url, &$error, &$settings)
 
     if( strpos($url, ' ') !== FALSE || strpos($url, '>') !== FALSE || strpos($url, '<') !== FALSE )
         $error = "Please enter a Valid URL.  <b>" . htmlspecialchars($url) . "</b> is not a valid URL";
-    elseif( strpos($host, '.') === FALSE )
+    elseif( strpos($host, '.') === FALSE && !$settings['allowNonFQDN'] )
         $error = "Please enter a Valid URL.  <b>" . htmlspecialchars($host) . "</b> is not a valid Internet host name";
     elseif( (!strcmp($host, "127.0.0.1") || !strncmp($host, "192.168.", 8)  || !strncmp($host, "169.254.", 8) || !strncmp($host, "10.", 3)) && !$settings['allowPrivate'] )
         $error = "You can not test <b>$host</b> from the public Internet.  Your web site needs to be hosted on the public Internet for testing";

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -48,6 +48,9 @@ render_max_load=8
 ; Allow (1) or disable (0) testing of sites on private IP addresses (http://192.168.0.1/ for example).
 allowPrivate=1
 
+; Allow (1) or disallow (0) non fully qualified domain names for URL hostnames (commonly found on private intranets)
+allowNonFQDN=0
+
 ; image quality (defaults to 30)
 ;iq=75
 


### PR DESCRIPTION
When setting up WPT Private Instance on our company intranet, I had to make this modification to allow testing sites that only used DNS short names and were not set up for fully qualified names. 

This off-by-default setting allows a user to use a non-fully-qualified hostname in the URL.