### PR TITLE
Only count navigationStart as start time candidates

### DIFF
--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -967,7 +967,7 @@ function ParseUserTiming($file) {
     // Find the first navigation to determine which is the main frame
     foreach ($events as $event) {
       if (is_array($event) && isset($event['name']) && isset($event['ts'])) {
-        if (!isset($start_time)) {
+        if (!isset($start_time) && $event['name'] == 'navigationStart') {
           $start_time = $event['ts'];
         }
         if ($event['name'] == 'navigationStart' ||


### PR DESCRIPTION
Hey Pat! We just noticed an issue where the `chromeUserTiming` times were incorrect. I found that `ParseUserTiming()` was setting the start timestamp based on the first user timing event. However I've seen at least two test runs where the first event is InteractiveTime.

I don't think this is the intended behaviour - shouldn't the start timestamp should be based on an event that we know represents the beginning of the page navigation? This patch would limit it to the navigationStart event, but I'm not sure if there are other events that would be start time candidates.