### PR TITLE
Increased the label input width to allow more characters to be seen

### DIFF
--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -104,10 +104,10 @@ h2 .medium {font-weight:normal; line-height: 18px; font-size: 18px;}
 .test_box input.text.short {width: 40px;}
 .test_box input.before_label {float: left;width: auto;}
 .test_box select {width: 380px;}
+.test_box #label {width: 200px;}
 .pending_tests {margin-left: 10px;color: #dcb315;font-size: 10px;}
 #addheaders {width: 400px;}
 #location {width: 370px;}
-#label {width: 200px;}
 
 #simplemodal-overlay {background-color:#000;}
 #simplemodal-container {background-color:#fff; border:2px solid #444; padding:4px;}

--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -107,6 +107,7 @@ h2 .medium {font-weight:normal; line-height: 18px; font-size: 18px;}
 .pending_tests {margin-left: 10px;color: #dcb315;font-size: 10px;}
 #addheaders {width: 400px;}
 #location {width: 370px;}
+#label {width: 200px;}
 
 #simplemodal-overlay {background-color:#000;}
 #simplemodal-container {background-color:#fff; border:2px solid #444; padding:4px;}


### PR DESCRIPTION
I've been finding the width of the test settings "label" input field quite limiting. I tend to add details around protocol, mobile, page, connection type etc for quick reference. The input currently displays 12 characters.

![screen shot 2018-12-06 at 22 51 07](https://user-images.githubusercontent.com/1223960/49616658-760aab00-f9a9-11e8-9ad1-681f73056b5c.png)

Small CSS tweak to increase the width to 200px, and allow for 20 characters to be visible.

![screen shot 2018-12-06 at 22 50 19](https://user-images.githubusercontent.com/1223960/49616632-5d9a9080-f9a9-11e8-840e-cd897ea3a051.png)


 