### PR TITLE
adding Netlify

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -122,6 +122,7 @@ CDN_PROVIDER cdnList[] = {
 	{".unicorncdn.net", _T("UnicornCDN")},
 	{".optimalcdn.com", _T("Optimal CDN")},
 	{".hosting4cdn.com", _T("Hosting4CDN")},
+	{".netlify.com", _T("Netlify")},
 	{NULL, NULL}
 };
 
@@ -160,4 +161,5 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"X-CDN", "Incapsula", _T("Incapsula")},
 	{"X-Iinfo", "", _T("Incapsula")},
 	{"server", "gocache", _T("GoCache")}
+	{"server", "Netlify", _T("Netlify")}
 };

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -175,6 +175,7 @@ CDN_PROVIDER cdnList[] = {
   {".kinxcdn.net", "KINX CDN"},
   {".stackpathdns.com", "StackPath"},
   {".hosting4cdn.com", "Hosting4CDN"},
+  {".netlify.com", "Netlify"},
   {"END_MARKER", "END_MARKER"}
 };
 
@@ -215,6 +216,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "UnicornCDN", "UnicornCDN"},
   {"server", "Optimal CDN", "Optimal CDN"},
   {"server", "Sucuri/Cloudproxy", "Sucuri/Cloudproxy"},
+  {"server", "Netlify", "Netlify"},
   {"section-io-id", "", "section.io"}
 };
 


### PR DESCRIPTION
Our CDN is identified by at least one of a *.netlify.com hostname or a header, "server: Netlify".