### PR TITLE
Mitigation for all runs in sharded tests inadvertently being assigned…

### DIFF
--- a/www/work/getwork.php
+++ b/www/work/getwork.php
@@ -342,7 +342,13 @@ function GetJob() {
         
         if ($is_json) {
           $testJson = TestToJSON($testInfo);
-          echo json_encode($testJson);
+          if(!isset($testJson['run']) && 
+	        GetSetting("shard_tests") && 
+			$testJson['type'] != 'traceroute'){
+            logTestMsg($testId,"Tried to start sharded test with no runs set");
+          } else {
+            echo json_encode($testJson);
+          }
         } else {
           echo $testInfo;
         }


### PR DESCRIPTION
… to one agent.
This occurs on our private instance for about 2% of 11k tests during very high load.
Fixes #1074