### PR TITLE
Fix PHP fatal: make $metric optional in graphite_key()

### DIFF
--- a/www/lib/statsd.inc.php
+++ b/www/lib/statsd.inc.php
@@ -56,7 +56,7 @@ function StatsdPost($location, $browser, $label, $cached, &$metrics) {
   }
 }
 
-function graphite_key($location, $browser, $label, $cached, $metric) {
+function graphite_key($location, $browser, $label, $cached, $metric = '') {
   if (GetSetting('statsdCleanPattern')) {
     $label = preg_replace('/' . GetSetting('statsdPattern') . '/', '', $label);
   }


### PR DESCRIPTION
The function signature for graphite_key() requires 5 arguments, but it is only getting called with 4.  That generates the following PHP fatal error in PHP 7.1+:

Uncaught ArgumentCountError: Too few arguments to function graphite_key(), 4 passed in www/lib/statsd.inc.php on line 52 and exactly 5 expected in www/lib/statsd.inc.php:59

The approach I've taken is to make the $metric argument optional, defaulting to an empty string.  The function does not use it, so another option would be to remove it.  I did not do that, just in case there are others depending on this function to continue to have 5 arguments.