### PR TITLE
Add the Bing Ads tracking script's CDN

### DIFF
--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -109,6 +109,7 @@ CDN_PROVIDER cdnList[] = {
   {".vo.msecnd.net", "Microsoft Azure"},
   {".azureedge.net", "Microsoft Azure"},
   {".azure.microsoft.com", "Microsoft Azure"},
+  {"bat.bing.com", "Microsoft"},
   {".voxcdn.net", "VoxCDN"},
   {".bluehatnetwork.com", "Blue Hat Network"},
   {".swiftcdn1.com", "SwiftCDN"},

--- a/agent/wpthook/cdn.h
+++ b/agent/wpthook/cdn.h
@@ -242,7 +242,8 @@ CDN_PROVIDER_HEADER cdnHeaderList[] = {
   {"server", "MNCDN", "Medianova"},
   {"server", "Roast.io", "Roast.io"},
   {"server", "SingularCDN", "Singular CDN"},
-  {"x-rocket-node", "", "Rocket CDN"}
+  {"x-rocket-node", "", "Rocket CDN"},
+  {"x-msedge-ref", "", "Microsoft"}
 };
 
 // Specific providers that require multiple headers


### PR DESCRIPTION
Used for example by the Bing Ads tracking script: https://bat.bing.com/bat.js.
I've chosen to add bat.bing.com directly in the domain lists in case they change their CDN in the future and to add the x-msedge-ref header as well to cover other usages of this CDN.