### PR TITLE
New setting: EC2.IdleTerminateMinutes

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -194,9 +194,9 @@ function EC2_TerminateIdleInstances() {
           }
         }
         
-        // Keep the instance if the location had work in the last 15 minutes
-        // and if this instance has checked in recently
-        if (isset($lastWork) && isset($lastCheck) && $lastWork < 15 && $lastCheck < 15)
+        // Keep the instance if the location had work in the last
+        // EC2.IdleTerminateMinutes and if this instance has checked in recently
+        if (isset($lastWork) && isset($lastCheck) && $lastWork < $idleTerminateMinutes && $lastCheck < $idleTerminateMinutes)
           $terminate = false;
         
         if ($terminate) {

--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -167,14 +167,14 @@ function EC2_TerminateIdleInstances() {
     }
 
 	$idleTerminateMinutes = GetSetting("EC2.IdleTerminateMinutes");
-	$minutes = $instance['runningTime'] / 60.0;
-	if ($idleTerminateMinutes) {
-		$timeCheck = ( $minutes > $idleTerminateMinutes );
-	} else {
-		$timeCheck = ( $minutes > 15 && $minutes % 60 >= 50 );
-	}
 
     foreach($instances as $instance) {
+      $minutes = $instance['runningTime'] / 60.0;
+      if ($idleTerminateMinutes) {
+        $timeCheck = ( $minutes > $idleTerminateMinutes );
+      } else {
+        $timeCheck = ( $minutes > 15 && $minutes % 60 >= 50 );
+      }
       if ($timeCheck) {
         $terminate = true;
         $lastWork = null;   // last job assigned from this location

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -223,6 +223,21 @@ agentUpdate=http://cdn.webpagetest.org/
 ; Start an EC2 instance for every X tests in the queue (up to the location max)
 ;EC2.ScaleFactor=100
 
+; !!! ONLY SET THIS FOR LINUX AGENTS !!!
+;
+; Number of minutes to let an instance run idle before terminating.  This
+; is only helpful for Linux agents, where EC2 gets billed per second, with a
+; minimum of 60 seconds.
+; https://aws.amazon.com/about-aws/whats-new/2017/10/announcing-amazon-ec2-per-second-billing/
+;
+; Be careful, it is possible to set this too low.  It needs to be longer than
+; the time it takes for AWS to spin up a new instance and wptagent to start
+; processing tests.
+;
+; Windows is still billed hourly.  Do not set this if you are using Windows
+; agents.
+;EC2.IdleTerminateMinutes=15
+
 ; Default location when using EC2 auto-scaling - this setting is required for auto-scaling
 ;EC2.default=us-east-1
 


### PR DESCRIPTION
This setting is for Linux EC2 instances, which are now billed by the second,
with a minimum of 60 seconds.  The name says it all, it is an int that provides
the number of minutes to let an instance sit idle before terminating it.

I have included comments around this setting, because some caution is needed.
If you push the number too low the agent will not have time to spin up and
ask for tests before being considered idle.

Windows instances are still billed per hour.  When EC2.IdleTerminateMinutes
is not set then the existing termination logic is still applied.

https://aws.amazon.com/about-aws/whats-new/2017/10/announcing-amazon-ec2-per-second-billing/

This has been working fine for the Linux agents that I've been testing.  I have not tested for Windows agents, but there should be no change there ( assuming EC2.IdleTerminateMinutes is not set ).