### PR TITLE
fix: don't test for http pkp

### DIFF
--- a/docker/server/config/locations.ini
+++ b/docker/server/config/locations.ini
@@ -41,6 +41,7 @@ label="Test Location - IE 8"
 [Test]
 browser=Chrome,Firefox
 label="Test Location"
+connectivity=LAN
 
 ;
 ; This is an exaple of a "remote" configuration where tests can be proxied to a remote

--- a/docker/server/config/locations.ini
+++ b/docker/server/config/locations.ini
@@ -41,7 +41,6 @@ label="Test Location - IE 8"
 [Test]
 browser=Chrome,Firefox
 label="Test Location"
-connectivity=LAN
 
 ;
 ; This is an exaple of a "remote" configuration where tests can be proxied to a remote

--- a/www/header.inc
+++ b/www/header.inc
@@ -401,13 +401,13 @@ function GetGrades($testInfo, $testRunResults, $firstRunResults)
       $grades['lighthouse'] = array( 'class' => 'F', 'grade' => '?', 'description' => 'Lighthouse PWA Score');
     }
 
-    //if (GetSetting('securityInsights') || isset($_REQUEST['securityInsights'])) {
+    if (GetSetting('securityInsights') || isset($_REQUEST['securityInsights'])) {
         require_once('security_checks.php');
         $securityGrade = getSecurityGrade($testInfo, $testRunResults);
         if (isset($securityGrade)) {
             $grades['security'] = array( 'class' => $securityGrade['class'], 'grade' => $securityGrade['grade'], 'description' => $securityGrade['description']);
         }
-    //}
+    }
 
     if ($testRunResults->isOptimizationChecked()) {
         require_once('optimization_detail.inc.php');

--- a/www/header.inc
+++ b/www/header.inc
@@ -191,7 +191,7 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
                             $lighthouse = $urlGenerator->resultPage("lighthouse");
                             echo "<li class=\"$check\"><a href=\"$lighthouse\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
                           }else if ($check == 'security') {
-                            $snykUrl = "https://snyk.io/test/website-scanner/?test={$id}&utm_medium=web&utm_source=webpagetest&utm_campaign=website-scanner";
+                            $snykUrl = "https://snyk.io/test/website-scanner/?test={$id}&utm_medium=referral&utm_source=webpagetest&utm_campaign=website-scanner";
                             echo "<li class=\"$check\"><a href=\"$snykUrl\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
                           }else {
                             echo "<li class=\"$check\"><a href=\"$optlink#$check\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";

--- a/www/header.inc
+++ b/www/header.inc
@@ -191,7 +191,7 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
                             $lighthouse = $urlGenerator->resultPage("lighthouse");
                             echo "<li class=\"$check\"><a href=\"$lighthouse\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
                           }else if ($check == 'security') {
-                            $snykUrl = "https://snyk.io/test/website-scanner/?test={$id}&tm_medium=web&utm_source=webpagetest&utm_campaign=website-scanner";
+                            $snykUrl = "https://snyk.io/test/website-scanner/?test={$id}&utm_medium=web&utm_source=webpagetest&utm_campaign=website-scanner";
                             echo "<li class=\"$check\"><a href=\"$snykUrl\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
                           }else {
                             echo "<li class=\"$check\"><a href=\"$optlink#$check\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";

--- a/www/header.inc
+++ b/www/header.inc
@@ -191,7 +191,7 @@ if( !strcasecmp('Test Result', $tab) && !@$nosubheader && !defined('EMBED') )
                             $lighthouse = $urlGenerator->resultPage("lighthouse");
                             echo "<li class=\"$check\"><a href=\"$lighthouse\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
                           }else if ($check == 'security') {
-                            $snykUrl = "https://snyk.io/test/website-scanner/?test={$id}";
+                            $snykUrl = "https://snyk.io/test/website-scanner/?test={$id}&tm_medium=web&utm_source=webpagetest&utm_campaign=website-scanner";
                             echo "<li class=\"$check\"><a href=\"$snykUrl\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
                           }else {
                             echo "<li class=\"$check\"><a href=\"$optlink#$check\"><h2 class=\"{$grade['class']}\">{$grade['grade']}</h2></a>{$grade['description']}</li>";
@@ -401,13 +401,13 @@ function GetGrades($testInfo, $testRunResults, $firstRunResults)
       $grades['lighthouse'] = array( 'class' => 'F', 'grade' => '?', 'description' => 'Lighthouse PWA Score');
     }
 
-    if (GetSetting('securityInsights') || isset($_REQUEST['securityInsights'])) {
+    //if (GetSetting('securityInsights') || isset($_REQUEST['securityInsights'])) {
         require_once('security_checks.php');
         $securityGrade = getSecurityGrade($testInfo, $testRunResults);
         if (isset($securityGrade)) {
             $grades['security'] = array( 'class' => $securityGrade['class'], 'grade' => $securityGrade['grade'], 'description' => $securityGrade['description']);
         }
-    }
+    //}
 
     if ($testRunResults->isOptimizationChecked()) {
         require_once('optimization_detail.inc.php');

--- a/www/settings/custom_metrics/securityHeaders.js.security
+++ b/www/settings/custom_metrics/securityHeaders.js.security
@@ -4,8 +4,7 @@ const HEADERS_SCORES = {
   "content-security-policy": 25,
   "x-frame-options": 20,
   "x-xss-protection": 20,
-  "x-content-type-options": 20,
-  "public-key-pins": 30,
+  "x-content-type-options": 20
 };
 
 function getHttpHeadersAndScheme(requests) {
@@ -34,12 +33,11 @@ function detectSecurityHeaders({ headers, scheme }) {
     "content-security-policy",
     "x-frame-options",
     "x-xss-protection",
-    "x-content-type-options",
+    "x-content-type-options"
   ];
 
   const securityHeadersHttps = [
     "strict-transport-security",
-    "public-key-pins",
     ...securityHeadersHttp,
   ];
 


### PR DESCRIPTION
## Context

A previous PR (#1349) introduced security insights for WebPageTest.

These insights tested the headers, among them was HTTP Public-Key-Pinning, and scored it based on Scott Helm's securityheaders formula that Scott had shared publicly on his blog.

## Changes in this PR

1. PKP is still a very disputed security headers among security practitioners due to its complexity and other traits and have been removed from securityheaders from being scored. This PR aligns with that update and removes the scoring for this header.

2. Added UTMs for the snyk landing page