### PR TITLE
fix: Patch for Arbitrary file read vulnerability

### DIFF
--- a/www/getfile.php
+++ b/www/getfile.php
@@ -6,7 +6,7 @@ if(array_key_exists("HTTP_IF_MODIFIED_SINCE",$_SERVER) && strlen(trim($_SERVER['
   $ok = false;
   if (isset($_REQUEST['file']) && isset($testPath) && is_dir($testPath)) {
     $file = $_REQUEST['file'];
-    if (preg_match('/[a-zA-Z0-9_\-]+\.(?P<ext>png|jpg|txt|zip|csv|mp4)/i', $file, $matches)) {
+    if (preg_match('/[a-zA-Z0-9_\-]+\.(?P<ext>png|jpg|txt|zip|csv|mp4)$/i', $file, $matches)) {
       $ext = strtolower($matches['ext']);
       $dir = '';
       if (isset($_REQUEST['video']) && preg_match('/[a-zA-Z0-9_\-]+/i', $_REQUEST['video'])) {


### PR DESCRIPTION
# Arbitrary file read vulnerability (Only working on Windows os)

**Date: 26 September 2019** . 
**Author: Woowon Kang (@wooeong2) / Juno Im ([@junorouse](https://twitter.com/junorouse)) from Theori**

# Summary

Attacker can read arbitrary files on webpagetest servers running on Windows OS.

# Trigger / Exploit

- https://github.com/WPO-Foundation/webpagetest/blob/master/www/getfile.php#L9

```php
    $file = $_REQUEST['file'];
    if (preg_match('/[a-zA-Z0-9_\-]+\.(?P<ext>png|jpg|txt|zip|csv|mp4)/i', $file, $matches)) {
```

Rules does not have `$` symbol, attacker can bypass with `a.jpg\..\..\..\..\..\..\..\{Arbitrary File}`.
Windows OS ignores not exist foler 

# Recommendation / Patch

```diff
- if (preg_match('/[a-zA-Z0-9_\-]+\.(?P<ext>png|jpg|txt|zip|csv|mp4)/i', $file, $matches)) {
+ if (preg_match('/[a-zA-Z0-9_\-]+\.(?P<ext>png|jpg|txt|zip|csv|mp4)$/i', $file, $matches)) {
```

