### PR TITLE
Remove input quickly.

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -150,7 +150,7 @@ $loc = ParseLocations($locations);
                 </ul>
                 <div id="analytical-review" class="test_box">
                     <ul class="input_fields">
-                        <li><input type="text" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
+                        <li><input type="search" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
                         <li>
                             <label for="location">Test Location</label>
                             <select name="where" id="location">


### PR DESCRIPTION
I think that if user want to remove a quick input, We should use type = "search" rather than type = "text".  If have any errors , I'm so sorry.

****Before****
![capture1](https://user-images.githubusercontent.com/26427911/33898569-704fc480-df9b-11e7-8ae9-8849a07da6a8.PNG)


****After****
![capture2](https://user-images.githubusercontent.com/26427911/33898739-e328d244-df9b-11e7-9ff3-d3ff2e0eb526.PNG)

