### PR TITLE
Minor markup changes for better consistency

### DIFF
--- a/www/include/RunResultHtmlTable.php
+++ b/www/include/RunResultHtmlTable.php
@@ -173,7 +173,7 @@ class RunResultHtmlTable {
   private function _headlineRow($isRepeatView, $runNumber) {
     $label = $this->_rvLabel($isRepeatView, $runNumber);
     $colspan = 9 + $this->_countLeftEnabledColumns() + $this->_countRightEnabledColumns();
-    return "<tr><td colspan='$colspan'>$label</td></tr>\n";
+    return "<tr><td colspan='$colspan' class='separation'>$label</td></tr>\n";
   }
 
   private function _rvLabel($isRepeatView, $runNumber) {

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -132,7 +132,7 @@ function printContent($fileHandler, $testInfo, $testRunResults) {
  */
 function printQuicklinks($testRunResults) {
     echo '<a name="quicklinks"><h1>Quicklinks</h1></a>';
-    echo '<div style="text-align: center;"><table class="pretty">';
+    echo '<div style="text-align: center;"><table class="pretty" id="quicklinks_table">';
     echo '<tbody>';
     for ($i = 1; $i <= $testRunResults->countSteps(); $i++) {
         $class = ($i % 2 == 0) ? " class='even'" : "";


### PR DESCRIPTION
A very complicated commit ;) which allows the table to be styled as all "pretty" tables with separation rows.
The quicklinks table on the screen shot page gets identified correctly.