### PR TITLE
Fix PHP warnings: make sure count() is given an array

### DIFF
--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -2049,7 +2049,7 @@ function UpdateTester($location, $tester, $testerInfo = null, $cpu = null, $erro
 
   // keep track of the success/error count
   if (isset($error)) {
-    if (!isset($tester_info['errors']))
+    if (!isset($tester_info['errors']) || !is_array($tester_info['errors']))
       $tester_info['errors'] = array();
     $tester_info['errors'][] = strlen($error) ? 100 : 0;
     if (count($tester_info['errors']) > 100)


### PR DESCRIPTION
Under PHP 7.2+ I get the following warnings:

```
PHP Warning:  Cannot use a scalar value as an array in www/common_lib.inc on line 2054

PHP Warning:  count(): Parameter must be an array or an object that implements Countable in www/common_lib.inc on line 2055
```

After some logging it appears that $tester_info['errors'] becomes zero under certain conditions.  In that case it never hits line 2053 where it gets initialized as an array.  Then count() emits the warning because it didn't get a countable variable, in this case an array.

This change updates the !isset() check to also make sure that $tester_info['errors'] is an array, and if it isn't, then we do the same initialization to make sure it is an array.