### PR TITLE
Option to disable the testlog in the UI

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -97,7 +97,9 @@ if (!defined('EMBED')) {
                 $navTabs['Test Result'] = isset($resultUrl) ? $resultUrl : '';
             }
 
-            $navTabs['Test History'] = FRIENDLY_URLS ? '/testlog/1/' : '/testlog.php?days=1';
+            if (empty($settings['disableTestlog'])) {
+              $navTabs['Test History'] = FRIENDLY_URLS ? '/testlog/1/' : '/testlog.php?days=1';
+            }
 
             if (is_dir('wptmonitor')) {
                 $navTabs['Monitor'] = '/wptmonitor/';

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -27,6 +27,8 @@ tcpdump_view="http://cloudshark.org/view?url="
 ; Comment-out to use classic-colored waterfalls as the default
 mime_waterfalls=1
 
+; Uncomment to disable the testlog in the UI
+;disableTestlog=1
 
 ; *********************
 ; Test options/defaults

--- a/www/testlog.php
+++ b/www/testlog.php
@@ -2,7 +2,7 @@
 include 'common.inc';
 set_time_limit(0);
 
-if ($userIsBot) {
+if ($userIsBot || !empty($settings['disableTestlog'])) {
   header('HTTP/1.0 403 Forbidden');
   exit;
 }


### PR DESCRIPTION
With the new option being set, access to the testlog can get disabled for users (if I'm not missing anything).
The default behavior shouldn't change at all.