### PR TITLE
Retrieve API key usage and limit for proactive monitoring

### DIFF
--- a/www/getKeyUsage.php
+++ b/www/getKeyUsage.php
@@ -1,0 +1,69 @@
+<?php
+    header('Content-type:application/json;charset=utf-8');
+
+    require_once('common.inc');
+    if (!$privateInstall) {
+        echo FormatResult(false, "/getKeyUsage.php only available on private instances.");
+        return;
+    }
+
+    if (isset($_REQUEST['k']) && preg_match('/^(?P<key>[0-9A-Za-z]+)$/', $_REQUEST['k'], $matches)) {
+        $api_key = $matches[0];
+    } else {
+        echo FormatResult(false, "Please provide a valid API key as a request param. Example: /getKeyUsage.php?k=your-api-key");
+        return;
+    }
+
+    $key_usage_filename = __DIR__ . "/dat/keys_" . gmdate("Ymd") . ".dat";
+    $key_usage_fp = fopen($key_usage_filename, "r");
+    if ($key_usage_fp) {
+        $contents = fgets($key_usage_fp);
+        if ($contents) {
+            $key_usages = json_decode(trim($contents), true);
+            if (is_array($key_usages) && array_key_exists($api_key, $key_usages)) {
+                $key_usage = $key_usages[$api_key];
+            } else {
+                echo FormatResult(false, "API key not found in usage file.");
+            }
+        } else {
+            echo FormatResult(false, "Unable to read usage file contents.");
+        }
+    } else {
+        echo FormatResult(false, "Unable to open file: " . $key_usage_filename);
+    }
+    fclose($key_usage_fp);
+    if (!isset($key_usage)) {
+        return;
+    }
+
+    $keys_path = dirname(__DIR__) . "/www/settings/keys.ini";
+    $keys = parse_ini_file($keys_path, true, INI_SCANNER_TYPED);
+    if ($keys) {
+        if (is_array($keys) && array_key_exists($api_key, $keys) &&
+            $keys[$api_key]['limit']) {
+            $limit = $keys[$api_key]['limit'];
+        } else {
+            echo FormatResult(false, "'limit' not found in keys.ini");
+        }
+    } else {
+        echo FormatResult(false, "Unable to find or open keys.ini at {$keys_path}");
+    }
+    if (!isset($limit)) {
+        return;
+    }
+
+    $result = array(
+        "usage" => $key_usage,
+        "limit" => $limit
+    );
+    echo FormatResult(true, $result);
+?>
+
+<?php
+    function FormatResult($success, $result) {
+        return json_encode(array(
+            "success" => $success,
+            "result" => $result
+        ));
+    }
+?>


### PR DESCRIPTION
What's the point of this PR?
+ Background: We have hundreds of WebPageTest tests executing on schedules. These tests fail en-masse when an API key exceeds its limit.
+ Motivation: We would like to expose key usage vs. limit to proactively address keys approaching their limit.

About this PR:
+ Adds an endpoint "/getKeyUsage.php" only available in private instances. 
+ Response type JSON
+ "/getKeyUsage.php" expects an API key
+ Responds with the provided key's usage for the day and the limit

Verified in our private instance.

Feedback much appreciated. 