### PR TITLE
Make webpagetest (slightly) more responsive

### DIFF
--- a/www/head.inc
+++ b/www/head.inc
@@ -11,6 +11,8 @@ if( strlen($page_description) )
 <link rel="shortcut icon" href="/images/favicon.ico" type="image/vnd.microsoft.icon">
 <link rel="icon" href="/images/favicon.png" type="image/png">
 
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
 <?php 
     if(!isset($noanalytics) && extension_loaded('newrelic'))
         echo @newrelic_get_browser_timing_header();
@@ -24,6 +26,7 @@ if( strlen($page_description) )
       include('./js/user-timing-rum-min.js');
     echo "\n</script>\n";
     echo "<link rel=\"stylesheet\" href=\"{$GLOBALS['cdnPath']}/pagestyle.css?v=" . VER_CSS . "\" type=\"text/css\">\n";
+    echo "<link rel=\"stylesheet\" href=\"{$GLOBALS['cdnPath']}/minimally-responsive.css?v=" . VER_CSS . "\" type=\"text/css\">\n";
     echo "<style type=\"text/css\">\n";
     
     // switch to the private install logo if we're not running on webpagetest

--- a/www/minimally-responsive.css
+++ b/www/minimally-responsive.css
@@ -1,0 +1,14 @@
+ @media only screen and (max-width: 980px) {
+    /* remove explicitly-set widths on a bunch of things */
+    .page, #test_box-container, .test_box input.text.large, .test_box label {
+        width: auto;
+    }
+    .test_box select, #location {
+        width: auto;
+        display: block;
+    }
+    #test_box-container, .test_box label { float: none; }
+    #test_box-container .ui-tabs-nav { height: auto; }
+    #test_box-container .ui-tabs-nav li { float: none; width: auto; display: block; }
+
+}


### PR DESCRIPTION
A small amount of CSS overrides, applied when the page width is less than 980px, to make pages be a bit more vertical and responsive. Not intended to be a complete fix by any means, but it's a start. Done as a separate CSS file so that the changes are isolated and can be easily removed, rather than adding a media query to the 'main' CSS; eventually as the site becomes responsive overall, this would of course be integrated into the main CSS.

I don't have a full webpagetest setup here, so I can't test actual webpagetests; in particular, this may mean that these CSS changes break result pages and the like. If that's the case, then the easiest thing might be to add `class="responsive-ok"` to `<body>` in index.php and apply this CSS just to `body.responsive-ok`, and gradually extend that selector so that it covers more pages as they're fixed.