### PR TITLE
Preserve original user timing mark names

### DIFF
--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -895,6 +895,7 @@ function loadUserTimingData(&$pageData, $userTimingFile) {
               if (!isset($pageData['userTimes']))
                 $pageData['userTimes'] = array();
               $pageData['userTimes'][$name] = $time;
+              $pageData['userTimes'][$event['name']] = $time;
             }
           } elseif ($event['entryType'] == 'measure' &&
                     isset($event['duration'])) {


### PR DESCRIPTION
It would be nice if we could preserve the original user timing names as well as the simplified `userTimes.{$name}` ones.