### PR TITLE
Remove input quickly

### DIFF
--- a/www/easy.php
+++ b/www/easy.php
@@ -67,7 +67,7 @@ $profiles = parse_ini_file('./settings/profiles.ini', true);
                 </ul>
                 <div id="analytical-review" class="test_box">
                     <ul class="input_fields">
-                        <li><input type="text" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
+                        <li><input type="search" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
                         <li>
                             <label for="profile">Test Configuration:</label>
                             <select name="profile" id="profile" onchange="profileChanged()">

--- a/www/index.php
+++ b/www/index.php
@@ -150,7 +150,7 @@ $loc = ParseLocations($locations);
                 </ul>
                 <div id="analytical-review" class="test_box">
                     <ul class="input_fields">
-                        <li><input type="text" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
+                        <li><input type="search" name="url" id="url" value="<?php echo $url; ?>" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
                         <li>
                             <label for="location">Test Location</label>
                             <select name="where" id="location">

--- a/www/traceroute.php
+++ b/www/traceroute.php
@@ -59,7 +59,7 @@ $page_description = "Test network path from multiple locations around the world 
                 </ul>
                 <div id="analytical-review" class="test_box">
                     <ul class="input_fields">
-                        <li><input type="text" name="url" id="url" value="Host Name/IP Address" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
+                        <li><input type="search" name="url" id="url" value="Host Name/IP Address" class="text large" onfocus="if (this.value == this.defaultValue) {this.value = '';}" onblur="if (this.value == '') {this.value = this.defaultValue;}" onkeypress="if (event.keyCode == 32) {return false;}"></li>
                         <li>
                             <label for="location">Test Location</label>
                             <select name="where" id="location">

--- a/www/video/index.php
+++ b/www/video/index.php
@@ -64,8 +64,8 @@ if (is_file(__DIR__ . '/../settings/profiles.ini'))
                             }
                             ?>
                             <div id="urldiv1" class="urldiv">
-                                Label: <input id="label1" type="text" name="label[1]" style="width:10em"> 
-                                URL: <input id="url1" type="text" name="url[1]" style="width:30em" onkeypress="if (event.keyCode == 32) {return false;}" > 
+                                Label: <input id="label1" type="search" name="label[1]" style="width:10em"> 
+                                URL: <input id="url1" type="search" name="url[1]" style="width:30em" onkeypress="if (event.keyCode == 32) {return false;}" > 
                                 <a href='#' onClick='return RemoveUrl("#urldiv1");'>Remove</a>
                             </div>
                         </div>


### PR DESCRIPTION
I think that if user want to remove a quick input, We should use type = "search" rather than type = "text". If have any errors , I'm so sorry.

Such as =>

Before
![capture1](https://user-images.githubusercontent.com/26427911/33904581-8a7b7a1c-dfae-11e7-8c61-2e82ef57866d.PNG)

After
![capture2](https://user-images.githubusercontent.com/26427911/33904589-92eb51d6-dfae-11e7-9e89-f1f752202c6b.PNG)
 
Thank you .