### PR TITLE
Basic Authentication: type=password to password

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -634,7 +634,7 @@ $loc = ParseLocations($locations);
                                     </li>
                                     <li>
                                         <label for="password" style="width: auto;">Password</label>
-                                        <input type="text" name="password" id="password" class="text" style="width: 200px;">
+                                        <input type="password" name="password" id="password" class="text" style="width: 200px;">
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
I think the "use test account" notice isn't enough for security: anyone accessing the browser could easily read the previously entered credentials. I'm adding a `type="password"` to the `input` field.