### PR TITLE
Added links between waterfall and filmstrip

### DIFF
--- a/www/include/WaterfallViewHtmlSnippet.php
+++ b/www/include/WaterfallViewHtmlSnippet.php
@@ -34,6 +34,7 @@ class WaterfallViewHtmlSnippet {
     $out .=  "<br><a href=\"" . $urlGenerator->stepDetailPage("customWaterfall", "width=930") . "\">customize waterfall</a> &#8226; ";
     $out .=  "<a id=\"view-images\" href=\"" . $urlGenerator->stepDetailPage("pageimages") . "\">View all Images</a>";
     $out .=  " &#8226; <a id=\"http2-dependencies\" href=\"" . $urlGenerator->stepDetailPage("http2_dependencies") . "\">View HTTP/2 Dependency Graph</a>";
+    $out .=  " &#8226; <a href=\"" . $urlGenerator->filmstripView() . "\">Filmstrip</a>";
     return $out;
   }
 

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -395,7 +395,7 @@ function ScreenShotTable()
 
             if (!defined('EMBED')) {
                 $urlGenerator = UrlGenerator::create(FRIENDLY_URLS, "", $test['id'], $test['run'], $test['cached'], $test['step']);
-                $href = $urlGenerator->resultPage("details");
+                $href = $urlGenerator->resultPage("details") . "#waterfall_view_step" . $test['step'];
                 echo "<a class=\"pagelink\" id=\"label_{$test['id']}\" href=\"$href\">" . WrapableString(htmlspecialchars($test['name'])) . '</a>';
             } else {
                 echo WrapableString(htmlspecialchars($test['name']));


### PR DESCRIPTION
When comparing multiple tests, it's often necessary to check out the waterfall (with request data).
The label next to the filmstrip now directly points to the waterfall of the specified step. This change doesn't affect singlestep results.

Similarly, when analyzing waterfalls, I often want to see the corresponding filmstrip. So far it was always necessary to navigate over the summary page, soI added a direct link. Especially for multiple runs and steps, this simplifies navigation to the filmstrip quite a lot.