### PR TITLE
Expose hero times in UI

### DIFF
--- a/www/include/RunResultHtmlTable.php
+++ b/www/include/RunResultHtmlTable.php
@@ -12,6 +12,7 @@ class RunResultHtmlTable {
   const COL_DOM_ELEMENTS = "domElements";
   const COL_TTI = "FirstInteractive";
   const COL_SPEED_INDEX = "SpeedIndex";
+  const COL_LAST_PAINTED_HERO = "LastPaintedHero";
   const COL_VISUAL_COMPLETE = "visualComplete";
   const COL_RESULT = "result";
   const COL_COST = "cost";
@@ -41,8 +42,8 @@ class RunResultHtmlTable {
     $this->runResults = $runResults;
     $this->rvRunResults = $rvRunResults;
     $this->isMultistep = $runResults->isMultistep();
-    $this->leftOptionalColumns = array(self::COL_LABEL, self::COL_USER_TIME,
-      self::COL_TTI, self::COL_SPEED_INDEX, self::COL_VISUAL_COMPLETE, self::COL_RESULT);
+    $this->leftOptionalColumns = array(self::COL_LABEL, self::COL_USER_TIME, self::COL_TTI,
+      self::COL_SPEED_INDEX, self::COL_LAST_PAINTED_HERO, self::COL_VISUAL_COMPLETE, self::COL_RESULT);
     $this->rightOptionalColumns = array(self::COL_CERTIFICATE_BYTES, self::COL_COST);
     $this->enabledColumns = array();
 
@@ -52,7 +53,7 @@ class RunResultHtmlTable {
     $this->enabledColumns[self::COL_RESULT] = true;
     $this->enabledColumns[self::COL_CERTIFICATE_BYTES] = $runResults->hasValidNonZeroMetric('certificate_bytes');
     $checkByMetric = array(self::COL_USER_TIME, self::COL_DOM_TIME, self::COL_TTI, self::COL_SPEED_INDEX,
-                           self::COL_VISUAL_COMPLETE);
+                           self::COL_LAST_PAINTED_HERO, self::COL_VISUAL_COMPLETE);
     foreach ($checkByMetric as $col) {
       $this->enabledColumns[$col] = $runResults->hasValidMetric($col) ||
                                    ($rvRunResults && $rvRunResults->hasValidMetric($col));
@@ -136,6 +137,9 @@ class RunResultHtmlTable {
     }
     if ($this->isColumnEnabled(self::COL_SPEED_INDEX)) {
       $out .= $this->_headCell('<a href="' . self::SPEED_INDEX_URL . '" target="_blank">Speed Index</a>');
+    }
+    if ($this->isColumnEnabled(self::COL_LAST_PAINTED_HERO)) {
+      $out .= $this->_headCell('<a href="https://github.com/WPO-Foundation/webpagetest/blob/master/docs/Metrics/HeroElements.md">Last Painted Hero</a>');
     }
     if ($this->isColumnEnabled(self::COL_DOM_TIME)) {
       $out .= $this->_headCell("DOM Element");
@@ -233,6 +237,9 @@ class RunResultHtmlTable {
       $speedIndex = $speedIndex !== null ? $speedIndex : $stepResult->getMetric("SpeedIndex");
       $speedIndex = $speedIndex !== null ? $speedIndex : "-";
       $out .= $this->_bodyCell($idPrefix . "SpeedIndex" . $idSuffix, $speedIndex, $class);
+    }
+    if($this->isColumnEnabled(self::COL_LAST_PAINTED_HERO)) {
+      $out .= $this->_bodyCell($idPrefix . "LastPaintedHero" . $idSuffix, $this->_getIntervalMetric($stepResult, "LastPaintedHero"), $class);
     }
     if ($this->isColumnEnabled(self::COL_DOM_TIME)) {
       $out .= $this->_bodyCell($idPrefix . "DomTime" . $idSuffix, $this->_getIntervalMetric($stepResult, "domTime"), $class);

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -476,6 +476,12 @@ function loadPageStepData($localPaths, $runCompleted, $testInfo = null) {
           }
         }
       }
+
+      foreach (['FirstPaintedHero', 'LastPaintedHero'] as $metric) {
+        if (isset($ret['heroElementTimes'][$metric])) {
+          $ret[$metric] = $ret['heroElementTimes'][$metric];
+        }
+      }
     }
   }
 

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -473,6 +473,7 @@ function loadPageStepData($localPaths, $runCompleted, $testInfo = null) {
         foreach ($hero_elements['timings'] as $timing) {
           if (isset($timing['value'])) {
             $ret['heroElementTimes'][$timing['name']] = $timing['value'];
+            $ret["heroElementTimes.{$timing['name']}"] = $timing['value'];
           }
         }
       }

--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 include __DIR__ . '/common.inc';
 require_once __DIR__ . '/video.inc';
 require_once __DIR__ . '/page_data.inc';
@@ -228,6 +228,59 @@ function printStep($fileHandler, $testInfo, $testStepResult, $useQuicklinks) {
     if ($fileHandler->fileExists($localPaths->additionalScreenShotFile("responsive"))) {
         echo '<br><br><h2 id="responsive">Responsive Site Check</h2>';
         echo '<img class="center" alt="Responsive Site Check image" src="' . $urlPaths->additionalScreenShotFile("responsive") . '">';
+    }
+
+    // Display hero element frames
+    if (gz_is_file($localPaths->heroElementsJsonFile())) {
+        $hero_data = json_decode(gz_file_get_contents($localPaths->heroElementsJsonFile()), true);
+        $visual_progress = $testStepResult->getVisualProgress();
+
+        if (isset($visual_progress['frames']) && $hero_data) {
+            $frames = $visual_progress['frames'];
+            $hero_elements = $hero_data['heroes'];
+            $hero_times = $testStepResult->getMetric('heroElementTimes');
+            $viewport = $hero_data['viewport'];
+
+            foreach ($hero_elements as $hero) {
+                $hero_time = $hero_times[$hero['name']];
+
+                if ($hero_time > 0 && isset($frames[$hero_time])) {
+                    $frame_path = $frames[$hero_time]['path'];
+                    if (strtolower(substr($frame_path, -4)) == '.png') {
+                        $frame = imagecreatefrompng("./{$frame_path}");
+                    } else {
+                        $frame = imagecreatefromjpeg("./{$frame_path}");
+                    }
+
+                    $frame_w = imagesx($frame);
+                    $frame_h = imagesy($frame);
+                    imagedestroy($frame);
+
+                    $scale = min($frame_w / $viewport['width'], $frame_h / $viewport['height']);
+                    $x = $hero['x'] * $scale;
+                    $y = $hero['y'] * $scale;
+                    $w = $hero['width'] * $scale;
+                    $h = $hero['height'] * $scale;
+
+                    echo '<br><br><h2 id="hero_' . $hero['name'] . '">Hero Time: ' . $hero['name'] . '</h2>';
+                    echo '<div style="display: inline-block; position: relative">';
+                    echo '<img class="center" alt="Hero Element Screen Shot" src="' . $frame_path . '">';
+                    echo <<<SVG
+                    <svg viewBox="0 0 {$frame_w} {$frame_h}" xmlns="http://www.w3.org/2000/svg" style="position: absolute; top: 0; left: 0; width: {$frame_w}; height: {$frame_h};">
+                        <rect x="0" y="0" width="100%" height="100%" fill="rgba(0, 0, 0, 0.3)" mask="url(#opacity-mask)" />
+
+                        <mask id="opacity-mask" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">
+                            <rect x="0" y="0" width="100%" height="100%" fill="white" />
+                            <rect x="{$x}" y="{$y}" width="{$w}" height="{$h}" fill="black" />
+                        </mask>
+
+                        <rect x="{$x}" y="{$y}" width="{$w}" height="{$h}" stroke="rgb(0, 255, 0)" stroke-width="2" fill="none" />
+                    </svg>
+SVG;
+                    echo '</div>';
+                }
+            }
+        }
     }
 
     // display all of the status messages

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -723,6 +723,16 @@ function DisplayGraphs() {
     foreach($tests as &$test) {
         $hasStepResult = array_key_exists('stepResult', $test) && is_a($test['stepResult'], "TestStepResult");
         if ($hasStepResult &&
+            !empty($test['stepResult']->getMetric('heroElements'))) {
+            foreach ($test['stepResult']->getMetric('heroElements') as $hero) {
+                $heroKey = "heroElementTimes.{$hero['name']}";
+
+                if (!isset($timeMetrics[$heroKey])) {
+                    $timeMetrics[$heroKey] = "Hero {$hero['name']}";
+                }
+            }
+        }
+        if ($hasStepResult &&
             !isset($timeMetrics['visualComplete85']) &&
             $test['stepResult']->getMetric('visualComplete85') > 0) {
             $timeMetrics['visualComplete85'] = "85% Visually Complete";


### PR DESCRIPTION
I've split this out info separate commits so feel free to cherry-pick. I've exposed the hero times in a few places in the UI:

## Metrics chart in the filmstrip view (LPH)

![screenshot_2018-07-09 webpagetest - visual comparison](https://user-images.githubusercontent.com/794263/42428532-2e0292ba-8388-11e8-9ed0-c0ff8bcf9e69.png)

## Test result summary table (LPH)

![screenshot_2018-07-09 webpagetest test result - joseph s xps 13 www bbc com news - 07 09 18 14 14 35](https://user-images.githubusercontent.com/794263/42428533-2e34019c-8388-11e8-892b-4add2ebb249b.png)

## Screen shot page (all hero elements)

![screenshot_2018-07-09 webpagetest screen shots - joseph s xps 13 www bbc com news - 07 09 18 14 14 35](https://user-images.githubusercontent.com/794263/42428534-2e668018-8388-11e8-85e5-7906a660b8c9.png)
