### PR TITLE
Added Naver to the list of known CDNs

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -219,7 +219,8 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "Sucuri/Cloudproxy", "Sucuri Firewall"},
   {"x-sucuri-id", "", "Sucuri Firewall"},
   {"server", "Netlify", "Netlify"},
-  {"section-io-id", "", "section.io"}
+  {"section-io-id", "", "section.io"},
+  {"server", "Testa/", "Naver"}
 };
 
 // Specific providers that require multiple headers


### PR DESCRIPTION
Please add [Naver](https://en.wikipedia.org/wiki/Naver)'s CDN to the known CDN list.

```
$ $ curl -si -D- -o /dev/null 'https://ssl.pstatic.net/sstatic/search/favicon/favicon_140327.ico'
HTTP/1.1 200 OK
Date: Tue, 03 Jan 2017 12:41:55 GMT
Server: Testa/4.8.6
Last-Modified: Thu, 27 Mar 2014 06:34:55 GMT
ETag: "1536-4f590c88381c0"
Accept-Ranges: bytes
Content-Length: 5430
Cache-Control: max-age=31536000
Expires: Wed, 03 Jan 2018 12:41:55 GMT
Vary: Accept-Encoding
Content-Type: image/x-icon
Age: 1709048
Strict-Transport-Security: max-age=31536000
```