### PR TITLE
Remove input quickly

### DIFF
--- a/www/easy.php
+++ b/www/easy.php
@@ -67,7 +67,7 @@ $profiles = parse_ini_file('./settings/profiles.ini', true);
                 </ul>
                 <div id="analytical-review" class="test_box">
                     <ul class="input_fields">
-                        <li><input type="text" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}"></li>
+                        <li><input type="search" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}"></li>
                         <li>
                             <label for="profile">Test Configuration:</label>
                             <select name="profile" id="profile" onchange="profileChanged()">

--- a/www/index.php
+++ b/www/index.php
@@ -150,7 +150,7 @@ $loc = ParseLocations($locations);
                 </ul>
                 <div id="analytical-review" class="test_box">
                     <ul class="input_fields">
-                        <li><input type="text" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}"></li>
+                        <li><input type="search" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}"></li>
                         <li>
                             <label for="location">Test Location</label>
                             <select name="where" id="location">

--- a/www/traceroute.php
+++ b/www/traceroute.php
@@ -59,7 +59,7 @@ $page_description = "Test network path from multiple locations around the world 
                 </ul>
                 <div id="analytical-review" class="test_box">
                     <ul class="input_fields">
-                        <li><input type="text" name="url" id="url" value="Host Name/IP Address" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}"></li>
+                        <li><input type="search" name="url" id="url" value="Host Name/IP Address" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}"></li>
                         <li>
                             <label for="location">Test Location</label>
                             <select name="where" id="location">
@@ -112,7 +112,7 @@ $page_description = "Test network path from multiple locations around the world 
                                 Number of Tests to Run<br>
                                 <small>Up to <?php echo $settings['maxruns']; ?></small>
                             </label>
-                            <input id="number_of_tests" type="text" class="text short" name="runs" value="3">
+                            <input id="number_of_tests" type="search" class="text short" name="runs" value="3">
                         </li>
                     </ul>
                 </div>

--- a/www/video/index.php
+++ b/www/video/index.php
@@ -64,8 +64,8 @@ if (is_file(__DIR__ . '/../settings/profiles.ini'))
                             }
                             ?>
                             <div id="urldiv1" class="urldiv">
-                                Label: <input id="label1" type="text" name="label[1]" style="width:10em"> 
-                                URL: <input id="url1" type="text" name="url[1]" style="width:30em"> 
+                                Label: <input id="label1" type="search" name="label[1]" style="width:10em"> 
+                                URL: <input id="url1" type="search" name="url[1]" style="width:30em"> 
                                 <a href='#' onClick='return RemoveUrl("#urldiv1");'>Remove</a>
                             </div>
                         </div>


### PR DESCRIPTION
I think that if user want to remove a quick input, We should use type = "search" rather than type = "text". If have any errors , I'm so sorry.

Such as =>

Before
![capture1](https://user-images.githubusercontent.com/26427911/33903426-f0768a0e-dfaa-11e7-8b97-44e8273a039a.PNG)

After
![capture2](https://user-images.githubusercontent.com/26427911/33903447-fb0ccad2-dfaa-11e7-892a-96567a5614b8.PNG)

