### PR TITLE
Docker php config: Do not display errors/warnings as plain pages

### DIFF
--- a/docker/server/config/php.ini
+++ b/docker/server/config/php.ini
@@ -1,3 +1,4 @@
 upload_max_filesize = 20M
 post_max_size = 20M
 memory_limit = 512M
+display_errors = false


### PR DESCRIPTION
We came across the problem when using `debug` mode on wpt server (i.e. `<wpt-server-url>/?debug=1`). Running the wpt server with docker we got the following warning messages when using starting a test run with the debug mode:
![image](https://user-images.githubusercontent.com/25281769/35670497-0a6834f2-0739-11e8-8fa7-7a01cb89b48c.png)

Since this behaviour breaks functionality we should not display the errors/warnings as plain sites. Also the user should not be confronted with the error/warning messages like this.
