### PR TITLE
Copy signed Firefox Plugin in PostBuildEvent 

### DIFF
--- a/agent/wptdriver/wptdriver.vcxproj
+++ b/agent/wptdriver/wptdriver.vcxproj
@@ -102,8 +102,9 @@
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
+mkdir "$(outdir)\templates\Firefox\extensions"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi"
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -133,8 +134,9 @@ copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdr
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
+mkdir "$(outdir)\templates\Firefox\extensions"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi"
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -170,8 +172,9 @@ copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdr
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
+mkdir "$(outdir)\templates\Firefox\extensions"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi"
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -207,8 +210,9 @@ copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdr
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
+mkdir "$(outdir)\templates\Firefox\extensions"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi"
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>

--- a/agent/wptdriver/wptdriver.vcxproj
+++ b/agent/wptdriver/wptdriver.vcxproj
@@ -102,9 +102,8 @@
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
-mkdir "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-xcopy /Y /E /S /I "..\browser\firefox\extension" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -134,9 +133,8 @@ xcopy /Y /E /S /I "..\browser\firefox\extension" "$(outdir)\templates\Firefox\ex
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
-mkdir "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-xcopy /Y /E /S /I "..\browser\firefox\extension" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -172,9 +170,8 @@ xcopy /Y /E /S /I "..\browser\firefox\extension" "$(outdir)\templates\Firefox\ex
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
-mkdir "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-xcopy /Y /E /S /I "..\browser\firefox\extension" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -210,9 +207,8 @@ xcopy /Y /E /S /I "..\browser\firefox\extension" "$(outdir)\templates\Firefox\ex
     </Link>
     <PostBuildEvent>
       <Command>copy /Y *.ini "$(outdir)\"
-mkdir "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
 copy /Y "..\browser\firefox\*.*" "$(outdir)\templates\Firefox\"
-xcopy /Y /E /S /I "..\browser\firefox\extension" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org"
+copy /Y "..\browser\firefox\*.xpi" "$(outdir)\templates\Firefox\extensions\wptdriver@webpagetest.org.xpi
 </Command>
     </PostBuildEvent>
     <PostBuildEvent>


### PR DESCRIPTION
Basically the fix for the issue #718 I opened recently.
The post-build event copies the signed firefox plugin to the output directory, not the plugin source.
Therefore automatic AppVeyor builds produce working wptdriver artifacts again.