### PR TITLE
fix #1204 make main metrics and W3C UserTiming tables scrollable

### DIFF
--- a/www/pagestyle.css
+++ b/www/pagestyle.css
@@ -237,7 +237,7 @@ table.result {width: 920px;}
 .bottom a:hover {text-decoration: underline;}
 
 /* shared table themes */
-table.pretty { margin-left:auto; margin-right:auto; background-color: #fff; border-collapse: collapse; border: 0px white solid; }
+table.pretty { margin-left:auto; margin-right:auto; background-color: #fff; border-collapse: collapse; border: 0px white solid; display: block; overflow-x:auto; }
 table.pretty th, table.pretty td {border: 1px silver solid; padding: 0.4em; text-align: center; }
 table.pretty th { background: gainsboro; }
 table.pretty th.empty { background: #fff; border:0; }


### PR DESCRIPTION
Test URL:
https://www.webpagetest.org/result/200831_E6_4855e8cc9ddbc56bf8b40421f75ba1e9/1/details/#waterfall_view_step1

Tested in Firefox and Chrome.
![image](https://user-images.githubusercontent.com/1437027/91770045-c2b40200-ebe0-11ea-88a2-d7b0917cd074.png)

I didn't test all the tables on all subpages, but I think they shouldn't be badly affected by this change.
But if you prefer to explicitly add scroll only to the two tables on the result page by their IDs, I could update the PR.