### PR TITLE
Allow custom key name in EC2

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -581,6 +581,12 @@ function EC2_LaunchInstance($region, $ami, $size, $user_data, $loc) {
       if ($subnetId) {
         $ec2_options['SubnetId'] = $subnetId;
       }
+	    
+      //add/modify the KeyName if present in config
+      $keyName = GetSetting("EC2.$region.keyName");
+      if ($keyName) {
+        $ec2_options['KeyName'] = $keyName;
+      }
 
       $response = $ec2->runInstances ( $ec2_options );
       $ret = true;


### PR DESCRIPTION
This PR allows the creation of wpt-agents with custom keyname on EC2,
This will allow ssh'ing into the wpt-agents created by the wpt-server.

https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-ec2-2016-11-15.html#runinstances