### PR TITLE
Show frame time next to hero elements and indicate LPH

### DIFF
--- a/www/screen_shot.php
+++ b/www/screen_shot.php
@@ -243,6 +243,11 @@ function printStep($fileHandler, $testInfo, $testStepResult, $useQuicklinks) {
 
             foreach ($hero_elements as $heroIndex => $hero) {
                 $hero_time = $hero_times[$hero['name']];
+                $hero_info = ["{$hero_time}ms"];
+
+                if (isset($hero_times["LastPaintedHero"]) && $hero_time == $hero_times["LastPaintedHero"]) {
+                    $hero_info[] = "<abbr title=\"Last Painted Hero\">LPH</abbr>";
+                }
 
                 if ($hero_time > 0 && isset($frames[$hero_time])) {
                     $frame_file = $frames[$hero_time]['file'];
@@ -267,7 +272,7 @@ function printStep($fileHandler, $testInfo, $testStepResult, $useQuicklinks) {
                     $w = $hero['width'] * $scale;
                     $h = $hero['height'] * $scale;
 
-                    echo '<br><br><h2 id="hero_' . $hero['name'] . '">Hero Time: ' . $hero['name'] . '</h2>';
+                    echo '<br><br><h2 id="hero_' . $hero['name'] . '">Hero Time: ' . $hero['name'] . ' <small>(' . implode(', ', $hero_info) . ')</small></h2>';
                     echo '<div style="display: inline-block; position: relative">';
                     echo '<img class="center" alt="Hero Element Screenshot" src="' . "{$urlPaths->videoDir()}/{$frame_file}" . '">';
                     echo <<<SVG


### PR DESCRIPTION
It would be nice to show some more context around the hero elements on the Screenshot page. This change notes the frame time and also indicates which element was the last painted hero. Do you think this is useful information? Is there a better way we could display it?

![Screenshot_2019-04-12 WebPageTest Screenshots - Joseph's XPS 13 -pages-at-bbc-news - 04 12 19 15 13 58](https://user-images.githubusercontent.com/794263/56010236-eef28880-5d36-11e9-91fe-5a1124be93e8.png)
