### PR TITLE
Fixed displaying the Chrome dev tools timeline

### DIFF
--- a/www/chrome/timeline.php
+++ b/www/chrome/timeline.php
@@ -8,6 +8,17 @@ $newTimeline = gz_is_file("$testPath/{$run}{$cachedText}_trace.json");
 if ($_REQUEST['run'] == 'lighthouse')
   $run = 'lighthouse';
 $timelineUrlParam = "/getTimeline.php?timeline=t:$id,r:$run,c:$cached,s:$step";
+if ($newTimeline) {
+  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+  $host  = $_SERVER['HTTP_HOST'];
+  $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
+  $cdn = GetSetting('cdn');
+  $url = $cdn ? $cdn : "$protocol://$host";
+  $url .= $uri;
+  // short-term hack because the timeline code doesn't URLdecode query params and we can't pass any URL with a &
+  $url .= "/inspector-20170320/inspector.html?experiments=true&loadTimelineFromURL=$timelineUrlParam";
+  header("Location: $url");
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -30,17 +41,7 @@ if (!$newTimeline) {
 }
 </script>
 <?php
-if ($newTimeline) {
-  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
-  $host  = $_SERVER['HTTP_HOST'];
-  $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
-  $cdn = GetSetting('cdn');
-  $url = $cdn ? $cdn : "$protocol://$host";
-  $url .= $uri;
-  // short-term hack because the timeline code doesn't URLdecode query params and we can't pass any URL with a &
-  $url .= "/inspector-20170320/inspector.html?experiments=true&loadTimelineFromURL=$timelineUrlParam";
-  header("Location: $url");
-} else {
+if (!$newTimeline) {
   echo '<iframe id="devtools" frameborder="0" height="100%" width="100%" src="/chrome/inspector-20140603/devtools.html" onload="DevToolsLoaded();"></iframe>';
 }
 ?>


### PR DESCRIPTION
The redirection to the Chrome inspector didn't work in our WPT setup. This happened due to the fact, that our webserver sent out parts of the HTML until it reached `header("Location: $url")`. Moving the URL building and redirecting above the HTML document seems to solve that problem.