### PR TITLE
Even better HTTP version parsing from HAR

### DIFF
--- a/www/har/HttpArchiveGenerator.php
+++ b/www/har/HttpArchiveGenerator.php
@@ -252,8 +252,9 @@ class HttpArchiveGenerator
                         $pos = strpos($header, 'HTTP/');
                         if ($pos !== false) {
                             $ver = (string)trim(substr($header, $pos, 8));
-                            // Only accept HTTP/1 values for versions from headers
-                            if ($ver != 'HTTP/1.0' && $ver != 'HTTP/1.1')
+                            // Only accept HTTP/0.9 and HTTP/1 values for versions from headers
+                            // HTTP/2 and above is not set in headers and will come from protocol
+                            if ($ver !== 'HTTP/0.9' && $ver !== 'HTTP/1.0' && $ver !== 'HTTP/1.1')
                                 $ver = '';
                         }
                     }
@@ -325,8 +326,9 @@ class HttpArchiveGenerator
                         $pos = strpos($header, 'HTTP/');
                         if ($pos !== false) {
                             $ver = (string)trim(substr($header, $pos, 8));
-                            // Only accept HTTP/1 values for versions from headers
-                            if ($ver != 'HTTP/1.0' && $ver != 'HTTP/1.1')
+                            // Only accept HTTP/0.9 and HTTP/1 values for versions from headers
+                            // HTTP/2 and above is not set in headers and will come from protocol
+                            if ($ver !== 'HTTP/0.9' && $ver !== 'HTTP/1.0' && $ver !== 'HTTP/1.1')
                                 $ver = '';
                         }
                     }

--- a/www/har/HttpArchiveGenerator.php
+++ b/www/har/HttpArchiveGenerator.php
@@ -248,20 +248,25 @@ class HttpArchiveGenerator
                         }
                     }
                 } else {
-                    if (!$ver) { // if version not already set then try to parse it
+                    if (!$ver) { // if version not already set then try to parse it from headers
                         $pos = strpos($header, 'HTTP/');
-                        if ($pos !== false)
+                        if ($pos !== false) {
                             $ver = (string)trim(substr($header, $pos, 8));
+                            // Only accept HTTP/1 values for versions from headers
+                            if ($ver != 'HTTP/1.0' && $ver != 'HTTP/1.1')
+                                $ver = '';
+                        }
                     }
                 }
             }
         }
         if ($headersSize)
             $request['headersSize'] = $headersSize;
-        if (strlen($ver)) {
-            $request['httpVersion'] = $ver;
-        } elseif(isset($requestData['protocol']) && strlen($requestData['protocol'])) {
+        // Get HTTP version from protocol and only fall back to parsed header version if not set
+        if(isset($requestData['protocol']) && strlen($requestData['protocol'])) {
             $request['httpVersion'] = $requestData['protocol'];
+        } elseif (strlen($ver)) {
+            $request['httpVersion'] = $ver;
         } else {
             $request['httpVersion'] = '';
         }
@@ -316,20 +321,25 @@ class HttpArchiveGenerator
                     if (!strcasecmp($name, 'location'))
                         $loc = (string)$val;
                 } else {
-                    if (!$ver) { // if version not already set then try to parse it
+                    if (!$ver) { // if version not already set then try to parse it from headers
                         $pos = strpos($header, 'HTTP/');
-                        if ($pos !== false)
+                        if ($pos !== false) {
                             $ver = (string)trim(substr($header, $pos, 8));
+                            // Only accept HTTP/1 values for versions from headers
+                            if ($ver != 'HTTP/1.0' && $ver != 'HTTP/1.1')
+                                $ver = '';
+                        }
                     }
                 }
             }
         }
         if ($headersSize)
             $response['headersSize'] = $headersSize;
-        if (strlen($ver)) {
-            $response['httpVersion'] = $ver;
-        } elseif(isset($requestData['protocol']) && strlen($requestData['protocol'])) {
+        // Get HTTP version from protocol and only fall back to parsed header version if not set
+        if(isset($requestData['protocol']) && strlen($requestData['protocol'])) {
             $response['httpVersion'] = $requestData['protocol'];
+        } elseif (strlen($ver)) {
+            $response['httpVersion'] = $ver;
         } else {
             $response['httpVersion'] = '';
         }


### PR DESCRIPTION
In #1392 (and a follow up correction by @pmeenan in https://github.com/WPO-Foundation/webpagetest/commit/0b79b27a8937e14af9b5a68edd5429edc108c399#diff-fdadb3a71806b1a9bee1c97ad160ff9c7eb655e8a58e7610a1ee70db10455b27) I attempted to improve HTTP Version Parsing for the HAR.

The results of the [first full HTTP Archive crawl since are in](https://docs.google.com/spreadsheets/d/1GTt4l90RD1pURSinPYy4Fn8cJ6p3_sWmL5x03EmV0E8/edit#gid=969081353) and it certainly looks better. However the request HTTP Version is still a little funny for a small number of sites.

This PR makes two changes:
1. Use `protocol` as the main preference and only falls back to parsed header if that is not set. I was a little nervous to do this initially but think it's the right thing to do. HTTP/2 (and above) are now more common than HTTP/1 and header parsing is brittle. However Chrome still doesn't report this for 3.95% of cases so can't depend on just this just yet.
2. Only allow HTTP/0.9 (yes it is still used!), HTTP/1.0 and HTTP/1.1 from parsed values to reduce false matches.