### PR TITLE
Updated glossary definition for "Cache Static"

### DIFF
--- a/www/optimization.inc
+++ b/www/optimization.inc
@@ -576,11 +576,8 @@ function dumpOptimizationGlossary(&$settings)
         </tr>
         <tr>
             <td class="nowrap">What is checked</td>
-            <td >
-                An "Expires" header is present (and is not 0 or -1) or a 
-                "cache-control: max-age" directive is present and set for an 
-                hour or greater.  If the expiration is set for less than 30 
-                days you will get a warning (only applies to max-age currently).
+            <td >             
+                An "Expires" header is present (and is not 0 or -1) or a "cache-control: max-age" directive is present and set for an hour or greater. If the expiration is set for less 7 days you will get a warning. If the expiration is set for less than 1 hour you will get a failure. This only applies to max-age currently. 
             </td>
         </tr>
 


### PR DESCRIPTION
Updated glossary definition for "Cache Static" to reflect current scoring parameters.  Based on the scoring in [wptagent ](https://github.com/WPO-Foundation/wptagent/blob/master/internal/optimization_checks.py#L382) as well as the failed/warning logic in [optimization.inc](https://github.com/WPO-Foundation/webpagetest/blob/master/www/optimization.inc#L275).

Existing Description:
An "Expires" header is present (and is not 0 or -1) or a "cache-control: max-age" directive is present and set for an hour or greater. If the expiration is set for less than 30 days you will get a warning (only applies to max-age currently).

Updated with:
An "Expires" header is present (and is not 0 or -1) or a "cache-control: max-age" directive is present and set for an hour or greater. If the expiration is set for less 7 days you will get a warning. If the expiration is set for less than 1 hour you will get a failure. This only applies to max-age currently. 
