### PR TITLE
Fix the layout of the Statistical Comparison table.

### DIFF
--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -1336,6 +1336,33 @@ table.glossary th{
 .chart{
     margin-bottom: 2.5em;
 }
+/* Overriding classes from https://www.gstatic.com/charts/50/css/table/table.css */ 
+.test_results-content .google-visualization-table-table{
+    border-collapse: collapse;
+    width: 100%;
+    font-size: inherit;
+}
+.test_results-content .google-visualization-table{
+    display: block;
+    margin-top: 1em;
+    font-size: .75em;
+}
+.test_results-content .google-visualization-table-th{
+    background: gainsboro;
+}
+.test_results-content .google-visualization-table-th,
+.test_results-content .google-visualization-table-td{
+    border: 1px solid silver;
+    padding: 0.4em;
+    line-height: 1.4em;
+}
+.test_results-content .google-visualization-table-table td{
+    border: 1px solid silver;
+}
+.test_results-content .google-visualization-table .gradient{
+    background-image: none;
+    background: gainsboro;
+}
 
 /* simple forms */
 .simple_form{


### PR DESCRIPTION
Table for statistical comparison uses styles from an external gstatic table CSS file. This fix matches the style of the tables on the page:

## Before
<img width="761" alt="Screenshot 2021-04-15 at 22 20 40" src="https://user-images.githubusercontent.com/1223960/114940793-376b4200-9e3a-11eb-9f95-43b496d2af61.png">

## After
<img width="752" alt="Screenshot 2021-04-15 at 22 20 19" src="https://user-images.githubusercontent.com/1223960/114940827-43ef9a80-9e3a-11eb-9cf1-9d2568b9823a.png">
