### PR TITLE
EC2: Leave one instance online

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -349,7 +349,9 @@ function EC2_StartNeededInstances() {
             if (!isset($tester['offline']) || !$tester['offline'])
               $online++;
           }
-          if ($online < $online_target) {
+          // Leave one instance running, so that it can process any tests that
+          // come in before it hits the termination time limit.
+          if (($online > 1 ) && ($online < $online_target)) {
             foreach ($testers['testers'] as $tester) {
               if ($online < $online_target && isset($tester['offline']) && $tester['offline']) {
                 $tester['offline'] = false;


### PR DESCRIPTION
EC2_SendInstancesOffline() will mark all agents as offline when there are
no more tests to run. This creates a window where a new test can be submitted,
an EC2 agent is running, but will never get the test because it has been
marked as offline.  The test has to wait until the agent gets terminated, then
a new one is spun up to process the queued up test.

By leaving one agent online, it can continue to accept tests during the
count down to being terminated.  It will then get cleaned up by the normal
EC2_TerminateIdleInstances() process.