### PR TITLE
Uppercase fix for JPEG XL.

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -633,7 +633,7 @@ $loc = ParseLocations($locations);
                                     </li>
                                     <li>
                                         <input type="checkbox" name="disableJXL" id="disableJXL" class="checkbox" style="float: left;width: auto;">
-                                        <label for="disableJXL" class="auto_width">Disable Jpeg XL image support</label>
+                                        <label for="disableJXL" class="auto_width">Disable JPEG XL image support</label>
                                     </li>
                                     <?php
                                     if ($admin && GetSetting('wprDesktop')) {


### PR DESCRIPTION
Apologies for the most pedantic PR! Simply uppercase Jpeg in JPEG XL.