### PR TITLE
Add roast.io to CDN list

### DIFF
--- a/agent/browser/ie/pagetest/cdn.h
+++ b/agent/browser/ie/pagetest/cdn.h
@@ -123,6 +123,7 @@ CDN_PROVIDER cdnList[] = {
 	{".optimalcdn.com", _T("Optimal CDN")},
 	{".hosting4cdn.com", _T("Hosting4CDN")},
 	{".netlify.com", _T("Netlify")},
+	{".roast.io", _T("Roast.io")},
 	{NULL, NULL}
 };
 
@@ -161,6 +162,7 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
 	{"X-Cache", "cache.51cdn.com", _T("ChinaNetCenter")},
 	{"X-CDN", "Incapsula", _T("Incapsula")},
 	{"X-Iinfo", "", _T("Incapsula")},
-	{"server", "gocache", _T("GoCache")}
-	{"server", "Netlify", _T("Netlify")}
+	{"server", "gocache", _T("GoCache")},
+	{"server", "Netlify", _T("Netlify")},
+	{"server", "Roast.io", _T("Roast.io")}
 };

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -178,6 +178,7 @@ CDN_PROVIDER cdnList[] = {
   {".netlify.com", "Netlify"},
   {".b-cdn.net", "BunnyCDN"},
   {".pix-cdn.org", "Advanced Hosters CDN"},
+  {".roast.io", "Roast.io"},
   {"END_MARKER", "END_MARKER"}
 };
 
@@ -226,7 +227,8 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"section-io-id", "", "section.io"},
   {"server", "Testa/", "Naver"},
   {"server", "BunnyCDN", "BunnyCDN"},
-  {"server", "MNCDN", "Medianova"}
+  {"server", "MNCDN", "Medianova"},
+  {"server", "Roast.io", "Roast.io"}
 };
 
 // Specific providers that require multiple headers


### PR DESCRIPTION
* The Roast.io CDN is identified by either a *.roast.io hostname or a header, `server: Roast.io`
* Current PoP list
  * Northern California, US
  * Oregon, US
  * Ohio, US
  * Frankfurt, Germany
  * Tokyo, Japan
  * Sydney, Australia

