### PR TITLE
Add label to bulk test if specified in UI

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -708,7 +708,7 @@
                         foreach( $bulk['urls'] as &$entry )
                         {
                             $testData = $test;
-                            if( $entry['l'] )
+                            if (isset($entry['l']) && strlen($entry['l']))
                             {
                                 $testData['label'] = $entry['l'];
                             }

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -708,7 +708,10 @@
                         foreach( $bulk['urls'] as &$entry )
                         {
                             $testData = $test;
-                            $testData['label'] = $entry['l'];
+                            if( $entry['l'] )
+                            {
+                                $testData['label'] = $entry['l'];
+                            }
                             if( $entry['ns'] )
                             {
                                 unset($testData['script']);


### PR DESCRIPTION
If a label is specified in UI, adds it to individual tests within bulk test so long as they don't have labels already specified.

Where individual tests already have labels specified these take precedence.

Code uses braces even though it's a single line if, aware it's different to rest of code base so  happy to remove them if you prefer.