### PR TITLE
Add StackPath to list of known CDNs

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -173,6 +173,7 @@ CDN_PROVIDER cdnList[] = {
   {".optimalcdn.com", "Optimal CDN"},
   {".kinxcdn.com", "KINX CDN"},
   {".kinxcdn.net", "KINX CDN"},
+  {".stackpathdns.com", "StackPath"},
   {"END_MARKER", "END_MARKER"}
 };
 


### PR DESCRIPTION
StackPath acquired MaxCDN and is using this domain for new customers.