### PR TITLE
Add support for communication over server's Private IP

### DIFF
--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -232,6 +232,9 @@ agentUpdate=http://cdn.webpagetest.org/
 ; Start an EC2 instance for every X tests in the queue (up to the location max)
 ;EC2.ScaleFactor=100
 
+; Pass the private IP address of the server through user-data for auto-launch agents instead of public EIP
+ec2_use_server_private_ip=1
+
 ; !!! ONLY SET THIS FOR LINUX AGENTS !!!
 ;
 ; Number of minutes to let an instance run idle before terminating.  This

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -233,7 +233,7 @@ agentUpdate=http://cdn.webpagetest.org/
 ;EC2.ScaleFactor=100
 
 ; Pass the private IP address of the server through user-data for auto-launch agents instead of public EIP
-ec2_use_server_private_ip=1
+;ec2_use_server_private_ip=1
 
 ; !!! ONLY SET THIS FOR LINUX AGENTS !!!
 ;


### PR DESCRIPTION
This set of changes allows an administrator to choose whether they want to launch EC2 agents with userdata pointing to the public IP of the EC2 server or the private IP of the EC2 server. I've seen a number of requests for help in the forums where people had to add special security group rules to allow agents to pull work from the server's public IP, and we needed it because we're adding a completely private WPT infrastructure in AWS and don't want it exposed to the Internet at all.