### PR TITLE
Added beanstalkd to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN echo deb http://www.deb-multimedia.org jessie main non-free >> /etc/apt/sour
     python \
     python-pillow \
     cron \
+    beanstalkd \
     supervisor && \
     \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y --force-yes\
@@ -57,10 +58,11 @@ COPY docker/server/config/php.ini /usr/local/etc/php/
 COPY docker/server/config/apache2.conf /etc/apache2/apache2.conf
 COPY docker/server/config/crontab /etc/crontab
 
-# config supervisor to run apache AND cron
+# config supervisor to run apache, cron, beanstalkd
 COPY docker/server/config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY docker/server/config/supervisord/supervisord_apache.conf /etc/supervisor/conf.d/supervisord_apache.conf
 COPY docker/server/config/supervisord/supervisord_cron.conf /etc/supervisor/conf.d/supervisord_cron.conf
+COPY docker/server/config/supervisord/supervisord_beanstalkd.conf /etc/supervisor/conf.d/supervisord_beanstalkd.conf
 
 # copy script to run WPT cron scripts
 COPY docker/server/scripts/wpt_cron_call.sh /scripts/wpt_cron_call.sh

--- a/docker/server/config/supervisord/supervisord_beanstalkd.conf
+++ b/docker/server/config/supervisord/supervisord_beanstalkd.conf
@@ -1,0 +1,6 @@
+[program:beanstalk]
+command = beanstalkd -l 127.0.0.1 -p 11300
+autostart = true
+autorestart = true
+stderr_logfile = /var/log/supervisor/beanstalk_stderr.log
+stdout_logfile = /var/log/supervisor/beanstalk_stdout.log


### PR DESCRIPTION
When the WPT server is deployed onto an EC2 instance as a docker container I'm unable to queue tests through the webpagetest node module because the docker container doesn't have beanstalkd running as a service

![screen shot 2017-06-09 at 1 56 56 pm](https://user-images.githubusercontent.com/1616682/26995755-698c0312-4d23-11e7-8fcc-c6aefe0bac18.jpg)

This PR runs beanstalkd as a service when the container is launched

![screen shot 2017-06-09 at 2 54 03 pm](https://user-images.githubusercontent.com/1616682/26995900-308341d8-4d24-11e7-9659-3c82a5112847.jpg)