### PR TITLE
Fixed tests cancelling.

### DIFF
--- a/www/cancelTest.php
+++ b/www/cancelTest.php
@@ -49,12 +49,13 @@ if( isset($test['test']) )
 * Cancel and individual test
 * 
 * @param mixed $id
+* @return bool
 */
 function CancelTest($id)
 {
+  $cancelled = false;
   $lock = LockTest($id);
   if ($lock) {
-    $cancelled = false;
     $testInfo = GetTestInfo($id);
     if ($testInfo && !array_key_exists('started', $testInfo)) {
       $testInfo['cancelled'] = time();
@@ -65,8 +66,10 @@ function CancelTest($id)
         $ext = 'url';
         if( $testInfo['priority'] )
             $ext = "p{$testInfo['priority']}";
-        $queued_job_file = $testInfo['workdir'] . "/$id.$ext";
-        $cancelled = @unlink($queued_job_file);
+        $file_to_search = $testInfo['workdir'] . "/*.$id.$ext";
+        $found_files = glob($file_to_search);
+        if (1 === count($found_files))
+          $cancelled = @unlink($found_files[0]);
       }
     }
     UnlockTest($lock);


### PR DESCRIPTION
Previously, the files on disk were not removed, and so, a message that the test was already cancelled was always shown.
Should fix issue #298.