### PR TITLE
Fixing Sucuri's product name. We don't call it "CloudProxy" anymore.

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -215,7 +215,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "hiberniacdn", "HiberniaCDN"},
   {"server", "UnicornCDN", "UnicornCDN"},
   {"server", "Optimal CDN", "Optimal CDN"},
-  {"server", "Sucuri/Cloudproxy", "Sucuri/Cloudproxy"},
+  {"server", "Sucuri/Cloudproxy", "Sucuri Firewall"},
   {"server", "Netlify", "Netlify"},
   {"section-io-id", "", "section.io"}
 };


### PR DESCRIPTION
Small PR to just fix Sucuri's product name from "Sucuri/CloudProxy" to "Sucuri Firewall".

