### PR TITLE
Adding flag to xperf provider to reduce ETL size

### DIFF
--- a/agent/webdriver/etw.py
+++ b/agent/webdriver/etw.py
@@ -27,7 +27,7 @@ class ETW:
     self.trace_name = None
     self.kernel_categories = []
     #self.kernel_categories = ['latency']
-    self.user_categories = ['Microsoft-IE',
+    self.user_categories = ['Microsoft-IE:0x30801308:0xff',
                             #'Microsoft-IEFRAME',
                             #'Microsoft-JScript',
                             #'Microsoft-PerfTrack-IEFRAME',


### PR DESCRIPTION
This flag should tell xperf to only record the events that are being parsed and read by the script.  It will reduce the ETL size and improve overall execution time for the Edge agent.

