### PR TITLE
Enable hero element timing by default

### DIFF
--- a/docs/Metrics/HeroElements.md
+++ b/docs/Metrics/HeroElements.md
@@ -15,3 +15,23 @@ WebPageTest will also calculate two more hero metrics, based on the values of th
 
 - **First Painted Hero** - The time that the first hero element is visible in the viewport.
 - **Last Painted Hero** - The time that the last hero element is visible in the viewport.
+
+## How hero elements are measured
+
+Hero element rendering times are calculated as follows:
+
+1. Identify the largest hero elements in the viewport.
+2. Collect the dimensions and position of these elements, as well as any custom selectors and elements with the `elementtiming` attribute.
+3. For each of the hero elements, crop the final video frame to use as a "fully rendered" reference.
+4. Iterate over each video frame, applying the same crop and comparing it to the reference frame.
+5. When a frame is found that is sufficiently similar to the reference, use the timestamp of that frame as the hero element render time.
+
+## Limitations
+
+### Only elements in the viewport can be measured
+
+Since the hero element timings are determined by analysing video frames, only elements that appear in the viewport can be measured. The hero element detection is done in such a way that only part of the element must be visible.
+
+### Animated content or pop-overs can interfere
+
+When a hero element is animated or is covered by pop-over elements, the rendering times may not be accurate. This is because the "fully rendered" reference frame may have the hero element in a state that is different to when it first renders.

--- a/www/index.php
+++ b/www/index.php
@@ -726,7 +726,6 @@ $loc = ParseLocations($locations);
                                     <p><label for="custom_metrics" class="full_width">Custom Metrics:</label></p>
                                     <textarea name="custom" id="custom_metrics" cols="0" rows="0"></textarea>
 
-                                    <?php if (isset($_REQUEST['heroElementTimes']) && $_REQUEST['heroElementTimes']): ?>
                                     <div class="notification-container">
                                         <br>
                                         <div class="notification"><div class="message">
@@ -736,7 +735,6 @@ $loc = ParseLocations($locations);
 
                                     <p><br><label for="hero_elements" class="full_width">Custom Hero Element Selectors:</label></p>
                                     <textarea name="heroElements" id="hero_elements" cols="0" rows="0"></textarea>
-                                    <?php endif ?>
                                 </div>
                             </div>
 

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -210,7 +210,7 @@
               $test['lighthouse'] = $req_lighthouse;
             $test['lighthouseTrace'] = isset($_REQUEST['lighthouseTrace']) && $_REQUEST['lighthouseTrace'] ? 1 : 0;
             $test['lighthouseThrottle'] = isset($_REQUEST['lighthouseThrottle']) && $_REQUEST['lighthouseThrottle'] ? 1 : GetSetting('lighthouseThrottle', 0);
-            $test['heroElementTimes'] = isset($_REQUEST['heroElementTimes']) ? (int) $_REQUEST['heroElementTimes'] : 1;
+            $test['heroElementTimes'] = isset($_REQUEST['heroElementTimes']) && $_REQUEST['heroElementTimes'] ? 1 : GetSetting('heroElementTimes', 0);
             if (isset($req_timeline))
               $test['timeline'] = $req_timeline;
             if (isset($_REQUEST['timeline_fps']) && $_REQUEST['timeline_fps'])
@@ -2235,8 +2235,8 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
                 AddIniLine($testFile, 'lighthouseTrace', '1');
             if( isset($test['lighthouseThrottle']) && $test['lighthouseThrottle'] )
                 AddIniLine($testFile, 'lighthouseThrottle', '1');
-            if( isset($test['heroElementTimes']) )
-                AddIniLine($testFile, 'heroElementTimes', $test['heroElementTimes']);
+            if( isset($test['heroElementTimes']) && $test['heroElementTimes'] )
+                AddIniLine($testFile, 'heroElementTimes', '1');
             if( isset($test['coverage']) && $test['coverage'] )
                 AddIniLine($testFile, 'coverage', '1');
             if( isset($test['heroElements']) && strlen($test['heroElements']) )

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -210,7 +210,7 @@
               $test['lighthouse'] = $req_lighthouse;
             $test['lighthouseTrace'] = isset($_REQUEST['lighthouseTrace']) && $_REQUEST['lighthouseTrace'] ? 1 : 0;
             $test['lighthouseThrottle'] = isset($_REQUEST['lighthouseThrottle']) && $_REQUEST['lighthouseThrottle'] ? 1 : GetSetting('lighthouseThrottle', 0);
-            $test['heroElementTimes'] = isset($_REQUEST['heroElementTimes']) && $_REQUEST['heroElementTimes'] ? 1 : 0;
+            $test['heroElementTimes'] = isset($_REQUEST['heroElementTimes']) ? (int) $_REQUEST['heroElementTimes'] : 1;
             if (isset($req_timeline))
               $test['timeline'] = $req_timeline;
             if (isset($_REQUEST['timeline_fps']) && $_REQUEST['timeline_fps'])
@@ -2235,8 +2235,8 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
                 AddIniLine($testFile, 'lighthouseTrace', '1');
             if( isset($test['lighthouseThrottle']) && $test['lighthouseThrottle'] )
                 AddIniLine($testFile, 'lighthouseThrottle', '1');
-            if( isset($test['heroElementTimes']) && $test['heroElementTimes'] )
-                AddIniLine($testFile, 'heroElementTimes', '1');
+            if( isset($test['heroElementTimes']) )
+                AddIniLine($testFile, 'heroElementTimes', $test['heroElementTimes']);
             if( isset($test['coverage']) && $test['coverage'] )
                 AddIniLine($testFile, 'coverage', '1');
             if( isset($test['heroElements']) && strlen($test['heroElements']) )

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -80,6 +80,9 @@ allowNonFQDN=0
 ;Uncomment to disable the force "3G Fast" throttling applied to lighthouse tests.
 ;lighthouseThrottle=1
 
+;Uncomment enable hero element times.
+;heroElementTimes=1
+
 ;Software identification string to include in the user agent string of tests
 ;UAModifier=PTST
 


### PR DESCRIPTION
SpeedCurve have been capturing hero element timing with wptagent for a while now. I recently performed some analysis to figure out whether the times reported by wptagent were close enough to the times reported by our existing implementation. For around 95% of our tests, the times varied by <10%. I dug into a load of the remaining 5% of tests and we determined that most of the differences were for acceptable reasons - mostly caused by fuzziness, since our implementation works with JPEG frames.

Anyways, we're pretty confident that the implementation in wptagent is good enough that everyone can use it reliably, so I'd like to turn it on by default in webpagetest.org.

There will be an accompanying PR in wptagent.