### PR TITLE
Fix graph page json encoding

### DIFF
--- a/www/graph_page_data.php
+++ b/www/graph_page_data.php
@@ -251,11 +251,11 @@ $common_label = implode(" ", $common_labels);
             <script type="text/javascript" src="//www.google.com/jsapi"></script>
             <script type="text/javascript">
                 <?php
-	            $chartDataJson = json_encode($chartData);
-	            // If JSON encode fails due to inf and nan, replace those occurences with '0' in the serialized output then retry.
-		    if (json_last_error() == JSON_ERROR_INF_OR_NAN) {
-		      $chartDataJson = json_encode(unserialize(str_replace(array('NAN;', 'INF;'), '0;', serialize($chartData))));
-		    }
+                    $chartDataJson = json_encode($chartData);
+                    // If JSON encode fails due to inf and nan, replace those occurences with '0' in the serialized output then retry.
+                    if (json_last_error() == JSON_ERROR_INF_OR_NAN) {
+                      $chartDataJson = json_encode(unserialize(str_replace(array('NAN;', 'INF;'), '0;', serialize($chartData))));
+                    }
                     echo "var chartData = " . $chartDataJson . ";\n";
                     echo "var runs = $num_runs;\n";
                 ?>

--- a/www/graph_page_data.php
+++ b/www/graph_page_data.php
@@ -251,7 +251,12 @@ $common_label = implode(" ", $common_labels);
             <script type="text/javascript" src="//www.google.com/jsapi"></script>
             <script type="text/javascript">
                 <?php
-                    echo "var chartData = " . json_encode($chartData) . ";\n";
+	            $chartDataJson = json_encode($chartData);
+	            // If JSON encode fails due to inf and nan, replace those occurences with '0' in the serialized output then retry.
+		    if (json_last_error() == JSON_ERROR_INF_OR_NAN) {
+		      $chartDataJson = json_encode(unserialize(str_replace(array('NAN;', 'INF;'), '0;', serialize($chartData))));
+		    }
+                    echo "var chartData = " . $chartDataJson . ";\n";
                     echo "var runs = $num_runs;\n";
                 ?>
             <?php include('graph_page_data.js'); ?>


### PR DESCRIPTION
When comparing 2 tests with statistical comparison, the underlying php json encode for charts fails because there are some INFs and NANs in the array.
Example: https://webpagetest.org/graph_page_data.php?tests=191204_4S_075e245f519e123b8a9b4a838ac3af34,191204_5X_8ed646fa71418e88cc74faf773901479&medianMetric=SpeedIndex&fv=1&control=0

Removing `control` from the parameters above or comparing only one test, i.e. only one test id in the `tests` parameter, then it works.