### PR TITLE
Enable FCP in Firefox (and eventually, Safari)

### DIFF
--- a/www/include/RunResultHtmlTable.php
+++ b/www/include/RunResultHtmlTable.php
@@ -17,7 +17,7 @@ class RunResultHtmlTable {
   const COL_RESULT = "result";
   const COL_COST = "cost";
   const COL_CERTIFICATE_BYTES = "certificate_bytes";
-  const COL_FIRST_CONTENTFUL_PAINT = 'chromeUserTiming.firstContentfulPaint';
+  const COL_FIRST_CONTENTFUL_PAINT = 'PerformancePaintTiming.first-contentful-paint';
   const COL_LARGEST_CONTENTFUL_PAINT = 'chromeUserTiming.LargestContentfulPaint';
   const COL_CUMULATIVE_LAYOUT_SHIFT = 'chromeUserTiming.CumulativeLayoutShift';
   const COL_TOTAL_BLOCKING_TIME = 'TotalBlockingTime';

--- a/www/include/RunResultHtmlTable.php
+++ b/www/include/RunResultHtmlTable.php
@@ -17,7 +17,7 @@ class RunResultHtmlTable {
   const COL_RESULT = "result";
   const COL_COST = "cost";
   const COL_CERTIFICATE_BYTES = "certificate_bytes";
-  const COL_FIRST_CONTENTFUL_PAINT = 'PerformancePaintTiming.first-contentful-paint';
+  const COL_FIRST_CONTENTFUL_PAINT = 'FirstContentfulPaint';
   const COL_LARGEST_CONTENTFUL_PAINT = 'chromeUserTiming.LargestContentfulPaint';
   const COL_CUMULATIVE_LAYOUT_SHIFT = 'chromeUserTiming.CumulativeLayoutShift';
   const COL_TOTAL_BLOCKING_TIME = 'TotalBlockingTime';

--- a/www/include/RunResultHtmlTable.php
+++ b/www/include/RunResultHtmlTable.php
@@ -17,7 +17,7 @@ class RunResultHtmlTable {
   const COL_RESULT = "result";
   const COL_COST = "cost";
   const COL_CERTIFICATE_BYTES = "certificate_bytes";
-  const COL_FIRST_CONTENTFUL_PAINT = 'FirstContentfulPaint';
+  const COL_FIRST_CONTENTFUL_PAINT = 'firstContentfulPaint';
   const COL_LARGEST_CONTENTFUL_PAINT = 'chromeUserTiming.LargestContentfulPaint';
   const COL_CUMULATIVE_LAYOUT_SHIFT = 'chromeUserTiming.CumulativeLayoutShift';
   const COL_TOTAL_BLOCKING_TIME = 'TotalBlockingTime';

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -78,7 +78,7 @@ function loadPageStepData($localPaths, $testInfo = null) {
       $ret = null;
     }
   }
-
+    
   if (!isset($ret) || !is_array($ret)) {
     $ret = loadPageData($localPaths->pageDataFile());
     if (!isset($ret) || !is_array($ret) || !count($ret))
@@ -99,7 +99,9 @@ function loadPageStepData($localPaths, $testInfo = null) {
         }
       }
     }
-
+    //set top level FCP
+    TopLevelFCP($ret);
+    
     if (!empty($ret) && !$basic_results) {
       $startOffset = array_key_exists('testStartOffset', $ret) ? intval(round($ret['testStartOffset'])) : 0;
       loadUserTimingData($ret, $localPaths->userTimedEventsFile());
@@ -457,14 +459,6 @@ function loadPageStepData($localPaths, $testInfo = null) {
       }
     }
 
-    // set a top level firstContentfulPaint metric
-    if (isset($ret) && is_array($ret) &&
-      !isset($ret['firstContentfulPaint'])) {
-        if (isset($ret['chromeUserTiming.firstContentfulPaint']))
-          $ret['firstContentfulPaint'] = $ret['chromeUserTiming.firstContentfulPaint'];
-        elseif (isset($ret['PerformancePaintTiming.first-contentful-paint']))
-          $ret['firstContentfulPaint'] = $ret['PerformancePaintTiming.first-contentful-paint'];
-    }
 
     // see if there is test-level lighthouse data to attach
     // Don't cache the lighthouse bit because the file may come in after other results are cached
@@ -507,6 +501,11 @@ function loadPageStepData($localPaths, $testInfo = null) {
         }
       }
     }
+  }
+  
+  // set top level FCP in case page data was already cached
+  if (!isset($ret['firstContentfulPaint'])) {
+    TopLevelFCP($ret);
   }
 
   if (isset($ret['fullyLoaded']))
@@ -1303,5 +1302,21 @@ function CalculateTimeToInteractive($localPaths, $startTime, $interactiveWindows
   }
   
   return $TTI;
+}
+
+/**
+* Set a top-level FCP metric
+* 
+* @param mixed pageData
+*/
+function TopLevelFCP(&$pageData) {
+  // set a top level firstContentfulPaint metric
+  if (isset($pageData) && is_array($pageData) &&
+  !isset($pageData['firstContentfulPaint'])) {
+    if (isset($pageData['chromeUserTiming.firstContentfulPaint']))
+      $pageData['firstContentfulPaint'] = $pageData['chromeUserTiming.firstContentfulPaint'];
+    elseif (isset($pageData['PerformancePaintTiming.first-contentful-paint']))
+      $pageData['firstContentfulPaint'] = $pageData['PerformancePaintTiming.first-contentful-paint'];
+  }
 }
 ?>

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -301,8 +301,8 @@ function loadPageStepData($localPaths, $testInfo = null) {
         $max_fid = null;
         if (isset($ret['render']) && $ret['render'] > 0)
           $seek_start = $ret['render'];
-        elseif (isset($ret['chromeUserTiming.firstContentfulPaint']) && $ret['chromeUserTiming.firstContentfulPaint'] > 0)
-          $seek_start = $ret['chromeUserTiming.firstContentfulPaint'];
+        elseif (isset($ret['PerformancePaintTiming.first-contentful-paint']) && $ret['PerformancePaintTiming.first-contentful-paint'] > 0)
+          $seek_start = $ret['PerformancePaintTiming.first-contentful-paint'];
         elseif (isset($ret['firstPaint']) && $ret['firstPaint'] > 0)
           $seek_start = $ret['firstPaint'];
         $DCL = null;

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -301,8 +301,8 @@ function loadPageStepData($localPaths, $testInfo = null) {
         $max_fid = null;
         if (isset($ret['render']) && $ret['render'] > 0)
           $seek_start = $ret['render'];
-        elseif (isset($ret['PerformancePaintTiming.first-contentful-paint']) && $ret['PerformancePaintTiming.first-contentful-paint'] > 0)
-          $seek_start = $ret['PerformancePaintTiming.first-contentful-paint'];
+        elseif (isset($ret['firstContentfulPaint']) && $ret['firstContentfulPaint'] > 0)
+          $seek_start = $ret['firstContentfulPaint'];
         elseif (isset($ret['firstPaint']) && $ret['firstPaint'] > 0)
           $seek_start = $ret['firstPaint'];
         $DCL = null;
@@ -455,6 +455,15 @@ function loadPageStepData($localPaths, $testInfo = null) {
         if (!isset($ret[$key]))
           $ret[$key] = $value;
       }
+    }
+
+    // set a top level firstContentfulPaint metric
+    if (isset($ret) && is_array($ret) &&
+      !isset($ret['firstContentfulPaint'])) {
+        if (isset($ret['chromeUserTiming.firstContentfulPaint']))
+          $ret['firstContentfulPaint'] = $ret['chromeUserTiming.firstContentfulPaint'];
+        elseif (isset($ret['PerformancePaintTiming.first-contentful-paint']))
+          $ret['firstContentfulPaint'] = $ret['PerformancePaintTiming.first-contentful-paint'];
     }
 
     // see if there is test-level lighthouse data to attach

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -996,9 +996,9 @@ function DisplayGraphs() {
             $timeMetrics['visualComplete99'] = "99% Visually Complete";
         }
         if ($hasStepResult &&
-            !isset($timeMetrics['chromeUserTiming.firstContentfulPaint']) &&
-            $test['stepResult']->getMetric('chromeUserTiming.firstContentfulPaint') > 0) {
-            $timeMetrics['chromeUserTiming.firstContentfulPaint'] = "First Contentful Paint";
+            !isset($timeMetrics['PerformancePaintTiming.first-contentful-paint']) &&
+            $test['stepResult']->getMetric('PerformancePaintTiming.first-contentful-paint') > 0) {
+            $timeMetrics['PerformancePaintTiming.first-contentful-paint'] = "First Contentful Paint";
         }
         if ($hasStepResult &&
             !isset($timeMetrics['chromeUserTiming.firstMeaningfulPaint']) &&
@@ -1183,7 +1183,8 @@ function DisplayGraphs() {
             }
             $row = 0;
             foreach($timeMetrics as $metric => $label) {
-              $metricKey = str_replace('.', '', $metric);
+              $filterOut = array('.', '-');
+              $metricKey = str_replace($filterOut, '', $metric);
               echo "var dataTimes$metricKey = new google.visualization.DataView(dataTimes);\n";
               echo "dataTimes$metricKey.setRows($row, $row);\n";
               $row++;

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -996,9 +996,9 @@ function DisplayGraphs() {
             $timeMetrics['visualComplete99'] = "99% Visually Complete";
         }
         if ($hasStepResult &&
-            !isset($timeMetrics['PerformancePaintTiming.first-contentful-paint']) &&
-            $test['stepResult']->getMetric('PerformancePaintTiming.first-contentful-paint') > 0) {
-            $timeMetrics['PerformancePaintTiming.first-contentful-paint'] = "First Contentful Paint";
+            !isset($timeMetrics['firstContentfulPaint']) &&
+            $test['stepResult']->getMetric('firstContentfulPaint') > 0) {
+            $timeMetrics['firstContentfulPaint'] = "First Contentful Paint";
         }
         if ($hasStepResult &&
             !isset($timeMetrics['chromeUserTiming.firstMeaningfulPaint']) &&


### PR DESCRIPTION
Firefox supports FCP since version 84 and Safari has it in their tech preview. We already capture the FCP metric for Firefox in the JSON, but don't expose it in the UI because we've been using the `chromeUserTiming.firstContentfulPaint` value.

This PR changes that to using the `PerformancePaintTiming.first-contentful-paint` value instead so that FCP gets exposed in the UI for non-Chrome browsers that support it.