### PR TITLE
Ensure the lower of two middle values is chosen when getting the median

### DIFF
--- a/www/include/TestResults.php
+++ b/www/include/TestResults.php
@@ -165,7 +165,7 @@ class TestResults {
    * @param string $metric Name of the metric to consider for selecting the median
    * @param bool $cached False if first views should be considered for selecting, true for repeat views
    * @param string $medianMode Can be set to "fastest" to consider the fastest run and not the median. Defaults to "median".
-   * @return float The run number of the median run
+   * @return float The run number of the median run (or lower of two middle values) of $metric,
    */
   public function getMedianRunNumber($metric, $cached, $medianMode = "median") {
     $values = $this->getMetricFromRuns($metric, $cached, true);
@@ -186,8 +186,17 @@ class TestResults {
     if ($numValues == 1 || $medianMode == "fastest") {
       return $runNumbers[0];
     }
-    $medianIndex = (int)floor($numValues / 2.0);
-    return $runNumbers[$medianIndex];
+    $medianIndex = (int)floor(((float)$numValues + 1.0) / 2.0);
+    $current = 0;
+    $run = null;
+    foreach( $runNumbers as $index => $time ) {
+      $current++;
+      if( $current == $medianIndex ) {
+          $run = $time;
+          break;
+      }
+    }
+    return $run;
   }
 
   /**


### PR DESCRIPTION
getMedianRunNumber() and getMedianRun() use different methods for selecting the median run when there are an even number of runs.

getMedianRuns() chooses the lower of the two middle values whereas getMedianRunNumber() chooses the upper as it doesn’t account for the 0 index on the array.

When using the "mv" param to only keep video for the median run this can lead to a mismatch between the video data that is kept and the median that is then shown on result.php and jsonResult.php

This updates getMedianRunNumber() to use the same approach as getMedianRun() and always select the lower of the two middle runs.

Please double check I’m doing the right thing here Pat!