### PR TITLE
Newer versions of xdebug do not support php < 7.0.

### DIFF
--- a/docker/local/Dockerfile_dev
+++ b/docker/local/Dockerfile_dev
@@ -1,6 +1,6 @@
 FROM webpagetest/server 
 
-RUN yes | pecl install xdebug \
+RUN yes | pecl install xdebug-2.5.5 \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini


### PR DESCRIPTION
Since the base im…age is PHP 5.6, force the installation of a version of xdebug that works.

Addresses #1201 