### PR TITLE
Implementing new CLS metric

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -152,7 +152,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '20.06');   // webpagetest version
-define('VER_CSS', 119);                // version of the sitewide css file
+define('VER_CSS', 120);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 45);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/common.inc
+++ b/www/common.inc
@@ -152,11 +152,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '20.06');   // webpagetest version
-<<<<<<< HEAD
-define('VER_CSS', 120);                // version of the sitewide css file
-=======
-define('VER_CSS', 121);                // version of the sitewide css file
->>>>>>> master
+define('VER_CSS', 122);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 45);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -259,7 +259,7 @@ function loadPageStepData($localPaths, $testInfo = null) {
           $ret['LayoutShifts'] = $layout_shifts;
 
           // Count the number of LayoutShifts before first paint
-          if (isset($ret['chromeUserTiming.CumulativeLayoutShift']) && isset($ret['chromeUserTiming.firstPaint'])) {
+          if (isset($ret['chromeUserTiming.TotalLayoutShift']) && isset($ret['chromeUserTiming.firstPaint'])) {
             $count = 0;
             $cls = 0;
             $fraction = 0;
@@ -269,8 +269,8 @@ function loadPageStepData($localPaths, $testInfo = null) {
                 $cls = $shift['cumulative_score'];
               }
             }
-            if ($ret['chromeUserTiming.CumulativeLayoutShift'] > 0) {
-              $fraction = (float)$cls / (float)$ret['chromeUserTiming.CumulativeLayoutShift'];
+            if ($ret['chromeUserTiming.TotalLayoutShift'] > 0) {
+              $fraction = (float)$cls / (float)$ret['chromeUserTiming.TotalLayoutShift'];
             }
           }
 

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -1093,9 +1093,16 @@ function ParseUserTiming($file, $browser_version, &$layout_shifts, &$page_data) 
         }
       }
 
-      $cumulative_layout_shift = null;
+      $total_layout_shift = null;
+
+      $max_layout_window = 0;
+      $firstShift = 0;
+      $prevShift = 0;
+      $curr = 0;
+      $shiftWindowCount = 0;
+
       if (isset($browser_version) && $browser_version >= 81) {
-        $cumulative_layout_shift = 0.0;
+        $total_layout_shift = 0.0;
         foreach ($events as $event) {
           if (is_array($event) &&
               isset($event['name']) &&
@@ -1122,15 +1129,29 @@ function ParseUserTiming($file, $browser_version, &$layout_shifts, &$page_data) 
                 $event['args']['data']['is_main_frame'] &&
                 isset($event['args']['data']['score'])) {
               if (isset($time)) {
-                if (!isset($cumulative_layout_shift)) {
-                  $cumulative_layout_shift = 0;
+                if (!isset($total_layout_shift)) {
+                  $total_layout_shift = 0;
                 }
-                $cumulative_layout_shift += $event['args']['data']['score'];
+                $total_layout_shift += $event['args']['data']['score'];
+
+                if (($time - $firstShift > 5000) || ($time - $prevShift > 1000)) {
+                  //new shift window
+                  $firstShift = $time;
+                  $curr = 0;
+                  $shiftWindowCount++;
+                }
+                $prevShift = $time;
+                $curr += $event['args']['data']['score'];
+                $max_layout_window = max($curr, $max_layout_window);
+
                 $shift = array(
                   'time' => $time,
                   'score' => $event['args']['data']['score'],
-                  'cumulative_score' => $cumulative_layout_shift
+                  'cumulative_score' => $total_layout_shift,
+                  'window_score' => $curr,
+                  'shift_window_num' => $shiftWindowCount
                 );
+
                 if (isset($event['args']['data']['region_rects'])) {
                   $shift['rects'] = $event['args']['data']['region_rects'];
                 }
@@ -1182,8 +1203,11 @@ function ParseUserTiming($file, $browser_version, &$layout_shifts, &$page_data) 
           }
         }
       }
-      if (isset($cumulative_layout_shift)) {
-        $user_timing[] = array('name' => 'CumulativeLayoutShift', 'value' => $cumulative_layout_shift);
+      if (isset($total_layout_shift)) {
+        $user_timing[] = array('name' => 'TotalLayoutShift', 'value' => $total_layout_shift);
+      }
+      if (isset($max_layout_window)) {
+        $user_timing[] = array('name' => 'CumulativeLayoutShift', 'value' => $max_layout_window);
       }
     }
   }

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -472,11 +472,16 @@ body.compact #main {
     .key li{
         padding-left: 1.8em;
         position: relative;
+        padding-bottom: .2em;
     }
     .key li b{
         position: absolute;
         left: 0;
         margin-right: 0;
+    }
+    .key .full{
+        grid-column: 1 / 3;
+        text-align: center;
     }
 }
 h1.attention{


### PR DESCRIPTION
With Chrome changing the way CLS is reported, figured we should update at some point, but keep around the other data because it's still important.

This PR does a couple things:

1. It moves the old CLS score to a new metric (`chromeUserTiming.TotalLayoutShift`)
2. It adds the new version of CLS as `chromeUserTiming.CumulativeLayoutShift`
3. It adds a little bit of context to the LayoutShifts object in the JSON response. Specifically, it adds:
      `window_score`: A running total of the current shift window
      `shift_window_num`: The number of the shift window an individual shift belongs in

A couple quick examples...

https://tim.webpagetest.org/jsonResult.php?test=210412_AiDcE9_b3057a7c4263ceb49f6951778301bccc&pretty=1

```json
"chromeUserTiming.TotalLayoutShift": 1.4525220889,
"chromeUserTiming.CumulativeLayoutShift": 0.41450670859999994,
"LayoutShifts": [
                    {
                        "time": 1915,
                        "score": 0.0002765496,
                        "cumulative_score": 0.0002765496,
                        "window_score": 0.0002765496,
                        "shift_window_num": 1,
                        "rects": [
                            [
                                112,
                                335,
                                1126,
                                104
                            ]
                        ],
....
```

https://tim.webpagetest.org/jsonResult.php?test=210414_BiDcRT_170b4883bf67fbfe086a56be49d807df&pretty=1

```json
"chromeUserTiming.TotalLayoutShift": 0.39808606060000007,
"chromeUserTiming.CumulativeLayoutShift": 0.2447705867,
"LayoutShifts": [
                    {
                        "time": 4025,
                        "score": 0.0045445632,
                        "cumulative_score": 0.0045445632,
                        "window_score": 0.0045445632,
                        "shift_window_num": 1,
                        "rects": [
                            [
                                52,
                                0,
                                1255,
                                40
                            ],
...
```