### PR TITLE
Update indicator for private tests

### DIFF
--- a/www/js/test.js
+++ b/www/js/test.js
@@ -450,10 +450,7 @@ function UpdateSettingsSummary()
     if( conn != undefined )
         summary += ", " + conn.replace(/\((.)*\)/,'') + " connection";
         
-    if( $('#keep_test_private').attr('checked') )
-        summary += ", private";
-    else
-        summary += ", results are public";
+    summary += ", results are private";
         
     $('#settings_summary').text(summary);
 }

--- a/www/js/test.js
+++ b/www/js/test.js
@@ -450,7 +450,6 @@ function UpdateSettingsSummary()
     if( conn != undefined )
         summary += ", " + conn.replace(/\((.)*\)/,'') + " connection";
         
-    summary += ", results are private";
         
     $('#settings_summary').text(summary);
 }


### PR DESCRIPTION
The test summary (when advanced settings is closed) indicates that tests are public, even though they are private by default. 

![image](https://user-images.githubusercontent.com/7459458/48747580-c52ead00-ec41-11e8-9407-dc29f35bbfb7.png)

This change updates the `UpdateSettingsSummary` function to always indicate that tests are private in the summary.