### PR TITLE
Update CDN List: wordpress.com/gravatar.com

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -162,6 +162,8 @@ CDN_PROVIDER cdnList[] = {
   {".cdninstagram.com", "Facebook"},
   {".rlcdn.com", "Reapleaf"},
   {".wp.com", "WordPress"},
+  {".wordpress.com", "WordPress"},
+  {".gravatar.com", "WordPress"},
   {".aads1.net", "Aryaka"},
   {".aads-cn.net", "Aryaka"},
   {".aads-cng.net", "Aryaka"},


### PR DESCRIPTION
Both wordpress.com and gravatar.com are served from a global anycast CDN.