### PR TITLE
Added a hook to initiate custom result postprocessing

### DIFF
--- a/www/work/workdone.php
+++ b/www/work/workdone.php
@@ -325,6 +325,10 @@ if (ValidateTestId($id)) {
 
           // do pre-complete post-processing
           MoveVideoFiles($testPath);
+
+          if (file_exists('custom/hooks/precompletePostprocess.php')) {
+            include 'custom/hooks/precompletePostprocess.php';
+          }
           
           if (!isset($pageData))
             $pageData = loadAllPageData($testPath);


### PR DESCRIPTION
In our private instance we have some very test specific result post processing. As it wouldn't make much sense to directly introduce these special cases in the main project, I'd like to introduce a way to include a custom hook.

So with these changes it's possible to add a `custom/hooks/precompletePostprocess.php` file gets included just before the test is marked as completed.