### PR TITLE
Omit dataURIs from list of images 

### DIFF
--- a/www/settings/custom_metrics/Images.js.sample
+++ b/www/settings/custom_metrics/Images.js.sample
@@ -7,7 +7,12 @@ var wptImages = function(win) {
   for (var i = 0; i < elements.length; i++) {
     var el = elements[i];
     if (el.tagName == 'IMG') {
-      images.push({'url': el.currentSrc || el.src, 'width': el.width, 'height': el.height, 'naturalWidth': el.naturalWidth, 'naturalHeight': el.naturalHeight});
+      var url = el.currentSrc || el.src;
+
+      // Only include HTTP(S) URLs i.e. skip dataURIs
+      if(url.indexOf("http") === 0) {
+        images.push({'url': url, 'width': el.width, 'height': el.height, 'naturalWidth': el.naturalWidth, 'naturalHeight': el.naturalHeight});
+      }
     }
     if (el.tagName == 'IFRAME') {
       try {
@@ -20,4 +25,5 @@ var wptImages = function(win) {
   }
   return images;
 };
+
 return JSON.stringify(wptImages());


### PR DESCRIPTION
Example - images uses existing code, images2 uses new code

https://www.webpagetest.org/custom_metrics.php?test=170618_YG_2997977599ac8eac31ffd62c2d4565eb&run=1&cached=0

(Might clean it up a bit more later)