### PR TITLE
Added logs directory as volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN chmod +x /scripts/migrate-settings && \
 
 VOLUME /var/www/html/settings
 VOLUME /var/www/html/results
+VOLUME /var/www/html/logs
 
 EXPOSE 80 443
 


### PR DESCRIPTION
Simply adds another volume to the Dockerfile, so logs directory can easily get mounted in a volume container.