### PR TITLE
Better HTTP Version parsing for HTTP Archive HAR

### DIFF
--- a/www/har/HttpArchiveGenerator.php
+++ b/www/har/HttpArchiveGenerator.php
@@ -222,7 +222,7 @@ class HttpArchiveGenerator
         $request['bodySize'] = -1;
         $request['cookies'] = array();
         $request['headers'] = array();
-        $ver = '';
+        $ver = $requestData['protocol'];
         $headersSize = 0;
         if (isset($requestData['headers']) && isset($requestData['headers']['request'])) {
             foreach ($requestData['headers']['request'] as &$header) {
@@ -248,9 +248,11 @@ class HttpArchiveGenerator
                         }
                     }
                 } else {
-                    $pos = strpos($header, 'HTTP/');
-                    if ($pos >= 0)
-                        $ver = (string)trim(substr($header, $pos + 5, 3));
+                    if (!$ver) { // if version not already set then try to parse it
+                        $pos = strpos($header, 'HTTP/');
+                        if ($pos !== false)
+                            $ver = (string)trim(substr($header, $pos + 5, 3));
+                    }
                 }
             }
         }
@@ -292,7 +294,7 @@ class HttpArchiveGenerator
         $response['headersSize'] = -1;
         $response['bodySize'] = (int)$requestData['objectSize'];
         $response['headers'] = array();
-        $ver = '';
+        $ver = $requestData['protocol'];
         $loc = '';
         $headersSize = 0;
         if (isset($requestData['headers']) && isset($requestData['headers']['response'])) {
@@ -308,9 +310,11 @@ class HttpArchiveGenerator
                     if (!strcasecmp($name, 'location'))
                         $loc = (string)$val;
                 } else {
-                    $pos = strpos($header, 'HTTP/');
-                    if ($pos >= 0)
-                        $ver = (string)trim(substr($header, $pos + 5, 3));
+                    if (!$ver) { // if version not already set then try to parse it
+                        $pos = strpos($header, 'HTTP/');
+                        if ($pos !== false)
+                            $ver = (string)trim(substr($header, $pos + 5, 3));
+                    }
                 }
             }
         }

--- a/www/har/HttpArchiveGenerator.php
+++ b/www/har/HttpArchiveGenerator.php
@@ -251,7 +251,7 @@ class HttpArchiveGenerator
                     if (!$ver) { // if version not already set then try to parse it
                         $pos = strpos($header, 'HTTP/');
                         if ($pos !== false)
-                            $ver = (string)trim(substr($header, $pos + 5, 3));
+                            $ver = (string)trim(substr($header, $pos, 8));
                     }
                 }
             }
@@ -313,7 +313,7 @@ class HttpArchiveGenerator
                     if (!$ver) { // if version not already set then try to parse it
                         $pos = strpos($header, 'HTTP/');
                         if ($pos !== false)
-                            $ver = (string)trim(substr($header, $pos + 5, 3));
+                            $ver = (string)trim(substr($header, $pos, 8));
                     }
                 }
             }

--- a/www/har/HttpArchiveGenerator.php
+++ b/www/har/HttpArchiveGenerator.php
@@ -222,7 +222,7 @@ class HttpArchiveGenerator
         $request['bodySize'] = -1;
         $request['cookies'] = array();
         $request['headers'] = array();
-        $ver = $requestData['protocol'];
+        $ver = '';
         $headersSize = 0;
         if (isset($requestData['headers']) && isset($requestData['headers']['request'])) {
             foreach ($requestData['headers']['request'] as &$header) {
@@ -258,7 +258,7 @@ class HttpArchiveGenerator
         }
         if ($headersSize)
             $request['headersSize'] = $headersSize;
-        $request['httpVersion'] = $ver;
+        $request['httpVersion'] = $ver || $requestData['protocol'];
 
         $request['queryString'] = array();
         $parts = parse_url($request['url']);
@@ -294,7 +294,7 @@ class HttpArchiveGenerator
         $response['headersSize'] = -1;
         $response['bodySize'] = (int)$requestData['objectSize'];
         $response['headers'] = array();
-        $ver = $requestData['protocol'];
+        $ver = '';
         $loc = '';
         $headersSize = 0;
         if (isset($requestData['headers']) && isset($requestData['headers']['response'])) {
@@ -320,7 +320,7 @@ class HttpArchiveGenerator
         }
         if ($headersSize)
             $response['headersSize'] = $headersSize;
-        $response['httpVersion'] = $ver;
+        $response['httpVersion'] = $ver || $requestData['protocol'];
         $response['redirectURL'] = $loc;
 
         $response['content'] = array();


### PR DESCRIPTION
Fixes #1391 

I've had a go at fixing this but not sure how to test this so could do with a code review and/or pointers how to test.

Four changes I've made (to both request and response) are:
1. Only try to parse the version from the header if not already set as first line more likely to contain the version for HTTP/1
2. Use `if ($pos !== false)` instead of `if ($pos >= 0)` as was picking up un-matched lines for request headers so setting it to blank for HTTP/1.1 (for blank lines) and `:status: 200`, `:method: GET` and `:authority: example.com` for HTTP > 1.
3. Include the full version string (`HTTP/1.1` instead of `1.1`) to be more consistent with the `protocol` field.
4. Use the `protocol` field if not able to parse (note this is same for request and response hence why I've left it to end, for those edge cases where they requests 1.0 and get back 1.1).

Things I haven't done:

- lowercase for consistency, so may be a mix of `HTTP/1.1` and `http/1.1`
- try to normalise the fields (e.g. `h2` -> `HTTP/2` or `h3-q050` -> 'HTTP/3')

Let me know if you think we should do that too.
