### PR TITLE
Sticky filmstrips for better comparison between waterfall and visual progreess

### DIFF
--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -113,11 +113,17 @@ else
                 }
                 #videoContainer
                 {
-                    position: sticky;
-                    top: 0;
-                    z-index: 5;
                     <?php
-                        echo "background: #$bgcolor;\n";
+                    if (array_key_exists('sticky', $_GET) && strlen($_GET['sticky'])) {
+                    ?>
+                        position: sticky;
+                        top: 0;
+                        z-index: 5;
+                        <?php
+                            echo "background: #$bgcolor;\n";
+                        ?>
+                    <?php
+                    }
                     ?>
                     table-layout: fixed;
                     margin-left: auto;
@@ -275,16 +281,21 @@ else
                 }
                 ?>
                 div.waterfall-container {top: -2em; width:930px; margin: 0 auto;}
-                div.waterfall-sliders {
-                    position: sticky;
-                    clear: none;
-                    margin-top: 3em;
-                    top: 0;
-                    z-index: 3;
-                    <?php
-                        echo "background: #$bgcolor;\n";
-                    ?>
+                <?php
+                if (array_key_exists('sticky', $_GET) && strlen($_GET['sticky'])) {
+                ?>
+                    div.waterfall-sliders {
+                        position: sticky;
+                        clear: none;
+                        margin-top: 3em;
+                        top: 0;
+                        z-index: 3;
+                        <?php
+                            echo "background: #$bgcolor;\n";
+                        ?>
+                <?php
                 }
+                ?>
             </style>
         </head>
         <body>
@@ -950,16 +961,22 @@ function DisplayGraphs() {
             ?>
         }
     </script>
-    <script>
-        var videoContainer = document.querySelector("#videoContainer");
-        var waterfallSliders = document.querySelector(".waterfall-sliders");
+    <?php
+    if (array_key_exists('sticky', $_GET) && strlen($_GET['sticky'])) {
+    ?>
+        <script>
+          var videoContainer = document.querySelector("#videoContainer");
+          var waterfallSliders = document.querySelector(".waterfall-sliders");
 
-        console.log(videoContainer);
-        console.log(waterfallSliders);
-        console.log(videoContainer.offsetHeight);
+          console.log(videoContainer);
+          console.log(waterfallSliders);
+          console.log(videoContainer.offsetHeight);
 
-        waterfallSliders.style.top = videoContainer.offsetHeight.toString() + "px";
-    </script>
+          waterfallSliders.style.top = videoContainer.offsetHeight.toString() + "px";
+        </script>
+    <?php
+    }
+    ?>
     <?php
 }
 ?>

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -113,6 +113,12 @@ else
                 }
                 #videoContainer
                 {
+                    position: sticky;
+                    top: 0;
+                    z-index: 2;
+                    <?php
+                        echo "background: #$bgcolor;\n";
+                    ?>
                     table-layout: fixed;
                     margin-left: auto;
                     margin-right: auto;
@@ -361,15 +367,7 @@ function ScreenShotTable()
         if (!defined('EMBED')) {
             echo '<br>';
         }
-        echo '<form id="createForm" name="create" method="get" action="/video/create.php">';
-        echo "<input type=\"hidden\" name=\"end\" value=\"$endTime\">";
-        echo '<input type="hidden" name="tests" value="' . htmlspecialchars($_REQUEST['tests']) . '">';
-        echo "<input type=\"hidden\" name=\"bg\" value=\"$bgcolor\">";
-        echo "<input type=\"hidden\" name=\"text\" value=\"$color\">";
-        if (isset($_REQUEST['labelHeight']) && is_numeric($_REQUEST['labelHeight']))
-          echo '<input type="hidden" name="labelHeight" value="' . htmlspecialchars($_REQUEST['labelHeight']) . '">"';
-        if (isset($_REQUEST['timeHeight']) && is_numeric($_REQUEST['timeHeight']))
-          echo '<input type="hidden" name="timeHeight" value="' . htmlspecialchars($_REQUEST['timeHeight']) . '">"';
+
         echo '<table id="videoContainer"><tr>';
 
         // build a table with the labels
@@ -506,6 +504,16 @@ function ScreenShotTable()
 
         // end of the container table
         echo "</td></tr></table>\n";
+
+        echo '<form id="createForm" name="create" method="get" action="/video/create.php">';
+        echo "<input type=\"hidden\" name=\"end\" value=\"$endTime\">";
+        echo '<input type="hidden" name="tests" value="' . htmlspecialchars($_REQUEST['tests']) . '">';
+        echo "<input type=\"hidden\" name=\"bg\" value=\"$bgcolor\">";
+        echo "<input type=\"hidden\" name=\"text\" value=\"$color\">";
+        if (isset($_REQUEST['labelHeight']) && is_numeric($_REQUEST['labelHeight']))
+            echo '<input type="hidden" name="labelHeight" value="' . htmlspecialchars($_REQUEST['labelHeight']) . '">"';
+        if (isset($_REQUEST['timeHeight']) && is_numeric($_REQUEST['timeHeight']))
+            echo '<input type="hidden" name="timeHeight" value="' . htmlspecialchars($_REQUEST['timeHeight']) . '">"';
         echo '<div class="page">';
         echo "<div id=\"image\">";
         echo "<a id=\"export\" class=\"pagelink\" href=\"filmstrip.php?tests=" . htmlspecialchars($_REQUEST['tests']) . "&thumbSize=$thumbSize&ival=$interval&end=$endTime&text=$color&bg=$bgcolor\">Export filmstrip as an image...</a>";

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -115,7 +115,7 @@ else
                 {
                     position: sticky;
                     top: 0;
-                    z-index: 2;
+                    z-index: 5;
                     <?php
                         echo "background: #$bgcolor;\n";
                     ?>
@@ -182,6 +182,7 @@ else
                     float: right;
                     position: relative;
                     top: -8em;
+                    z-index: 4;
                 }
                 #layoutTable
                 {
@@ -273,7 +274,17 @@ else
                 <?php
                 }
                 ?>
-                div.waterfall-container {top: -8em; width:930px; margin: 0 auto;}
+                div.waterfall-container {top: -2em; width:930px; margin: 0 auto;}
+                div.waterfall-sliders {
+                    position: sticky;
+                    clear: none;
+                    margin-top: 3em;
+                    top: 0;
+                    z-index: 3;
+                    <?php
+                        echo "background: #$bgcolor;\n";
+                    ?>
+                }
             </style>
         </head>
         <body>
@@ -938,6 +949,16 @@ function DisplayGraphs() {
             }
             ?>
         }
+    </script>
+    <script>
+        var videoContainer = document.querySelector("#videoContainer");
+        var waterfallSliders = document.querySelector(".waterfall-sliders");
+
+        console.log(videoContainer);
+        console.log(waterfallSliders);
+        console.log(videoContainer.offsetHeight);
+
+        waterfallSliders.style.top = videoContainer.offsetHeight.toString() + "px";
     </script>
     <?php
 }

--- a/www/waterfall.inc
+++ b/www/waterfall.inc
@@ -1440,7 +1440,7 @@ EOT;
 function InsertMultiWaterfall(&$waterfalls, $waterfall_options) {
   require_once('./object_detail.inc');
   $opacity = number_format(1.0 / count($waterfalls), 2, '.', '');
-  echo '<div class="waterfall-container" style="text-align: left;margin-top:10em;">';
+  echo '<div class="waterfall-container waterfall-sliders" style="text-align: left;">';
   echo 'Waterfall Opacity (adjust sliders to adjust the transparency of the given waterfall):<br>';
   echo '<table>';
   if (count($waterfalls) == 2) {


### PR DESCRIPTION
While I'm inspecting correlations between the waterfall and visual loading of a website, I often find myself scrolling down because of long waterfalls. But then the filmstrip scrolls out of the viewport and I'm loosing context of the visual state of the website at that point of time.

This feature enables a sticky view when accessing the filmstrip view via the URL query parameter `sticky=true`. When scrolling down the filmstrip sticks to the top of the viewport and the waterfall scrolls behind filmstrip.

This works for both, only one result or multiple results. When viewing more than 2 results the space underneath the filmstrips becomes quite limited. Therefore I decided to make it optional via URL query parameter.