### PR TITLE
Add visualComplete85 metric

### DIFF
--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -187,11 +187,14 @@ function loadPageStepData($localPaths, $runCompleted, $options = null, $testInfo
       if (!isset($ret['SpeedIndex']) ||
           !array_key_exists('render', $ret) || !$ret['render'] ||
           !array_key_exists('lastVisualChange', $ret) || !$ret['lastVisualChange'] ||
+          !array_key_exists('visualComplete85', $ret) || !$ret['visualComplete85'] ||
           !array_key_exists('visualComplete', $ret) || !$ret['visualComplete']) {
         $progress = GetVisualProgressForStep($localPaths, $runCompleted, null, null, $startOffset);
         if (isset($progress) && is_array($progress)) {
           if (array_key_exists('SpeedIndex', $progress))
             $ret['SpeedIndex'] = $progress['SpeedIndex'];
+          if (array_key_exists('visualComplete85', $progress))
+            $ret['visualComplete85'] = $progress['visualComplete85'];
           if (array_key_exists('visualComplete', $progress))
             $ret['visualComplete'] = $progress['visualComplete'];
           if (array_key_exists('startRender', $progress) && (!array_key_exists('render', $ret) || !$ret['render']))

--- a/www/video/visualProgress.inc.php
+++ b/www/video/visualProgress.inc.php
@@ -157,6 +157,8 @@ function GetVisualProgressForStep($localPaths, $runCompleted, $options = null, $
     foreach($frames['frames'] as $time => &$frame) {
       if ($frame['progress'] > 0 && !array_key_exists('startRender', $frames))
         $frames['startRender'] = $time;
+      if (!$frames['visualComplete85'] && $frame['progress'] >= 85)
+        $frames['visualComplete85'] = $time;
       if (!$frames['visualComplete'] && $frame['progress'] == 100)
         $frames['visualComplete'] = $time;
       // fix up the frame paths in case we have a cached version referencing a relay path

--- a/www/video/visualProgress.inc.php
+++ b/www/video/visualProgress.inc.php
@@ -157,7 +157,7 @@ function GetVisualProgressForStep($localPaths, $runCompleted, $options = null, $
     foreach($frames['frames'] as $time => &$frame) {
       if ($frame['progress'] > 0 && !array_key_exists('startRender', $frames))
         $frames['startRender'] = $time;
-      if (!$frames['visualComplete85'] && $frame['progress'] >= 85)
+      if (!isset($frames['visualComplete85']) && $frame['progress'] >= 85)
         $frames['visualComplete85'] = $time;
       if (!$frames['visualComplete'] && $frame['progress'] == 100)
         $frames['visualComplete'] = $time;


### PR DESCRIPTION
I really like the visualComplete85 that Lighthouse (I think?) introduced.

I already use the visualComplete metric but this one spikes when a pages has a video playing ad. Or sometimes stays 99% for a very long time for a very small change.

This visualComplete85 can mitigate these small changes from metric dashboards.

I don't know where the 85% number originally comes from but for now lets keep it in line with other tools?