### PR TITLE
Adding $median_metric to the `<h2>Performance Results...` element.

### DIFF
--- a/www/result.inc
+++ b/www/result.inc
@@ -175,7 +175,7 @@ $page_description = "Website performance test result$testLabel.";
                 if ($fvMedian)
                 {
                     if ($testResults->countRuns() > 1)
-                        echo '<h2>Performance Results (Median Run)</h2>';
+                        echo '<h2>Performance Results (Median Run - ' . $median_metric . ')</h2>';
                     $fvRunResults = $testResults->getRunResult($fvMedian, false);
                     $rvRunResults = $rvMedian ? $testResults->getRunResult($rvMedian, true) : null;
                     $resultTable = new RunResultHtmlTable($testInfo, $fvRunResults, $rvRunResults);

--- a/www/result.inc
+++ b/www/result.inc
@@ -175,7 +175,7 @@ $page_description = "Website performance test result$testLabel.";
                 if ($fvMedian)
                 {
                     if ($testResults->countRuns() > 1)
-                        echo '<h2>Performance Results (Median Run - ' . $median_metric . ')</h2>';
+                        echo '<h2>Performance Results (Median Run - ' . htmlspecialchars($median_metric) . ')</h2>';
                     $fvRunResults = $testResults->getRunResult($fvMedian, false);
                     $rvRunResults = $rvMedian ? $testResults->getRunResult($rvMedian, true) : null;
                     $resultTable = new RunResultHtmlTable($testInfo, $fvRunResults, $rvRunResults);


### PR DESCRIPTION
Added the median metric to the "Performance Results" element (see below). Tested it in a private Google instance. This closes https://github.com/WPO-Foundation/webpagetest/issues/1339

<img width="958" alt="Screen Shot 2020-04-14 at 11 54 36 PM" src="https://user-images.githubusercontent.com/7434954/79307363-a0c51780-7eab-11ea-9b4a-b6f1edf442d7.png">
