### PR TITLE
Add hero element support

### DIFF
--- a/docs/Metrics/HeroElements.md
+++ b/docs/Metrics/HeroElements.md
@@ -10,3 +10,8 @@ You can also specify your own hero elements. This can be done by:
 
 - Adding the `elementtiming` attribute to any element. This approach is based on the [Hero Text Element Timing proposal](https://docs.google.com/document/d/1sBM5lzDPws2mg1wRKiwM0TGFv9WqI6gEdF7vYhBYqUg/edit?usp=sharing).
 - Specifying element names and selectors in the WebPageTest UI. These can be specified in the **Custom Hero Element Selectors** text box within the **Custom** tab. The format is a JSON string of `{ "heroElementName": "elementSelector" }`, for example: `{ "intro": "p.introduction", "buyButton": ".item .buy" }`.
+
+WebPageTest will also calculate two more hero metrics, based on the values of the other hero elements:
+
+- **First Painted Hero** - The time that the first hero element is visible in the viewport.
+- **Last Painted Hero** - The time that the last hero element is visible in the viewport.

--- a/docs/Metrics/HeroElements.md
+++ b/docs/Metrics/HeroElements.md
@@ -1,0 +1,12 @@
+# Hero Elements
+
+Hero elements enable you to measure when critical elements are displayed on screen. WebPageTest defines some default hero elements:
+
+- **H1** - The largest `<h1>` element visible in the viewport. If no `<h1>` is visible, then the largest `<h2>` will be used instead.
+- **Largest Image** - The largest `<img>` element visible in the viewport.
+- **Largest Background Image** - The largest element of any type visible in the viewport that has a background image.
+
+You can also specify your own hero elements. This can be done by:
+
+- Adding the `elementtiming` attribute to any element. This approach is based on the [Hero Text Element Timing proposal](https://docs.google.com/document/d/1sBM5lzDPws2mg1wRKiwM0TGFv9WqI6gEdF7vYhBYqUg/edit?usp=sharing).
+- Specifying element names and selectors in the WebPageTest UI. These can be specified in the **Custom Hero Element Selectors** text box within the **Custom** tab. The format is a JSON string of `{ "heroElementName": "elementSelector" }`, for example: `{ "intro": "p.introduction", "buyButton": ".item .buy" }`.

--- a/www/include/TestPaths.php
+++ b/www/include/TestPaths.php
@@ -361,6 +361,13 @@ class TestPaths {
   }
 
   /**
+   * @return string Path for the hero element timing results
+   */
+  public function heroElementsJsonFile() {
+    return $this->testRoot . $this->underscoreIdentifier() . "_hero_elements.json";
+  }
+
+  /**
    * @return string Path for the netlog-parsed requests
    */
   public function netlogRequestsFile() {

--- a/www/index.php
+++ b/www/index.php
@@ -161,6 +161,8 @@ $loc = ParseLocations($locations);
               echo '<input type="hidden" name="htmlbody" value="' . htmlspecialchars($_REQUEST['htmlbody']) . "\">\n";
             if (isset($_REQUEST['disable_video']))
               echo '<input type="hidden" name="disable_video" value="' . htmlspecialchars($_REQUEST['disable_video']) . "\">\n";
+            if (isset($_REQUEST['heroElementTimes']))
+              echo '<input type="hidden" name="heroElementTimes" value="' . htmlspecialchars($_REQUEST['heroElementTimes']) . "\">\n";
             ?>
 
             <h2 class="cufon-dincond_black">Test a website's performance</h2>
@@ -703,9 +705,14 @@ $loc = ParseLocations($locations);
                                             See <a href="https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/custom-metrics">the documentation</a> for details on how to specify custom metrics to be captured.
                                         </div></div>
                                     </div>
-                                    
+
                                     <p><label for="custom_metrics" class="full_width">Custom Metrics:</label></p>
                                     <textarea name="custom" id="custom_metrics" cols="0" rows="0"></textarea>
+
+                                    <?php if (isset($_REQUEST['heroElementTimes']) && $_REQUEST['heroElementTimes']): ?>
+                                    <p><br><label for="hero_elements" class="full_width">Custom Hero Element Selectors:</label></p>
+                                    <textarea name="heroElements" id="hero_elements" cols="0" rows="0"></textarea>
+                                    <?php endif ?>
                                 </div>
                             </div>
 

--- a/www/index.php
+++ b/www/index.php
@@ -709,6 +709,7 @@ $loc = ParseLocations($locations);
                                     <p><label for="custom_metrics" class="full_width">Custom Metrics:</label></p>
                                     <textarea name="custom" id="custom_metrics" cols="0" rows="0"></textarea>
 
+                                    <?php if (isset($_REQUEST['heroElementTimes']) && $_REQUEST['heroElementTimes']): ?>
                                     <div class="notification-container">
                                         <br>
                                         <div class="notification"><div class="message">
@@ -716,7 +717,6 @@ $loc = ParseLocations($locations);
                                         </div></div>
                                     </div>
 
-                                    <?php if (isset($_REQUEST['heroElementTimes']) && $_REQUEST['heroElementTimes']): ?>
                                     <p><br><label for="hero_elements" class="full_width">Custom Hero Element Selectors:</label></p>
                                     <textarea name="heroElements" id="hero_elements" cols="0" rows="0"></textarea>
                                     <?php endif ?>

--- a/www/index.php
+++ b/www/index.php
@@ -709,6 +709,13 @@ $loc = ParseLocations($locations);
                                     <p><label for="custom_metrics" class="full_width">Custom Metrics:</label></p>
                                     <textarea name="custom" id="custom_metrics" cols="0" rows="0"></textarea>
 
+                                    <div class="notification-container">
+                                        <br>
+                                        <div class="notification"><div class="message">
+                                            See <a href="https://github.com/WPO-Foundation/webpagetest/blob/master/docs/Metrics/HeroElements.md">the documentation</a> for details on how to specify custom hero elements.
+                                        </div></div>
+                                    </div>
+
                                     <?php if (isset($_REQUEST['heroElementTimes']) && $_REQUEST['heroElementTimes']): ?>
                                     <p><br><label for="hero_elements" class="full_width">Custom Hero Element Selectors:</label></p>
                                     <textarea name="heroElements" id="hero_elements" cols="0" rows="0"></textarea>

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -459,7 +459,26 @@ function loadPageStepData($localPaths, $runCompleted, $testInfo = null) {
       }
     }  
   }
-  
+
+  $hero_elements_file = $localPaths->heroElementsJsonFile();
+  if (gz_is_file($hero_elements_file)) {
+    $hero_elements = json_decode(gz_file_get_contents($hero_elements_file), true);
+    if ($hero_elements) {
+      $ret['heroElements'] = array();
+      $ret['heroElementTimes'] = array();
+      if (isset($hero_elements['heroes'])) {
+        $ret['heroElements'] = $hero_elements['heroes'];
+      }
+      if (isset($hero_elements['timings'])) {
+        foreach ($hero_elements['timings'] as $timing) {
+          if (isset($timing['value'])) {
+            $ret['heroElementTimes'][$timing['name']] = $timing['value'];
+          }
+        }
+      }
+    }
+  }
+
   if (isset($ret['fullyLoaded']))
     $ret['fullyLoaded'] = intval(round($ret['fullyLoaded']));
   

--- a/www/work/getwork.php
+++ b/www/work/getwork.php
@@ -197,6 +197,8 @@ function TestToJSON($testInfo) {
                   $testJson['customMetrics'][$metric] = $code;
                 }
               }
+            } elseif ($key == 'heroElements') {
+              $testJson['heroElements'] = json_decode(base64_decode($value));
             } elseif ($key == 'injectScript') {
               $testJson['injectScript'] = base64_decode($value);
             } elseif( filter_var($value, FILTER_VALIDATE_INT) !== false ) {


### PR DESCRIPTION
Don't merge this yet! It's pretty much ready to go, pending my figuring out where to store the timing results so that they can be surfaced in resultJson.php. I'll ping you when it's fully tested and ready.

 - Allow custom element selectors to be specified on a per-test basis
 - Expose hero element timing in JSON results

Related PR: WPO-Foundation/wptagent#99