### PR TITLE
Docker Tweaks so container can manage AMI's eg be used in k8s cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,15 +58,16 @@ COPY docker/server/config/php.ini /usr/local/etc/php/
 COPY docker/server/config/apache2.conf /etc/apache2/apache2.conf
 COPY docker/server/config/crontab /etc/crontab
 
-# config supervisor to run apache, cron, beanstalkd
+# config supervisor to run apache, cron, beanstalkd, ec2init
 COPY docker/server/config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY docker/server/config/supervisord/supervisord_apache.conf /etc/supervisor/conf.d/supervisord_apache.conf
 COPY docker/server/config/supervisord/supervisord_cron.conf /etc/supervisor/conf.d/supervisord_cron.conf
 COPY docker/server/config/supervisord/supervisord_beanstalkd.conf /etc/supervisor/conf.d/supervisord_beanstalkd.conf
+COPY docker/server/config/supervisord/supervisord_ec2init.conf /etc/supervisor/conf.d/supervisord_ec2init.conf
 
-# copy script to run WPT cron scripts
-COPY docker/server/scripts/wpt_cron_call.sh /scripts/wpt_cron_call.sh
-RUN chmod 755 /scripts/wpt_cron_call.sh && \
+# copy WPT scripts, set executable and create crontab
+COPY docker/server/scripts/ /scripts/
+RUN chmod 755 /scripts/* && \
     crontab /etc/crontab
 
 VOLUME /var/www/html/settings

--- a/docker/server/config/supervisord/supervisord_ec2init.conf
+++ b/docker/server/config/supervisord/supervisord_ec2init.conf
@@ -1,0 +1,13 @@
+[program:ec2init]
+command=/scripts/docker_ec2init.sh
+stderr_logfile=/var/log/supervisor/docker_ec2init_stderr.log
+stdout_logfile=/var/log/supervisor/docker_ec2init_stdout.log
+startsecs = 0
+autostart=true
+autorestart=false
+stopwaitsecs = 3
+stopasgroup = false
+killasgroup = true
+startretries=1
+exitcodes=0,2
+user=root

--- a/docker/server/scripts/docker_ec2init.sh
+++ b/docker/server/scripts/docker_ec2init.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 if [[ -n "${EC2_INIT}" && "${EC2_INIT}" == "true" ]]; then
+  if [[ -d '/user-data' ]]; then
+    rm /var/www/html/cli/user-data || true
+    cd /user-data
+    for k8s_secret in $(ls) ; do
+      echo "${k8s_secret}=$(cat $k8s_secret)" >> /var/www/html/cli/user-data
+    done
+  fi
   /usr/local/bin/php -c /usr/local/etc/php/php.ini /var/www/html/cli/ec2init.php
 fi

--- a/docker/server/scripts/docker_ec2init.sh
+++ b/docker/server/scripts/docker_ec2init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [[ -n "${EC2_INIT}" && "${EC2_INIT}" == "true" ]]; then
+  /usr/local/bin/php -c /usr/local/etc/php/php.ini /var/www/html/cli/ec2init.php
+fi

--- a/www/cli/ec2init.php
+++ b/www/cli/ec2init.php
@@ -84,13 +84,19 @@ function SetupAPIKeys() {
   $keys .= "description=API Key\n";
   $keys .= "limit=0\n";
   $keys .= "\n";
-  
+
   file_put_contents('./settings/keys.ini', $keys);
 }
 
 function GetUserData() {
   $ret = false;
-  $data = file_get_contents("http://169.254.169.254/latest/user-data");
+  if (file_exists('./cli/user-data')){
+    echo "Using local userdata file\n";
+    $data = file_get_contents('./cli/user-data');
+  } else {
+    echo "Looking for remote userdata file\n";
+  	$data = file_get_contents("http://169.254.169.254/latest/user-data");
+	}
   if ($data !== false && strlen($data)) {
     $ret = array();
     $lines = explode("\n", $data);

--- a/www/cli/ec2init.php
+++ b/www/cli/ec2init.php
@@ -95,8 +95,8 @@ function GetUserData() {
     $data = file_get_contents('./cli/user-data');
   } else {
     echo "Looking for remote userdata file\n";
-  	$data = file_get_contents("http://169.254.169.254/latest/user-data");
-	}
+    $data = file_get_contents("http://169.254.169.254/latest/user-data");
+  }
   if ($data !== false && strlen($data)) {
     $ret = array();
     $lines = explode("\n", $data);


### PR DESCRIPTION
These changes allow the image to be used in a [kubernetes chart](https://github.com/kubernetes/charts) so rather than just a local docker container OR an Amazon Image, one can now use the docker image to manage amazon agent instances.