### PR TITLE
Result table: Only show separation row if the test has first and repeat view

### DIFF
--- a/www/include/TestResultsHtmlTables.php
+++ b/www/include/TestResultsHtmlTables.php
@@ -68,7 +68,7 @@ class TestResultsHtmlTables {
     $firstViewResults = $this->testResults->getRunResult($run, false);
     $hasRepeatView = !$this->testInfo->isFirstViewOnly() || $this->testResults->getRunResult($run, true);
 
-    if ($this->isMultistep) {
+    if ($this->isMultistep && $hasRepeatView) {
       $out .= $this->_createSeparationRow("First View", $columns);
     }
     $out .= $this->_createRunResultRows($run, false, $columns);


### PR DESCRIPTION
No need for the "First View" separation row when there is no repeat view.