### PR TITLE
add the link to JSON results in the result page

### DIFF
--- a/www/result.inc
+++ b/www/result.inc
@@ -143,6 +143,8 @@ $page_description = "Website performance test result$testLabel.";
                     $fvMedian = $testResults->getMedianRunNumber($median_metric, false);
                     $rvMedian = $testResults->getMedianRunNumber($median_metric, true);
 
+                    echo "<a href='/jsonResult.php?test=$id'>View JSON result</a><br>";
+
                     // create friendlier (unique) names for the file URLs
                     $fileUrl = GetFileUrl($url);
                     if( FRIENDLY_URLS )

--- a/www/result.inc
+++ b/www/result.inc
@@ -143,7 +143,7 @@ $page_description = "Website performance test result$testLabel.";
                     $fvMedian = $testResults->getMedianRunNumber($median_metric, false);
                     $rvMedian = $testResults->getMedianRunNumber($median_metric, true);
 
-                    echo "<a href='/jsonResult.php?test=$id'>View JSON result</a><br>";
+                    echo "<a href='/jsonResult.php?test=$id&pretty=1'>View JSON result</a><br>";
 
                     // create friendlier (unique) names for the file URLs
                     $fileUrl = GetFileUrl($url);


### PR DESCRIPTION
I believe this "View JSON result" link is useful for developers to see all the data in JSON.

Here is a screenshot:

![Screen Shot 2019-12-16 at 14 50 53](https://user-images.githubusercontent.com/101800/70882569-879e7e00-2013-11ea-8e85-0d9e9bcc15fb.png)
