### PR TITLE
Adding IAM Instance Profile option for wpt agents

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -570,6 +570,14 @@ function EC2_LaunchInstance($region, $ami, $size, $user_data, $loc) {
         'UserData' => base64_encode ( $user_data )
       );
 
+      // add/modify IAM instance profile(s) if present in config
+      $iamInstanceProfile = GetSetting('EC2.iamInstanceProfile');
+      if ($iamInstanceProfile) {
+        $ec2_options['IamInstanceProfile'] = array(
+          'Name' => $iamInstanceProfile
+        );
+      }
+
       //add/modify the SecurityGroupIds if present in config
       $secGroups = GetSetting("EC2.$region.securityGroup");
       if ($secGroups) {

--- a/www/settings/settings.ini.sample
+++ b/www/settings/settings.ini.sample
@@ -281,6 +281,9 @@ maxNavigateCount=20
 ; Tags to add to the agent instances
 ; EC2.tags="myTag=>myValue|foo=>bar"
 
+; IAM instance profile ID to assign to the agent instances
+; EC2.iamInstanceProfile=name-of-instance-profile
+
 ; Default location when using EC2 auto-scaling - this setting is required for auto-scaling
 ;EC2.default=us-east-1
 


### PR DESCRIPTION
For private installations I have needed to pass through an IAM instance profile to the WPT Agents that are spun up by WPT server, so that the WPT agents can use AWS Inspector Agent - this is a common security requirement.

(This needs a predefined role with `AmazonEC2RoleforSSM` and `AmazonSSMManagedInstanceCore`.)

*This is only useful if you have your own custom WPT agent AMIs where you have already installed AWS Inspector*- is it too niche, or is having this option available useful?