### PR TITLE
Skip none content encoding to make usage work in Chrome

### DIFF
--- a/www/usage.php
+++ b/www/usage.php
@@ -1,7 +1,6 @@
 <?php
 include 'common.inc';
 set_time_limit(0);
-header('Content-Encoding: none;');
 
 // parse the logs for the counts
 $days = $_REQUEST['days'];


### PR DESCRIPTION
The usage page isn't working in Chrome (http://wpt.wmftest.org/usage.php) for us because of the content encoding set to none, I guess sometimes back in history that was a fix for something but I couldn't backtrack it.

<img width="677" alt="screen shot 2017-07-05 at 1 23 32 pm" src="https://user-images.githubusercontent.com/540757/27862563-1e32c618-6186-11e7-8fff-1fc9daa90aac.png">
