### PR TITLE
Fix UrlGenerator for tests with relay IDs

### DIFF
--- a/www/include/UrlGenerator.php
+++ b/www/include/UrlGenerator.php
@@ -10,6 +10,7 @@ abstract class UrlGenerator {
   protected $step;
   protected $baseUrl;
   protected $testId;
+  protected $testIdWithoutRelayKey;
 
   protected function __construct($baseUrl, $testId, $run, $cached, $step = 1) {
     $this->baseUrl = rtrim(strval($baseUrl), "/");
@@ -17,6 +18,8 @@ abstract class UrlGenerator {
     $this->run = intval($run);
     $this->cached = $cached ? true : false;
     $this->step = $step;
+    $dotPos = stripos($testId, ".");
+    $this->testIdWithoutRelayKey = $dotPos === false ? $testId : substr($testId, $dotPos + 1);
   }
 
   /**
@@ -178,7 +181,7 @@ abstract class UrlGenerator {
 class FriendlyUrlGenerator extends UrlGenerator {
 
   public function resultPage($page, $extraParams = null) {
-    $url = $this->baseUrl . "/result/" . $this->testId . "/" . $this->run . "/" . $page . "/";
+    $url = $this->baseUrl . "/result/" . $this->testIdWithoutRelayKey . "/" . $this->run . "/" . $page . "/";
     if ($this->cached) {
       $url .= "cached/";
     }
@@ -196,11 +199,11 @@ class FriendlyUrlGenerator extends UrlGenerator {
       $thumbName = substr($image, 0, $dotPos) . "_thumb" . substr($image, $dotPos);
     }
 
-    return $this->baseUrl . "/result/" . $this->testId . "/" . $this->underscorePrefix() . $thumbName;
+    return $this->baseUrl . "/result/" . $this->testIdWithoutRelayKey . "/" . $this->underscorePrefix() . $thumbName;
   }
 
   public function generatedImage($image) {
-    $parts = explode("_", $this->testId);
+    $parts = explode("_", $this->testIdWithoutRelayKey);
     $testPath = substr($parts[0], 0, 2) . "/" . substr($parts[0], 2, 2) . "/" . substr($parts[0], 4, 2) .
                 "/" . $parts[1];
     if (sizeof($parts) > 2) {
@@ -210,7 +213,7 @@ class FriendlyUrlGenerator extends UrlGenerator {
   }
 
   public function resultSummary($extraParams = null) {
-    $url = $this->baseUrl . "/result/" . $this->testId . "/";
+    $url = $this->baseUrl . "/result/" . $this->testIdWithoutRelayKey . "/";
     if ($extraParams != null) {
       $url .= "?" . $extraParams;
     }

--- a/www/tests/UrlGeneratorTest.php
+++ b/www/tests/UrlGeneratorTest.php
@@ -75,6 +75,13 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expectedCached . "?param=value", $ug->resultPage("details", "param=value"));
   }
 
+  public function testResultPageFriendlyUrlWithRelayId() {
+    $expected = "https://test/result/qwerty/3/details/";
+
+    $ug = UrlGenerator::create(true, "https://test/", "ab3cdef1.qwerty", 3, false);
+    $this->assertEquals($expected, $ug->resultPage("details"));
+  }
+
   public function testResultPageFriendlyUrlWithStep() {
     // step should actually be in the URL
     $expected = "https://test/result/qwerty/3/details/";
@@ -135,6 +142,13 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expectedCached, $ug->thumbnail("screen.jpg"));
   }
 
+  public function testThumbFriendlyUrlWithRelay() {
+    $expectedCached = "https://test/result/qwerty/3_Cached_screen_thumb.jpg";
+
+    $ug = UrlGenerator::create(true, "https://test/", "ab4cd2ef.qwerty", 3, true);
+    $this->assertEquals($expectedCached, $ug->thumbnail("screen.jpg"));
+  }
+
   public function testThumbFriendlyUrlWithStep() {
     $expected = "https://test/result/qwerty/3_2_screen_thumb.jpg";
     $expectedCached = "https://test/result/qwerty/3_Cached_2_screen_thumb.jpg";
@@ -168,6 +182,13 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expectedCached, $ug->generatedImage("waterfall"));
   }
 
+  public function testGeneratedImageFriendlyUrlWithRelay() {
+    $expected = "https://test/results/16/06/09/a7/b8/3_waterfall.png";
+
+    $ug = UrlGenerator::create(true, "https://test/", "2abcdfefe2131.160609_a7_b8", 3, false, 1);
+    $this->assertEquals($expected, $ug->generatedImage("waterfall"));
+  }
+
   public function testGeneratedImageFriendlyUrlWithStep() {
     $expected = "https://test/results/16/06/09/a7/b8/3_2_waterfall.png";
     $expectedCached = "https://test/results/16/06/09/a7/b8/3_Cached_2_waterfall.png";
@@ -184,6 +205,12 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
     $ug = UrlGenerator::create(true, "https://test/", "160609_a7_b8", 3, true, 2);
     $this->assertEquals($expected, $ug->resultSummary());
     $this->assertEquals($expected . "?param=value", $ug->resultSummary("param=value"));
+  }
+
+  public function testResultSummaryFriendlyUrlWithRelay() {
+    $expected = "https://test/result/160609_a7_b8/";
+    $ug = UrlGenerator::create(true, "https://test/", "213jbk21j132.160609_a7_b8", 3, true, 2);
+    $this->assertEquals($expected, $ug->resultSummary());
   }
 
   public function testResultSummaryStandardUrl() {
@@ -256,6 +283,12 @@ class UrlGeneratorTest extends PHPUnit_Framework_TestCase {
   public function testOptimizationChecklistImageFriendly() {
     $expected = "https://test/results/16/08/10/AB/CDE/3_Cached_2_optimization.png";
     $ug = UrlGenerator::create(true, "https://test/", "160810_AB_CDE", 3, true, 2);
+    $this->assertEquals($expected, $ug->optimizationChecklistImage());
+  }
+
+  public function testOptimizationChecklistImageFriendlyWithRelay() {
+    $expected = "https://test/results/16/08/10/AB/CDE/3_Cached_2_optimization.png";
+    $ug = UrlGenerator::create(true, "https://test/", "3242nklk234nl.160810_AB_CDE", 3, true, 2);
     $this->assertEquals($expected, $ug->optimizationChecklistImage());
   }
 


### PR DESCRIPTION
This is a fix for #690.

For friendly URLs, the relay key should be omitted in URLs.

However, I'm not sure if it's okay to simply omit the relay key. Manually using URLs without the relay key work on the test server in the issue, but I'm not sure if this is sufficient as `GetTestPath` seems to return a different path for IDs with relay key.
