### PR TITLE
Correct URL for list of known CDNs

### DIFF
--- a/www/optimization.inc
+++ b/www/optimization.inc
@@ -588,7 +588,7 @@ function dumpOptimizationGlossary(&$settings)
         </tr>
         <tr>
             <td class="nowrap">What is checked</td>
-            <td >Checked to see if it is hosted on a known CDN (CNAME mapped to a known CDN network).  80% of the static resources need to be served from a CDN for the overall page to be considered using a CDN. The current list of known CDN's is <a href="https://github.com/WPO-Foundation/webpagetest/blob/master/agent/wpthook/cdn.h">here</a></td>
+            <td >Checked to see if it is hosted on a known CDN (CNAME mapped to a known CDN network).  80% of the static resources need to be served from a CDN for the overall page to be considered using a CDN. The current list of known CDN's is <a href="https://github.com/WPO-Foundation/wptagent/blob/master/internal/optimization_checks.py#L48">here</a></td>
         </tr>
 
     </table>


### PR DESCRIPTION
Was digging into how WPT figures out if a CDN was used and found this old broken URL and so submitting this as a suggested fix.