### PR TITLE
wptloader: Move username check to wpthook

### DIFF
--- a/agent/wpthook/dllmain.cc
+++ b/agent/wpthook/dllmain.cc
@@ -29,6 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "stdafx.h"
 #include "wpthook.h"
+#include <TCHAR.H>
+#include <Lmcons.h>
 
 HINSTANCE global_dll_handle = NULL; // DLL handle
 extern WptHook * global_hook;
@@ -63,6 +65,14 @@ BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
                        LPVOID lpReserved) {
   BOOL ok = TRUE;
+
+  // Check we don't run as SYSTEM
+  TCHAR user[UNLEN + 1];
+  DWORD userlen = UNLEN;
+  if (!GetUserName(user, &userlen) || lstrcmpi(user, L"SYSTEM") == 0) {
+    return false;
+  }
+
   switch (ul_reason_for_call) {
     case DLL_PROCESS_ATTACH: {
         // This is called VERY early in a process - only use kernel32.dll

--- a/agent/wptloader/dllmain.cpp
+++ b/agent/wptloader/dllmain.cpp
@@ -41,19 +41,12 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 	switch (ul_reason_for_call)
 	{
 	case DLL_PROCESS_ATTACH: {
-      TCHAR user[UNLEN + 1];
-      DWORD len = sizeof(user)/sizeof(TCHAR);
-      user[0] = 0;
-      if (GetUserName(user, &len)) {
-        if (lstrcmpi(user, _T("SYSTEM"))) {
-          module_handle = hModule;
-          // Spawn a background thread to try loading the hookdll
-          HANDLE thread_handle = CreateThread(NULL, 0, ::LoaderThreadProc, 0, 0,
-                                              NULL);
-          if (thread_handle)
-            CloseHandle(thread_handle);
-        }
-      }
+      module_handle = hModule;
+      // Spawn a background thread to try loading the hookdll
+      HANDLE thread_handle = CreateThread(NULL, 0, ::LoaderThreadProc, 0, 0,
+                                          NULL);
+      if (thread_handle)
+        CloseHandle(thread_handle);
     } break;
 	case DLL_THREAD_ATTACH:
 	case DLL_THREAD_DETACH:


### PR DESCRIPTION
This is an attempt to fix Issue #724 where the checking the user's name in wptloader is causing a memory access violation exception with Firefox 48 on Windows 7 32bits.

I haven't figured out why this exception is caused, and why it doesn't happen with other browsers. However I have moved the username check from `wptloader` to the very beginning of `wpthook` and this doesn't fail.