### PR TITLE
Add google cdn

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -156,7 +156,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"server", "gws", _T("Google")},
 	{"server", "GSE", _T("Google")},
 	{"server", "Golfe2", _T("Google")},
-	{"Via", "google", "Google"},
+	{"Via", "google", _T"Google"},
 	{"server", "tsa_b", _T("Twitter")},
 	{"X-Cache", "cache.51cdn.com", _T("ChinaNetCenter")},
 	{"X-CDN", "Incapsula", _T("Incapsula")},

--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -156,7 +156,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"server", "gws", _T("Google")},
 	{"server", "GSE", _T("Google")},
 	{"server", "Golfe2", _T("Google")},
-	{"Via", "google", _T"Google"},
+	{"Via", "google", _T("Google")},
 	{"server", "tsa_b", _T("Twitter")},
 	{"X-Cache", "cache.51cdn.com", _T("ChinaNetCenter")},
 	{"X-CDN", "Incapsula", _T("Incapsula")},

--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -156,7 +156,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"server", "gws", _T("Google")},
 	{"server", "GSE", _T("Google")},
 	{"server", "Golfe2", _T("Google")},
-	{"Via", "1.1 google", "Google"},
+	{"Via", "google", "Google"},
 	{"server", "tsa_b", _T("Twitter")},
 	{"X-Cache", "cache.51cdn.com", _T("ChinaNetCenter")},
 	{"X-CDN", "Incapsula", _T("Incapsula")},

--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -156,6 +156,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"server", "gws", _T("Google")},
 	{"server", "GSE", _T("Google")},
 	{"server", "Golfe2", _T("Google")},
+	{"Via", "1.1 google", "Google"},
 	{"server", "tsa_b", _T("Twitter")},
 	{"X-Cache", "cache.51cdn.com", _T("ChinaNetCenter")},
 	{"X-CDN", "Incapsula", _T("Incapsula")},

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -208,7 +208,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "gws", "Google"},
   {"server", "GSE", "Google"},
   {"server", "Golfe2", "Google"},
-  {"Via", "1.1 google", "Google"},
+  {"Via", "google", "Google"},
   {"server", "tsa_b", "Twitter"},
   {"X-Cache", "cache.51cdn.com", "ChinaNetCenter"},
   {"X-CDN", "Incapsula", "Incapsula"},

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -208,6 +208,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "gws", "Google"},
   {"server", "GSE", "Google"},
   {"server", "Golfe2", "Google"},
+  {"Via", "1.1 google", "Google"},
   {"server", "tsa_b", "Twitter"},
   {"X-Cache", "cache.51cdn.com", "ChinaNetCenter"},
   {"X-CDN", "Incapsula", "Incapsula"},


### PR DESCRIPTION
Added Google CDN
You can verify that the response header "Via: 1.1 google" is their header [here](https://cloud.google.com/cdn/docs/troubleshooting)