### PR TITLE
Define max-width of textarea in pagestyle.css

### DIFF
--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -11,7 +11,7 @@ a {color: #000;}
 img {border: none;}
 input, select, textarea {color: #444;font-family: Arial, Helvetica, sans-serif;font-size: 12px;}
 input.checkbox, input.radio {margin: 0 10px 0 0;}
-textarea {overflow-x: hidden;width: 400px;height: 100px;padding: 3px;}
+textarea {overflow-x: hidden;width: 400px;height: 100px;padding: 3px; max-width: 99%}
 
 h2 .small {font-weight:normal; font-size: 12px;}
 h2 .medium {font-weight:normal; line-height: 18px; font-size: 18px;}

--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -11,7 +11,7 @@ a {color: #000;}
 img {border: none;}
 input, select, textarea {color: #444;font-family: Arial, Helvetica, sans-serif;font-size: 12px;}
 input.checkbox, input.radio {margin: 0 10px 0 0;}
-textarea {overflow-x: hidden;width: 400px;height: 100px;padding: 3px; max-width: 99%}
+textarea {overflow-x: hidden;width: 400px;height: 100px;padding: 3px; max-width: 99%;}
 
 h2 .small {font-weight:normal; font-size: 12px;}
 h2 .medium {font-weight:normal; line-height: 18px; font-size: 18px;}


### PR DESCRIPTION
for textarea in Advanced settings when you press a mouse for resizing horizontally out of "test_subbox-container" and you unpress a mouse then you can't resizing it again

Example
![image](https://user-images.githubusercontent.com/34522525/33964046-b42c5c4c-e089-11e7-9a24-99aed41c8c6f.png)

I fixes this with define max-width in pagestyle.css