### PR TITLE
Improve contrast of waterfall overlays

### DIFF
--- a/www/waterfall.css
+++ b/www/waterfall.css
@@ -2,8 +2,8 @@
 div.waterfall-container {position: relative; left: 0; top: 0; clear:both;text-align: left; width: 1012px; margin:auto;}
 img.waterfall-image {position: relative; left: 0; top: 0; width: 100%;}
 div.request-overlay {cursor:pointer; padding: 0; margin: 0; width: 1010px; left: 1px; background-color: #FFF; overflow: hidden; opacity:0.9; filter:alpha(opacity=90);}
-div.request-overlay.selected {opacity:0.4; background-color: #1151bb;}
-div.request-overlay.lcp-request {opacity:0.4; background-color: #008000;}
+div.request-overlay.selected {opacity:0.4; mix-blend-mode: multiply; background-color: #1151bb;}
+div.request-overlay.lcp-request {opacity:0.4; mix-blend-mode: multiply; background-color: #008000;}
 div.transparent {opacity:0.0; filter:alpha(opacity=0);}
 div.dialog-title {display: inline;}
 div.dialog-title a {color: #fff;}


### PR DESCRIPTION
During a working session yesterday, a client expressed that it was tricky to notice the different parts of a request (bytes received vs waiting for bytes) on vitals.php. I've added a bit of blending to prop up the request details colour, that almost gives the impression that the overlay is behind the request row. And I've also applied the same changes to the regular request overlay, for consistency.