### PR TITLE
add gce-us-west2-linux for GCP locations

### DIFF
--- a/www/settings/locations.ini.GCE-sample
+++ b/www/settings/locations.ini.GCE-sample
@@ -14,17 +14,18 @@
 2=gce-us-east1-linux-loc
 3=gce-us-central1-linux-loc
 4=gce-us-west1-linux-loc
-5=gce-northamerica-northeast1-linux-loc
-6=gce-southamerica-east1-linux-loc
-7=gce-europe-west2-linux-loc
-8=gce-europe-west1-linux-loc
-9=gce-europe-west3-linux-loc
-10=gce-europe-west4-linux-loc
-11=gce-asia-south1-linux-loc
-12=gce-asia-southeast1-linux-loc
-13=gce-asia-east1-linux-loc
-14=gce-asia-northeast1-linux-loc
-15=gce-australia-southeast1-linux-loc
+5=gce-us-west2-linux-loc
+6=gce-northamerica-northeast1-linux-loc
+7=gce-southamerica-east1-linux-loc
+8=gce-europe-west2-linux-loc
+9=gce-europe-west1-linux-loc
+10=gce-europe-west3-linux-loc
+11=gce-europe-west4-linux-loc
+12=gce-asia-south1-linux-loc
+13=gce-asia-southeast1-linux-loc
+14=gce-asia-east1-linux-loc
+15=gce-asia-northeast1-linux-loc
+16=gce-australia-southeast1-linux-loc
 default=gce-us-east4-linux-loc
 
 ;
@@ -69,6 +70,15 @@ group=North America
 [gce-us-west1-linux]
 browser=Chrome,Chrome Beta,Chrome Canary,Firefox,Firefox Nightly,Opera,Opera Beta,Opera Developer
 label="Oregon, USA"
+
+[gce-us-west2-linux-loc]
+1=gce-us-west2-linux
+label="California, USA (Chrome,Firefox,Opera)"
+group=North America
+
+[gce-us-west2-linux]
+browser=Chrome,Chrome Beta,Chrome Canary,Firefox,Firefox Nightly,Opera,Opera Beta,Opera Developer
+label="California, USA"
 
 
 [gce-northamerica-northeast1-linux-loc]


### PR DESCRIPTION
I think it is worth providing because `us-west2` is placed in California, very near to SF.

https://cloud.google.com/compute/docs/regions-zones/