### PR TITLE
Generate correct URLs if WPT runs behind a SSL-terminating proxy

### DIFF
--- a/www/benchmarks/cron.php
+++ b/www/benchmarks/cron.php
@@ -119,7 +119,7 @@ function PreProcessBenchmark($benchmark) {
     echo "Benchmark '$benchmark' needs processing, spawning task\n";
     logMsg("Benchmark '$benchmark' needs processing, spawning task", "./log/$logFile", true);
 
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $url = "$protocol://" . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'] . '?benchmark=' . urlencode($benchmark);
     if (function_exists('curl_init')) {
       $c = curl_init();
@@ -497,7 +497,7 @@ function SubmitBenchmarkTest($url, $location, &$settings, $benchmark) {
                     ));
 
     $ctx = stream_context_create($params);
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $fp = fopen("$protocol://{$_SERVER['HTTP_HOST']}/runtest.php", 'rb', false, $ctx);
     if ($fp) {
         $response = @stream_get_contents($fp);

--- a/www/chrome/timeline.php
+++ b/www/chrome/timeline.php
@@ -9,7 +9,7 @@ if ($_REQUEST['run'] == 'lighthouse')
   $run = 'lighthouse';
 $timelineUrlParam = "/getTimeline.php?timeline=t:$id,r:$run,c:$cached,s:$step";
 if ($newTimeline) {
-  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+  $protocol = getUrlProtocol();
   $host  = $_SERVER['HTTP_HOST'];
   $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
   $cdn = GetSetting('cdn');

--- a/www/common.inc
+++ b/www/common.inc
@@ -139,14 +139,10 @@ if (array_key_exists('HTTP_HOST', $_SERVER) &&
 if (isset($_REQUEST['bulk'])) {
     $settings['noBulk'] = 0;
 }
-$is_ssl = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? true : false;
+$is_ssl = isSslConnection();
 $GLOBALS['cdnPath'] = '';
 if (isset($settings['cdn']) && !$is_ssl) {
     $GLOBALS['cdnPath'] = $settings['cdn'];
-}
-$GLOBALS['ptotocol'] = 'http';
-if ($is_ssl) {
-    $GLOBALS['ptotocol'] = 'https';
 }
 
 $tz_offset = null;

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1,5 +1,6 @@
 <?php
 require_once(__DIR__ . '/archive.inc');
+require_once(__DIR__ . '/util.inc');
 
 if(extension_loaded('newrelic')) {
   newrelic_add_custom_tracer('RestoreTest');
@@ -2502,7 +2503,7 @@ function ShardKey($test_num, $locationID = null) {
 * @param mixed $relative_url
 */
 function SendAsyncRequest($relative_url) {
-  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+  $protocol = getUrlProtocol();
   $url = "$protocol://{$_SERVER['HTTP_HOST']}$relative_url";
   $local = GetSetting('local_server');
   if ($local)

--- a/www/create_pss.php
+++ b/www/create_pss.php
@@ -32,7 +32,7 @@ if (array_key_exists('original', $_REQUEST) && array_key_exists('optimized', $_R
             if (FRIENDLY_URLS)
                 $url = "/result/{$test['id']}/";
 
-            $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+            $protocol = getUrlProtocol();
             header("Location: $protocol://{$_SERVER['HTTP_HOST']}$url");    
         } else {
             echo "Invalid Test.  Should be /create_pss.php?original=&LT;original test ID&GT;&optimized=&LT;optimized test ID&GT;";

--- a/www/getkey.php
+++ b/www/getkey.php
@@ -291,7 +291,7 @@ function EmailKeyInfo($info, $display) {
       }
     }
   }
-  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+  $protocol = getUrlProtocol();
   $url = "$protocol://{$_SERVER['HTTP_HOST']}/getLocations.php?f=html&k=$prefix";
   $content .= "\nThe list of current locations available for API testing here: $url.\n";
   if (count($locations)) {
@@ -314,7 +314,7 @@ function EmailKeyInfo($info, $display) {
 function EmailValidation($info) {
   $email = $info['email'];
   $id = $info['id'];
-  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+  $protocol = getUrlProtocol();
   $url = "$protocol://{$_SERVER['HTTP_HOST']}{$_SERVER['PHP_SELF']}?validate=$id";
   $content = "Thank you for requesting a WebPageTest API key.  In order to assign a key we need to validate your email address.\n\nTo complete the validation and retrieve your API key please go to $url";
   SendMessage($email, 'WebPagetest API Key Request', $content);

--- a/www/google/get_pss_cached_test.php
+++ b/www/google/get_pss_cached_test.php
@@ -10,7 +10,7 @@ if (array_key_exists('url', $_REQUEST) && strlen($_REQUEST['url'])) {
 }
 
 if (isset($id) && strlen($id)) {
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $host  = $_SERVER['HTTP_HOST'];
     $ret['statusCode'] = 200;
     $ret['statusText'] = 'Ok';

--- a/www/import.php
+++ b/www/import.php
@@ -333,7 +333,7 @@ function CreateTestID() {
 }
 
 function TestResult(&$test, $error) {
-  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+  $protocol = getUrlProtocol();
   $host  = $_SERVER['HTTP_HOST'];
   $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
   if (array_key_exists('f', $_REQUEST)) {

--- a/www/import_benchmark.php
+++ b/www/import_benchmark.php
@@ -161,7 +161,7 @@ function ImportBenchmarkRun($benchmark, $epoch, &$test_data) {
     file_put_contents("./results/benchmarks/$benchmark/state.json", json_encode($state));
     Unlock($lock);
     // kick off the collection and aggregation of the results
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $host  = $_SERVER['HTTP_HOST'];
     $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
     $cron = "$protocol://$host$uri/benchmarks/cron.php?benchmark=" . urlencode($benchmark);

--- a/www/jpeginfo/jpeginfo.php
+++ b/www/jpeginfo/jpeginfo.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/../util.inc');
 chdir('..');
 include 'jpeginfo/jpeginfo.inc.php';
 if (array_key_exists('url', $_REQUEST) &&
@@ -34,7 +35,7 @@ if (array_key_exists('url', $_REQUEST) &&
       mkdir($dir, 0777, true);
     move_uploaded_file($_FILES['imgfile']['tmp_name'], $path);
   }
-  $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+  $protocol = getUrlProtocol();
   header("Location: $protocol://{$_SERVER['HTTP_HOST']}{$_SERVER['PHP_SELF']}?id=$id");
 } else {
   echo "<!DOCTYPE html>\n<html>\n<head>\n</head>\n<body>\n";

--- a/www/jsonResult.php
+++ b/www/jsonResult.php
@@ -51,7 +51,7 @@ if (isset($test['test']['batch']) && $test['test']['batch']) {
     $ret['statusText'] = $ret['data']['statusText'];
 
     if ($ret['statusCode'] == 200) {
-      $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+      $protocol = getUrlProtocol();
       $host  = $_SERVER['HTTP_HOST'];
       $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
       $urlStart = "$protocol://$host$uri";

--- a/www/oauth/login.php
+++ b/www/oauth/login.php
@@ -7,7 +7,7 @@ set_include_path(get_include_path() . PATH_SEPARATOR . './lib/oauth');
 require_once 'Google/Client.php';
 $client_id = GetSetting('google_oauth_client_id');
 $client_secret = GetSetting('google_oauth_client_secret');
-$protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+$protocol = getUrlProtocol();
 $host  = $_SERVER['HTTP_HOST'];
 $uri   = $_SERVER['PHP_SELF'];
 $redirect_uri = "$protocol://$host$uri";

--- a/www/resultBatch.inc
+++ b/www/resultBatch.inc
@@ -1,5 +1,6 @@
 <?php
 require_once('testStatus.inc');
+require_once('util.inc');
 require_once('./video/visualProgress.inc.php');
 //error_reporting(E_ALL);
 
@@ -656,7 +657,7 @@ function DisplayPSS(&$tests, $video, &$dirty)
     $started = 0;
     global $fvonly;
     $url = '';
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $host  = $_SERVER['HTTP_HOST'];
     $videoCustom = '2';
 
@@ -1619,7 +1620,7 @@ function CreateVideo(&$tests, $end = null)
 
     if (!strlen($end))
         $end = 'visual';
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $host  = $_SERVER['HTTP_HOST'];
     $request = "$protocol://$host/video/create.php?f=json&force=1&end=$end&tests=";
 

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -303,7 +303,7 @@
             if (array_key_exists('tsview_id', $_REQUEST)){
               $test['tsview_id'] = $_REQUEST['tsview_id'];
 
-              $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+              $protocol = getUrlProtocol();
               $test['tsview_results_host'] = "{$protocol}://{$_SERVER['HTTP_HOST']}";
 
               // tsview_configs format: KEY>VALUE,KEY>VALUE,......
@@ -415,7 +415,7 @@
                        is_file("./browsers/{$test['browser']}.apk"))) {
                     $customBrowsers = parse_ini_file('./browsers/browsers.ini');
                     if (array_key_exists($test['browser'], $customBrowsers)) {
-                      $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+                      $protocol = getUrlProtocol();
                       $base_uri = "$protocol://{$_SERVER['HTTP_HOST']}/browsers/";
                       if (array_key_exists('browsers_url', $settings) && strlen($settings['browsers_url']))
                           $base_uri = $settings['browsers_url'];
@@ -928,7 +928,7 @@
                 if (array_key_exists('submit_callback', $test)) {
                     $test['submit_callback']($test);
                 }
-                $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+                $protocol = getUrlProtocol();
                 $host  = $_SERVER['HTTP_HOST'];
                 $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
 
@@ -1282,7 +1282,7 @@ function ValidateKey(&$test, &$error, $key = null)
     }elseif (!isset($admin) || !$admin) {
       $error = 'An error occurred processing your request (missing API key).';
       if (GetSetting('allow_getkeys')) {
-        $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+        $protocol = getUrlProtocol();
         $url = "$protocol://{$_SERVER['HTTP_HOST']}/getkey.php";
         $error .= "  If you do not have an API key assigned you can request one at $url";
       }

--- a/www/util.inc
+++ b/www/util.inc
@@ -12,4 +12,3 @@ function getUrlProtocol() {
     return isSslConnection() ? 'https' : 'http';
 }
 ?>
-

--- a/www/util.inc
+++ b/www/util.inc
@@ -1,0 +1,11 @@
+<?php
+
+function isSslConnection() {
+    return ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? true : false;
+}
+
+function getUrlProtocol() {
+    return isSslConnection() ? 'https' : 'http';
+}
+?>
+

--- a/www/util.inc
+++ b/www/util.inc
@@ -1,7 +1,11 @@
 <?php
 
 function isSslConnection() {
-    return ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? true : false;
+    return (
+        (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ||
+        (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On') ||
+        (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == "https")
+    ) ? true : false;
 }
 
 function getUrlProtocol() {

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/../util.inc');
 if( !isset($_REQUEST['tests']) && isset($_REQUEST['t']) )
 {
     $tests = '';
@@ -14,8 +15,7 @@ if( !isset($_REQUEST['tests']) && isset($_REQUEST['t']) )
                 $tests .= "-r:{$parts[1]}";
         }
     }
-
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $host  = $_SERVER['HTTP_HOST'];
     $uri = $_SERVER['PHP_SELF'];
     $params = '';

--- a/www/video/create.php
+++ b/www/video/create.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/../util.inc');
 $version = 9;
 if( !isset($_REQUEST['tests']) && isset($_REQUEST['t']) )
 {
@@ -28,7 +29,7 @@ if( !isset($_REQUEST['tests']) && isset($_REQUEST['t']) )
         }
     }
 
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $host  = $_SERVER['HTTP_HOST'];
     $uri = $_SERVER['PHP_SELF'];
     $params = '';
@@ -278,7 +279,7 @@ else
     // redirect to the destination page
     if( $id )
     {
-        $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+        $protocol = getUrlProtocol();
         $host  = $_SERVER['HTTP_HOST'];
         $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
 

--- a/www/video/docompare.php
+++ b/www/video/docompare.php
@@ -66,7 +66,7 @@ if( count($ids) )
         $idStr .= $id;
     }
 
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $compareUrl = "$protocol://" . $_SERVER['HTTP_HOST'] . "/video/compare.php?tests=$idStr";
     header("Location: $compareUrl");
 }
@@ -88,7 +88,7 @@ function SubmitTest($url, $label, $key)
     global $ip;
     $id = null;
 
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $testUrl = "$protocol://" . $_SERVER['HTTP_HOST'] . '/runtest.php?';
     $testUrl .= 'f=xml&priority=2&runs=3&video=1&mv=1&fvonly=1&url=' . urlencode($url);
     if( $label && strlen($label) )

--- a/www/video/view.php
+++ b/www/video/view.php
@@ -106,7 +106,7 @@ if( $xml || $json )
         {
             $code = 200;
 
-            $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+            $protocol = getUrlProtocol();
             $host  = $_SERVER['HTTP_HOST'];
             $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
             $videoUrl = "$protocol://$host$uri/download.php?id=$videoId";
@@ -314,7 +314,7 @@ else
                 if(!$embed) {
                     echo "<br><a class=\"link\" href=\"/video/download.php?id=$videoId\">Download</a> | ";
                     echo '<a class="link" href="javascript:ShowEmbed()">Embed</a>';
-                    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+                    $protocol = getUrlProtocol();
                     $dataText = 'View as data comparison';
                     $dataUrl = "$protocol://{$_SERVER['HTTP_HOST']}{$_SERVER['PHP_SELF']}?id=$videoId&data=1";
                     if ($displayData) {
@@ -374,7 +374,7 @@ else
               $dimensions = "&width=$width&height=$height";
               $framesize = " width=\"$width\" height=\"$height\"";
             }
-            $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+            $protocol = getUrlProtocol();
             echo htmlspecialchars("<iframe src=\"$protocol://{$_SERVER['HTTP_HOST']}{$_SERVER['PHP_SELF']}?id=$videoId&embed=1$dimensions\"$framesize></iframe>");
             ?>
             </p>

--- a/www/widgets/pagespeed/tree.php
+++ b/www/widgets/pagespeed/tree.php
@@ -24,7 +24,7 @@ header ("Content-type: text/javascript");
 $div = $_REQUEST['div'];
 if (strlen($testPath) && strlen($div)) {
     // inject the css file into the document dynamically
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     $base_path = "$protocol://" . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
     $css = "$base_path/tree.css?v=2";
     echo "var pagespeed_tree_css=document.createElement('link');\n";

--- a/www/work/getwork.php
+++ b/www/work/getwork.php
@@ -222,7 +222,7 @@ function TestToJSON($testInfo) {
   if (isset($_REQUEST['apk']) && is_file(__DIR__ . '/update/apk.dat')) {
     $apk_info = json_decode(file_get_contents(__DIR__ . '/update/apk.dat'), true);
     if (isset($apk_info) && is_array($apk_info) && isset($apk_info['packages']) && is_array($apk_info['packages'])) {
-      $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+      $protocol = getUrlProtocol();
       $update_path = dirname($_SERVER['PHP_SELF']) . '/update/';
       $base_uri = "$protocol://{$_SERVER['HTTP_HOST']}$update_path";
       foreach ($apk_info['packages'] as $package => $info)

--- a/www/work/postprocess.php
+++ b/www/work/postprocess.php
@@ -53,7 +53,7 @@ if (array_key_exists('test', $_REQUEST)) {
             $testData['testConnectivity'] = $testInfo['connectivity'];
             $testData['tester'] = array_key_exists('test_runs', $testInfo) && array_key_exists($run, $testInfo['test_runs']) && array_key_exists('tester', $testInfo['test_runs'][$run]) ? $testInfo['test_runs'][$run]['tester'] : $testInfo['tester'];
             $testData['testRunId'] = "$id.$run.$cached";
-            $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+            $protocol = getUrlProtocol();
             $testData['testResultUrl'] = "$protocol://{$_SERVER['HTTP_HOST']}/details.php?test=$id&run=$run&cached=$cached";
             error_log(json_encode($testData) . "\n", 3, $pageLog);
           }
@@ -81,7 +81,7 @@ if (array_key_exists('test', $_REQUEST)) {
               $request['testConnectivity'] = $testInfo['connectivity'];
               $request['tester'] = array_key_exists('test_runs', $testInfo) && array_key_exists($run, $testInfo['test_runs']) && array_key_exists('tester', $testInfo['test_runs'][$run]) ? $testInfo['test_runs'][$run]['tester'] : $testInfo['tester'];
               $request['testRunId'] = "$id.$run.$cached";
-              $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+              $protocol = getUrlProtocol();
               $request['testResultUrl'] = "$protocol://{$_SERVER['HTTP_HOST']}/details.php?test=$id&run=$run&cached=$cached";
               error_log(json_encode($request) . "\n", 3, $requestsLog);
             }
@@ -208,7 +208,7 @@ function notify( $mailto, $from,  $id, $testPath, $host )
         $shorturl .= '...';
 
     $subject = "Test results for $shorturl";
-    $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+    $protocol = getUrlProtocol();
     if( !isset($host) )
         $host  = $_SERVER['HTTP_HOST'];
 

--- a/www/xmlResult.php
+++ b/www/xmlResult.php
@@ -39,7 +39,7 @@ else
     $status = GetTestStatus($id);
     if( isset($test['test']['completeTime']) )
     {
-        $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+        $protocol = getUrlProtocol();
         $host  = $_SERVER['HTTP_HOST'];
         $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
         $path = substr($testPath, 1);
@@ -166,7 +166,7 @@ function BatchResult($id, $testPath)
         echo "<statusText>Ok</statusText>";
         if( strlen($_REQUEST['r']) )
             echo "<requestId>{$_REQUEST['r']}</requestId>";
-        $protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 'On')) ? 'https' : 'http';
+        $protocol = getUrlProtocol();
         $host  = $_SERVER['HTTP_HOST'];
         $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
 


### PR DESCRIPTION
In case a reverse proxy handles the SSL connection and terminates it (common in a docker setup), the WPT server is accessed via `https` from outside, but neither `$_SERVER['HTTPS']` nor `$_SERVER['HTTP_SSL']` is set, since the interal access is via http.
These proxies commonly set the [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) header, resulting in the `$_SERVER['HTTP_X_FORWARDED_PROTO']` variable in PHP.

Since the logic was duplicated in many places, I extracted it into one function and added the X-Forwarded-Proto logic.

Not all scripts include `common.inc` or `common_lib.inc`, so I chose to introduce a new file `util.inc`.
It's included in `common_lib.inc` for most of the scripts, but is also explicitly included in `jpeginfo` or the top part of `video/compare.php` or `video/create.php` that usually do not include `common_lib.inc`.

(I also saw that `$GLOBALS['ptotocol']` is set at one place, which is both has a typo and is unused, so I removed it).