### PR TITLE
add windows test agent password

### DIFF
--- a/docs/EC2/Server AMI.md
+++ b/docs/EC2/Server AMI.md
@@ -53,3 +53,7 @@ headless=0
 ```
 
 The full list of settings that can be specified is in [settings.ini.sample](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/settings.ini.sample)
+
+Connect to a Windows Test Agent:
+
+The password is: 2dialit


### PR DESCRIPTION
I keep forgetting and then searching the internet for hours til I find what the password is for windows test agents in case you want to connect and check for a problem.