### PR TITLE
add documentation of agentUpdate config param

### DIFF
--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -143,6 +143,10 @@ maxNavigateCount=20
 ; (assumes a git clone and just runs "git pull origin master" as the web user).
 ;gitUpdate=1
 
+; Automatically update test agents hourly (pulls the latest test agents from the provided server)
+; Removing this line means the the old wptdriver agent will not auto-update
+agentUpdate=http://cdn.webpagetest.org/
+
 ; If an android device is connected to the server, scrape updated APK's off of the
 ; device to be installed on the test agents automatically (for cases where
 ; play auto-updating doesn't work - i.e. reverse-tethered devices)


### PR DESCRIPTION
@pmeenan I am happy to document this process thoroughly if you can point me in the right direction.

This PR...
+ adds comments and documentation about `agentUpdate` setting

!! QUESTION: removing `agentUpdate` [disables the automatic agent update](https://github.com/WPO-Foundation/wptagent/issues/98#issuecomment-380690929), but I don't see [where this value is consumed](https://github.com/search?q=org%3AWPO-Foundation+agentUpdate&type=Code). I'm expecting something like `GetSetting('agentUpdate')` or similar.

!! QUESTION: what does setting `agentUpdate` have to do with setting `apkPackages`, if anything? I ask because [you link to it in this post](https://github.com/WPO-Foundation/webpagetest/issues/819#issuecomment-282000598), but I don't see where/how `agentUpdate` is used.

!! QUESTION: Is the documentation [at the link](https://github.com/WPO-Foundation/webpagetest-docs/blob/b9c5c33562c50c9821387841ec284cd30ad538bc/user/Private%20Instances/wptdriver.md#updating-test-agents) still relevant?

- https://www.webpagetest.org/work/update/update.zip response is 404
- http://www.webpagetest.org/work/update/wptupdate.zip is 404
- inspecting source at http://www.webpagetest.org does not reveal anything with either update.zip or wptupdate.zip
- [This seems to be the most up-to-date info](https://github.com/WPO-Foundation/webpagetest/issues/819#issuecomment-282000598)...? 
- inspecting source at [apkUpdate.php](https://github.com/WPO-Foundation/webpagetest/blob/master/www/cron/apkUpdate.php) seems to reveal that the hourly job retrieves a .dat file from here: http://webpagetest.org/work/update/apk.dat
- Then the hourly job just pulls the new package using `adb` [on this line](https://github.com/WPO-Foundation/webpagetest/blob/master/www/cron/apkUpdate.php#L113)



Thank you!