### PR TITLE
EC2: fix PR #973

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -273,8 +273,10 @@ function EC2_SendInstancesOffline() {
         foreach ($testers['testers'] as $tester) {
           if (!isset($tester['offline']) || !$tester['offline'])
             $online++;
-        }
-        if ($online > $online_target) {
+        }  
+        // Leave one instance running, so that it can process any tests that
+        // come in before it hits the termination time limit.
+        if (($online > 1 ) && ($online > $online_target)) {
           foreach ($testers['testers'] as &$tester) {
             if ($online > $online_target && (!isset($tester['offline']) || !$tester['offline'])) {
               $tester['offline'] = true;
@@ -349,9 +351,7 @@ function EC2_StartNeededInstances() {
             if (!isset($tester['offline']) || !$tester['offline'])
               $online++;
           }
-          // Leave one instance running, so that it can process any tests that
-          // come in before it hits the termination time limit.
-          if (($online > 1 ) && ($online < $online_target)) {
+          if ($online < $online_target) {
             foreach ($testers['testers'] as $tester) {
               if ($online < $online_target && isset($tester['offline']) && $tester['offline']) {
                 $tester['offline'] = false;


### PR DESCRIPTION
In the original PR - https://github.com/WPO-Foundation/webpagetest/pull/973 -
I had an update that made sure one EC2 instance was left running to process
new tests requests.  The change was sort of correct.  The logic was right, but
I made it in the wrong spot.

The change should have been made in EC2_SendInstancesOffline() - which is
what this change fixes.  However, it was instead done in
EC2_StartNeededInstances().

My ability to make mistakes with the WPT source code has gone to absurd
levels.  I simply did not pay enough attention to where I was in the source
code when committing this change to my local repo, compared to where I had
tested the correct change with a private WPT instance.