### PR TITLE
Fixed problem when enter long url Runtest.php

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -2447,7 +2447,8 @@ function ErrorPage($error) {
                 <?php
                 include 'header.inc';
 
-                echo "<p>$error</p>\n";
+                $str = $error;
+                echo wordwrap($str,150,"<br>\n",TRUE);
                 ?>
 
                 <?php include('footer.inc'); ?>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26427910/33804847-1df7b588-dde0-11e7-9d43-657b5145a0a5.png)
![image](https://user-images.githubusercontent.com/26427910/33804850-2b3e666a-dde0-11e7-9049-75775f519de2.png)
when input wrong and long url it'll show out of bound browser.