### PR TITLE
Add support for basic auth parameters in test agents configuration

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -97,12 +97,21 @@ function EC2_StartInstance($ami) {
         $host = file_get_contents('http://169.254.169.254/latest/meta-data/hostname');
     }
     $user_data = "wpt_server=$host";
+    $wpt_username = GetSetting('ba_username');
+    $wpt_password = GetSetting('ba_password');
+    $wpt_validcertificate = GetSetting('validcertificate');
     if (strlen($urlblast))
       $user_data .= " wpt_location=$urlblast";
     if (strlen($wptdriver))
       $user_data .= " wpt_loc=$wptdriver";
     if (isset($key) && strlen($key))
       $user_data .= " wpt_key=$key";
+    if (isset($wpt_username) && strlen($wpt_username))
+      $user_data .= " wpt_username=$wpt_username";
+    if (isset($wpt_password) && strlen($wpt_password))
+        $user_data .= " wpt_password=$wpt_password";
+    if (isset($wpt_validcertificate) && strlen($wpt_validcertificate))
+        $user_data .= " wpt_validcertificate=$wpt_validcertificate";
     if (!$size)
       $size = 'm3.medium';
     $started = EC2_LaunchInstance($region, $ami, $size, $user_data, $loc);

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -130,6 +130,11 @@ agentUpdate=http://cdn.webpagetest.org/
 ; YYMMDD_<serverID>hash_xxx
 ;serverID=A
 
+; For basic authentication with WPT server
+;ba_username=username
+;ba_password=password
+;validcertificate=1
+
 ; ***********************
 ; Test result integration
 ; ***********************


### PR DESCRIPTION
Related issue: https://github.com/WPO-Foundation/webpagetest/issues/879

Added and handled missing parameters for EC2 Test Agents to be able to access sites protected by basic auth.