### PR TITLE
Adding support for minimum test duration for edge agents

### DIFF
--- a/agent/webdriver/edge.py
+++ b/agent/webdriver/edge.py
@@ -110,7 +110,11 @@ def RunTest(driver, test):
 
   # Wait for idle if it is not an onload-ending test
   if not test.EndAtOnLoad():
-    recorder.WaitForIdle(30)
+    minTestDuration = test.GetMinimumTestDuration()
+    if minTestDuration > 0:
+      recorder.WaitForDuration(minTestDuration)
+    else:
+      recorder.WaitForIdle(30)
 
   # Stop Recording
   recorder.Stop()

--- a/agent/webdriver/edge.py
+++ b/agent/webdriver/edge.py
@@ -113,8 +113,7 @@ def RunTest(driver, test):
     minTestDuration = test.GetMinimumTestDuration()
     if minTestDuration > 0:
       recorder.WaitForDuration(minTestDuration)
-    else:
-      recorder.WaitForIdle(30)
+    recorder.WaitForIdle(30)
 
   # Stop Recording
   recorder.Stop()

--- a/agent/webdriver/recorder.py
+++ b/agent/webdriver/recorder.py
@@ -73,6 +73,13 @@ class WptRecord:
       except:
         pass
 
+  def WaitForDuration(self, wait_seconds):
+    if wait_seconds is not None:
+      try:
+        time.sleep(wait_seconds)
+      except:
+        pass
+
   def Stop(self):
     if self.window is not None:
       try:

--- a/agent/webdriver/wpt_test_info.py
+++ b/agent/webdriver/wpt_test_info.py
@@ -176,3 +176,9 @@ class WptTest:
     if self.test is not None and 'doc_complete' in self.test and self.test['doc_complete']:
       doc_complete = True
     return doc_complete
+
+  def GetMinimumTestDuration(self):
+    minimum_duration = 0
+    if self.test is not None and 'minimum_duration' in self.test and self.test['minimum_duration']:
+      minimum_duration = int(self.test['minimum_duration']) /1000
+    return minimum_duration


### PR DESCRIPTION
Python script changes to enable the Edge agents to use the supplied minimum test duration setting.
I tried to follow convention and put functions where they most made sense.  