### PR TITLE
New param `shaperLimit` to runtest.php for network shaping

### DIFF
--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1182,6 +1182,8 @@ function GetTestInfoHtml($includeScript = true)
         $html .= "<b>Connectivity:</b> {$test['testinfo']['bwIn']}/{$test['testinfo']['bwOut']} Kbps, {$test['testinfo']['latency']}ms Latency";
         if( $test['testinfo']['plr'] )
             $html .= ", {$test['testinfo']['plr']}% Packet Loss";
+        if( $test['testinfo']['tcQdiscLimit'] )
+            $html .= ", tc qdisc limit={$test['testinfo']['tcQdiscLimit']} Packets";
         $html .= '<br>';
     }
     if( isset($test['testinfo']['script']) && strlen($test['testinfo']['script']) )
@@ -2037,7 +2039,7 @@ function GetTesters($locationId, $includeOffline = false, $include_sensitive = t
   } elseif (function_exists('apc_store')) {
     apc_store($cache_key, $location, 60);
   }
-  
+
   return $location;
 }
 

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1182,8 +1182,8 @@ function GetTestInfoHtml($includeScript = true)
         $html .= "<b>Connectivity:</b> {$test['testinfo']['bwIn']}/{$test['testinfo']['bwOut']} Kbps, {$test['testinfo']['latency']}ms Latency";
         if( $test['testinfo']['plr'] )
             $html .= ", {$test['testinfo']['plr']}% Packet Loss";
-        if( $test['testinfo']['tcQdiscLimit'] )
-            $html .= ", tc qdisc limit={$test['testinfo']['tcQdiscLimit']} Packets";
+        if( $test['testinfo']['shaperLimit'] )
+            $html .= ", shaperLimit {$test['testinfo']['shaperLimit']}";
         $html .= '<br>';
     }
     if( isset($test['testinfo']['script']) && strlen($test['testinfo']['script']) )

--- a/www/include/JsonResultGenerator.php
+++ b/www/include/JsonResultGenerator.php
@@ -89,6 +89,8 @@ class JsonResultGenerator {
         $ret['latency'] = $testInfo['latency'];
       if (array_key_exists('plr', $testInfo))
         $ret['plr'] = $testInfo['plr'];
+      if (array_key_exists('tcQdiscLimit', $testInfo))
+        $ret['tcQdiscLimit'] = $testInfo['tcQdiscLimit'];
       if (array_key_exists('mobile', $testInfo))
         $ret['mobile'] = $testInfo['mobile'];
       if (array_key_exists('label', $testInfo) && strlen($testInfo['label']))

--- a/www/include/JsonResultGenerator.php
+++ b/www/include/JsonResultGenerator.php
@@ -89,8 +89,8 @@ class JsonResultGenerator {
         $ret['latency'] = $testInfo['latency'];
       if (array_key_exists('plr', $testInfo))
         $ret['plr'] = $testInfo['plr'];
-      if (array_key_exists('tcQdiscLimit', $testInfo))
-        $ret['tcQdiscLimit'] = $testInfo['tcQdiscLimit'];
+      if (array_key_exists('shaperLimit', $testInfo))
+        $ret['shaperLimit'] = $testInfo['shaperLimit'];
       if (array_key_exists('mobile', $testInfo))
         $ret['mobile'] = $testInfo['mobile'];
       if (array_key_exists('label', $testInfo) && strlen($testInfo['label']))

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -200,7 +200,7 @@
             $test['latency'] = isset($req_latency) ? (int)$req_latency : 0;
             $test['testLatency'] = isset($req_latency) ? (int)$req_latency : 0;
             $test['plr'] = isset($req_plr) ? trim($req_plr) : 0;
-            $test['tcQdiscLimit'] = isset($req_tcQdiscLimit) ? (int)$req_tcQdiscLimit : 0;
+            $test['shaperLimit'] = isset($req_shaperLimit) ? (int)$req_shaperLimit : 0;
             if (isset($req_pingback))
               $test['callback'] = $req_pingback;
             if (!$json && !isset($req_pingback) && isset($req_callback))
@@ -1879,7 +1879,7 @@ function GetRedirect($url, &$rhost, &$rurl) {
 
       if( strlen($host) && $original !== $host )
         $rhost = $host;
-      
+
       // Cache the redirct info
       $redirect_info = array('host' => $rhost, 'url' => $rurl);
       $redirect_cache[$url] = $redirect_info;
@@ -2247,7 +2247,7 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
                 AddIniLine($testFile, 'bwOut', $test['bwOut']);
                 AddIniLine($testFile, 'latency', $test['testLatency']);
                 AddIniLine($testFile, 'plr', $test['plr']);
-                AddIniLine($testFile, 'tcQdiscLimit', $test['tcQdiscLimit']);
+                AddIniLine($testFile, 'shaperLimit', $test['shaperLimit']);
             }
 
             if( isset($test['browserExe']) && strlen($test['browserExe']) )
@@ -2768,7 +2768,7 @@ function ReportAnalytics(&$test)
     $ip = $_SERVER['REMOTE_ADDR'];
     if( array_key_exists('ip',$test) && strlen($test['ip']) )
         $ip = $test['ip'];
-            
+
     $data = array(
       'v' => '1',
       'tid' => $ga,
@@ -2803,7 +2803,7 @@ function ReportAnalytics(&$test)
     curl_setopt($ch, CURLOPT_URL, $ga_url);
     curl_setopt($ch, CURLOPT_USERAGENT, $ua);
     curl_setopt($ch, CURLOPT_HTTP_VERSION,CURL_HTTP_VERSION_1_1);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true); 
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -200,6 +200,7 @@
             $test['latency'] = isset($req_latency) ? (int)$req_latency : 0;
             $test['testLatency'] = isset($req_latency) ? (int)$req_latency : 0;
             $test['plr'] = isset($req_plr) ? trim($req_plr) : 0;
+            $test['tcQdiscLimit'] = isset($req_tcQdiscLimit) ? (int)$req_tcQdiscLimit : 0;
             if (isset($req_pingback))
               $test['callback'] = $req_pingback;
             if (!$json && !isset($req_pingback) && isset($req_callback))
@@ -2246,6 +2247,7 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
                 AddIniLine($testFile, 'bwOut', $test['bwOut']);
                 AddIniLine($testFile, 'latency', $test['testLatency']);
                 AddIniLine($testFile, 'plr', $test['plr']);
+                AddIniLine($testFile, 'tcQdiscLimit', $test['tcQdiscLimit']);
             }
 
             if( isset($test['browserExe']) && strlen($test['browserExe']) )


### PR DESCRIPTION
Add a new parameter `shaperLimit` to give `tc qdisc` with `limit N`. The core logic is implemented in wptagent, so see https://github.com/WPO-Foundation/wptagent/pull/359 for details.