### PR TITLE
Add logic to include step number (from step 2 on) to view / download of Chrome Timeline / Traces

### DIFF
--- a/www/chrome/timeline.php
+++ b/www/chrome/timeline.php
@@ -7,7 +7,7 @@ include 'common.inc';
 $newTimeline = gz_is_file("$testPath/{$run}{$cachedText}_trace.json");
 if ($_REQUEST['run'] == 'lighthouse')
   $run = 'lighthouse';
-$timelineUrlParam = "/getTimeline.php?timeline=t:$id,r:$run,c:$cached";
+$timelineUrlParam = "/getTimeline.php?timeline=t:$id,r:$run,c:$cached,s:$step";
 ?>
 <!DOCTYPE html>
 <html>

--- a/www/chrome/trace.php
+++ b/www/chrome/trace.php
@@ -4,8 +4,10 @@ include 'common.inc';
 RestoreTest($id);
 if ($_REQUEST['run'] == 'lighthouse')
   $fileBase = 'lighthouse';
-else
-  $fileBase = "$run{$cachedText}";
+else{
+  $stepSuffix = $step > 1 ? ("_" . $step) : "";
+  $fileBase = "$run{$cachedText}{$stepSuffix}";
+}
 $traceFile = "$testPath/{$fileBase}_trace.json.gz";
 if (!is_file($traceFile) && is_file("$testPath/{$fileBase}_trace.json")) {
   if (gz_compress("$testPath/{$fileBase}_trace.json")) {

--- a/www/getTimeline.php
+++ b/www/getTimeline.php
@@ -12,13 +12,17 @@ if (isset($_REQUEST['timeline'])) {
       $_REQUEST['run'] = $value;
     elseif ($key == 'c')
       $_REQUEST['cached'] = $value;
+    elseif ($key == 's')
+      $_REQUEST['step'] = $value;
   }
 }
 include 'common.inc';
 if ($_REQUEST['run'] == 'lighthouse')
   $fileBase = 'lighthouse';
-else
-  $fileBase = "$run{$cachedText}";
+else {
+  $stepSuffix = $step > 1 ? ("_" . $step) : "";
+  $fileBase = "$run{$cachedText}{$stepSuffix}";
+}
 $ok = false;
 if (gz_is_file("$testPath/{$fileBase}_trace.json")) {
   $ok = true;


### PR DESCRIPTION
Fixes #1076 

Currently timeline for first step is downloaded / viewed for all steps, and although the traces for all steps can be downloaded the view always shows step 1

Test example - https://www.webpagetest.org/result/180102_MQ_8c463034f08bb8481ba760af8d3207c3/

