### PR TITLE
1452: Clean up custom waterfall settings form

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -149,7 +149,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
-define('VER_CSS', 142);                // version of the sitewide css file
+define('VER_CSS', 143);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/customWaterfall.php
+++ b/www/customWaterfall.php
@@ -85,7 +85,9 @@ $waterfallSnippet = new WaterfallViewHtmlSnippet($testInfo, $testRunResults->get
                 if( FRIENDLY_URLS )
                     $extension = 'png';
                 echo "<img id=\"waterfallImage\" style=\"display: block; margin-left: auto; margin-right: auto;\" alt=\"Waterfall\" src=\"/waterfall.$extension?test=$id&run=$run&cached=$cached&step=$step&cpu=1&bw=1&ut=1&mime=1&js=1&wait=1\">";
-            ?>
+                echo "<p class=\"customwaterfall_download\"><a class=\"pill\" download href=\"/waterfall.$extension?test=$id&run=$run&cached=$cached&step=$step&cpu=1&bw=1&ut=1&mime=1&js=1&wait=1\">Download Waterfall Image</a></p>";
+
+?>
             </div>
             <?php include('footer.inc'); ?>
         

--- a/www/customWaterfall.php
+++ b/www/customWaterfall.php
@@ -42,7 +42,7 @@ $page_description = "Website speed test custom waterfall$testLabel";
             <div class="customwaterfall_hed">
                 <h1>Generate a Custom Waterfall</h1>
                 <details open class="box customwaterfall_settings">
-                    <summary id="customwaterfall_settings_title" class="customwaterfall_settings_hed">Waterfall Settings</summary>
+                    <summary id="customwaterfall_settings_title" class="customwaterfall_settings_hed"><i class="icon_plus"></i>Waterfall Settings</summary>
                     <form aria-labelledby="customwaterfall_settings_title" name="urlEntry" action="javascript:UpdateWaterfall();" method="GET">
                         <fieldset>
                             <legend>Chart Type</legend>
@@ -105,13 +105,8 @@ $waterfallSnippet = new WaterfallViewHtmlSnippet($testInfo, $testRunResults->get
                     UpdateWaterfall();
                 });
 
-                $("input[name=coloring]").click(function(){
-                    UpdateWaterfall();
-                });
-
-                $("input[type=checkbox]").click(function(){
-                    UpdateWaterfall();
-                });
+                $("input[name=coloring], input[type=checkbox]").click( UpdateWaterfall );
+                $("input[type=text]").on( "input", UpdateWaterfall );
 
                 // reset the wait cursor when the image loads
                 $('#waterfallImage').load(function(){

--- a/www/customWaterfall.php
+++ b/www/customWaterfall.php
@@ -42,7 +42,7 @@ $page_description = "Website speed test custom waterfall$testLabel";
             <div class="customwaterfall_hed">
                 <h1>Generate a Custom Waterfall</h1>
                 <details open class="box customwaterfall_settings">
-                    <summary id="customwaterfall_settings_title" class="customwaterfall_settings_hed"><i class="icon_plus"></i>Waterfall Settings</summary>
+                    <summary id="customwaterfall_settings_title" class="customwaterfall_settings_hed"><span><i class="icon_plus"></i> <span>Waterfall Settings</span></span></summary>
                     <form aria-labelledby="customwaterfall_settings_title" name="urlEntry" action="javascript:UpdateWaterfall();" method="GET">
                         <fieldset>
                             <legend>Chart Type</legend>

--- a/www/customWaterfall.php
+++ b/www/customWaterfall.php
@@ -39,14 +39,15 @@ $page_description = "Website speed test custom waterfall$testLabel";
             $tab = null;
             include 'header.inc';
             ?>
-            <h1>Generate a Custom Waterfall</h1>
-            <div class="box customwaterfall_settings">
-                <h2 class="customwaterfall_settings_hed">Waterfall Settings</h2>
-                <form name="urlEntry" action="javascript:UpdateWaterfall();" method="GET">
-                    <fieldset>
-                        <legend>Chart Type</legend>
-                            <label><input type="radio" name="type" value="waterfall" checked>Waterfall</label>
-                            <label><input type="radio" name="type" value="connection"> Connection View</label>
+            <div class="customwaterfall_hed">
+                <h1>Generate a Custom Waterfall</h1>
+                <details open class="box customwaterfall_settings">
+                    <summary id="customwaterfall_settings_title" class="customwaterfall_settings_hed">Waterfall Settings</summary>
+                    <form aria-labelledby="customwaterfall_settings_title" name="urlEntry" action="javascript:UpdateWaterfall();" method="GET">
+                        <fieldset>
+                            <legend>Chart Type</legend>
+                                <label><input type="radio" name="type" value="waterfall" checked>Waterfall</label>
+                                <label><input type="radio" name="type" value="connection"> Connection View</label>
                         </fieldset>
                         <fieldset>
                             <legend>Chart Coloring</legend>
@@ -58,8 +59,8 @@ $page_description = "Website speed test custom waterfall$testLabel";
                             <label>Maximum Time <em>(In seconds, leave blank for automatic)</em>: <input id="max" type="text" name="max" style="width:2em" value=""></label>
                             <label>Requests <em>(i.e. 1,2,3,4-9,8)</em>: <input id="requests" type="text" name="requests" value=""></label>
                         </fieldset>
-                        <details>
-                            <summary>Show/Hide Extras</summary>
+                        <fieldset>
+                            <legend>Show/Hide Extras</legend>
                             <label><input id="showUT" type="checkbox" checked>Lines for User Timing Marks</label>
                             <label><input id="showCPU" type="checkbox" checked>CPU Utilization</label>
                             <label><input id="showBW" type="checkbox" checked>Bandwidth Utilization</label>
@@ -68,9 +69,10 @@ $page_description = "Website speed test custom waterfall$testLabel";
                             <label><input id="showChunks" type="checkbox" checked>Download chunks</label>
                             <label><input id="showJS" type="checkbox" checked>JS Execution chunks</label>
                             <label><input id="showWait" type="checkbox" checked>Wait Time</label>
-                        </details>
+                         </fieldset>
                         <button id="update" onclick="javascript:UpdateWaterfall();">Update Waterfall</button><br>
-                </form>
+                    </form>
+                </details>
             </div>
             <div class="box">
                 

--- a/www/customWaterfall.php
+++ b/www/customWaterfall.php
@@ -26,10 +26,11 @@ $page_description = "Website speed test custom waterfall$testLabel";
         <?php $gaTemplate = 'Custom Waterfall'; include ('head.inc'); ?>
         <style>
             div.bar {
-            height:20px;
-            margin-top:auto;
-            margin-bottom:auto;
-        }
+                height:20px;
+                margin-top:auto;
+                margin-bottom:auto;
+            }
+            
             <?php include "waterfall.css";?>
         </style>
     </head>
@@ -39,26 +40,36 @@ $page_description = "Website speed test custom waterfall$testLabel";
             include 'header.inc';
             ?>
             <h1>Generate a Custom Waterfall</h1>
-            <div class="box">
+            <div class="box customwaterfall_settings">
+                <h2 class="customwaterfall_settings_hed">Waterfall Settings</h2>
                 <form name="urlEntry" action="javascript:UpdateWaterfall();" method="GET">
-                    Chart Type:
-                        <label><input type="radio" name="type" value="waterfall" checked="checked">Waterfall</label>
-                     &nbsp; <label><input type="radio" name="type" value="connection"> Connection View</label><br>
-                    Chart Coloring:
-                        <label><input type="radio" name="coloring" value="classic"> Classic</label>
-                     &nbsp; <label><input type="radio" name="coloring" value="mime" checked="checked"> By MIME Type</label><br>
-                     <label>Image Width: <input id="width" type="text" name="width" style="width:3em" value="930"> Pixels (300-2000)</label><br>
-                     <label>Maximum Time: <input id="max" type="text" name="max" style="width:2em" value=""> Seconds (leave blank for automatic)</label><br>
-                     <label>Requests (i.e. 1,2,3,4-9,8): <input id="requests" type="text" name="requests" style="width:20em" value=""></label>
-                    <button id="update" onclick="javascript:UpdateWaterfall();">Update Waterfall</button><br>
-                    <label><input id="showUT" type="checkbox" checked> Draw lines for User Timing Marks</label>
-                    <label><input id="showCPU" type="checkbox" checked> Show CPU Utilization</label>
-                    <label><input id="showBW" type="checkbox" checked> Show Bandwidth Utilization</label> <br>
-                    <label><input id="showDots" type="checkbox" checked> Show Ellipsis (...) for missing items</label>
-                    <label><input id="showLabels" type="checkbox" checked> Show Labels for requests (URL)</label>
-                    <label><input id="showChunks" type="checkbox" checked> Show download chunks</label>
-                    <label><input id="showJS" type="checkbox" checked> Show JS Execution chunks</label>
-                    <label><input id="showWait" type="checkbox" checked> Show Wait Time</label>
+                    <fieldset>
+                        <legend>Chart Type</legend>
+                            <label><input type="radio" name="type" value="waterfall" checked>Waterfall</label>
+                            <label><input type="radio" name="type" value="connection"> Connection View</label>
+                        </fieldset>
+                        <fieldset>
+                            <legend>Chart Coloring</legend>
+                            <label><input type="radio" name="coloring" value="classic"> Classic</label>
+                            <label><input type="radio" name="coloring" value="mime" checked="checked"> By MIME Type</label>
+                        </fieldset> 
+                        <fieldset>
+                            <label>Image Width <em>(Pixels, 300-2000)</em>: <input id="width" type="text" name="width" style="width:3em" value="930"></label>
+                            <label>Maximum Time <em>(In seconds, leave blank for automatic)</em>: <input id="max" type="text" name="max" style="width:2em" value=""></label>
+                            <label>Requests <em>(i.e. 1,2,3,4-9,8)</em>: <input id="requests" type="text" name="requests" value=""></label>
+                        </fieldset>
+                        <details>
+                            <summary>Show/Hide Extras</summary>
+                            <label><input id="showUT" type="checkbox" checked>Lines for User Timing Marks</label>
+                            <label><input id="showCPU" type="checkbox" checked>CPU Utilization</label>
+                            <label><input id="showBW" type="checkbox" checked>Bandwidth Utilization</label>
+                            <label><input id="showDots" type="checkbox" checked>Ellipsis (...) for missing items</label>
+                            <label><input id="showLabels" type="checkbox" checked>Labels for requests (URL)</label>
+                            <label><input id="showChunks" type="checkbox" checked>Download chunks</label>
+                            <label><input id="showJS" type="checkbox" checked>JS Execution chunks</label>
+                            <label><input id="showWait" type="checkbox" checked>Wait Time</label>
+                        </details>
+                        <button id="update" onclick="javascript:UpdateWaterfall();">Update Waterfall</button><br>
                 </form>
             </div>
             <div class="box">

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -101,6 +101,7 @@ a.pill{
     padding: 0.6875em 1.4375em;
     line-height: 1em;
     text-decoration: none;
+    color: #fff;
 }
 .home a {color: #fff;}
 img {border: none;}

--- a/www/waterfall.css
+++ b/www/waterfall.css
@@ -220,7 +220,7 @@ div.bar {
 .customwaterfall_settings_hed::-webkit-details-marker {
     display: none;
 }
-.customwaterfall_settings_hed {
+.customwaterfall_settings_hed > span {
     position: relative;
     display: flex;
     gap: .5rem;

--- a/www/waterfall.css
+++ b/www/waterfall.css
@@ -173,3 +173,59 @@ div.bar {
 #experimentSettings input[type="text"] {
     margin-bottom: 1em;
 }
+
+/* custom waterfall settings */
+
+@media (min-width: 60em) {
+    .customwaterfall_settings {
+        position: fixed;
+        overflow: auto;
+        right: 1vw;
+        top: 20vh;
+        bottom: 1vh;
+        width: 20vw;
+        background: rgba(18, 29, 53, .9);
+        color: #fff;
+        border: 1px solid #2F80ED;
+        box-shadow: 0 0 30px rgb(47 128 237 / 50%);
+    }
+}
+.customwaterfall_settings_hed {
+    font-size: .9rem;
+    margin: 0 0 .8rem;
+    font-weight: normal;
+    padding: 0 0 .8em;
+    border-bottom: 1px solid rgba(255,255,255,.2);
+}
+.customwaterfall_settings fieldset {
+    border: 0;
+    padding: .3rem 0 0;
+    margin: 0 0 1rem;
+}
+.customwaterfall_settings legend {
+    font-weight: bold;
+    margin: 0;
+    display: block;
+    padding: 0;
+}
+.customwaterfall_settings summary {
+    font-weight: bold;
+}
+.customwaterfall_settings label,
+.customwaterfall_settings label input[type=text] {
+    display: block;
+    margin-bottom: .5rem;
+}
+.customwaterfall_settings label input[type=text] {
+    margin: .2rem 0 1rem;
+}
+.customwaterfall_settings label em {
+    font-size: .8em;
+}
+.customwaterfall_settings label {
+    margin: .3rem 0 .5rem;
+    line-height: 1.2
+}
+.customwaterfall_settings button {
+    display: none; /* necessary button? does non-js work anyway? */
+}

--- a/www/waterfall.css
+++ b/www/waterfall.css
@@ -175,44 +175,6 @@ div.bar {
 }
 
 /* custom waterfall settings */
-
-@media (min-width: 60em) {
-    .customwaterfall_hed {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-    }
-    .customwaterfall_settings {
-        padding: 1.3rem 2rem;
-        transition: all .5s ease-out;
-        border: 1px solid transparent;
-        box-shadow: none;
-        background: transparent;
-        margin: 0;
-    }
-    .customwaterfall_settings:hover,
-    .customwaterfall_settings:focus-within {
-        border-color: #ccc;
-    }
-    
-    .customwaterfall_settings[open] {
-        border: 1px solid #2F80ED;
-        box-shadow: 0 0 30px rgb(47 128 237 / 50%);
-        background: rgba(18, 29, 53, .9);
-        color: #fff;
-        min-height: 20rem;
-        position: fixed;
-        z-index: 999;
-        right: 2vw;
-        top: auto;
-        width: 20vw;
-    }
-    .customwaterfall_settings form {
-        overflow: auto;
-        max-height: 65vh;
-        min-height: 20rem;
-    }
-}
 .customwaterfall_settings_hed {
     font-size: .9rem;
     font-weight: bold;
@@ -251,4 +213,91 @@ div.bar {
 }
 .customwaterfall_settings button {
     display: none; /* necessary button? does non-js work anyway? */
+}
+.customwaterfall_settings_hed {
+    list-style-type: none;
+}
+.customwaterfall_settings_hed::-webkit-details-marker {
+    display: none;
+}
+.customwaterfall_settings_hed {
+    position: relative;
+    display: flex;
+    gap: .5rem;
+}
+.customwaterfall_settings_hed .icon_plus {
+    background: rgba(255,255,255,1);
+    border-radius: 100%;
+    display: inline-block;
+    width: 1.3em;
+    height: 1.3em;
+    position: relative;
+}
+.customwaterfall_settings_hed .icon_plus:before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    margin-top: -.1rem;
+    left: 25%;
+    right: 25%;
+    height: .2em;
+    background: #555;
+}
+.customwaterfall_settings_hed .icon_plus:after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    margin-left: -.1rem;
+    top: 25%;
+    bottom: 25%;
+    width: .2em;
+    background: #555;
+}
+.customwaterfall_settings[open] > .customwaterfall_settings_hed .icon_plus {
+    transform: rotate(45deg);
+    position: absolute;
+    right: 0;
+}
+/* at 60em and up, the settings are displayed as a fixed panel */
+@media (min-width: 60em) {
+    .customwaterfall_hed {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+    }
+    .customwaterfall_settings {
+        padding: 1rem 1.5rem;
+        transition: all .5s ease-out;
+        border: 1px solid transparent;
+        box-shadow: none;
+        background: transparent;
+        margin: 0;
+        font-size: .9rem;
+    }
+    .customwaterfall_settings:hover,
+    .customwaterfall_settings:focus-within {
+        border: 1px solid #2F80ED;
+        box-shadow: 0 0 30px rgb(47 128 237 / 50%);
+    }
+    .customwaterfall_settings:focus-within summary:focus {
+        outline: none;
+    }
+    .customwaterfall_settings[open] {
+        border: 1px solid #2F80ED;
+        box-shadow: 0 0 30px rgb(47 128 237 / 50%);
+        background: rgba(18, 29, 53, .9);
+        color: #fff;
+        min-height: 20rem;
+        position: fixed;
+        z-index: 999;
+        right: 2vw;
+        top: auto;
+        width: 20vw;
+        max-width: 20rem;
+    }
+    .customwaterfall_settings form {
+        overflow: auto;
+        max-height: 65vh;
+        min-height: 20rem;
+    }
 }

--- a/www/waterfall.css
+++ b/www/waterfall.css
@@ -258,6 +258,9 @@ div.bar {
     position: absolute;
     right: 0;
 }
+.customwaterfall_download {
+    margin: 3rem 0;
+}
 /* at 60em and up, the settings are displayed as a fixed panel */
 @media (min-width: 60em) {
     .customwaterfall_hed {

--- a/www/waterfall.css
+++ b/www/waterfall.css
@@ -177,25 +177,51 @@ div.bar {
 /* custom waterfall settings */
 
 @media (min-width: 60em) {
+    .customwaterfall_hed {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+    }
     .customwaterfall_settings {
-        position: fixed;
-        overflow: auto;
-        right: 1vw;
-        top: 20vh;
-        bottom: 1vh;
-        width: 20vw;
-        background: rgba(18, 29, 53, .9);
-        color: #fff;
+        padding: 1.3rem 2rem;
+        transition: all .5s ease-out;
+        border: 1px solid transparent;
+        box-shadow: none;
+        background: transparent;
+        margin: 0;
+    }
+    .customwaterfall_settings:hover,
+    .customwaterfall_settings:focus-within {
+        border-color: #ccc;
+    }
+    
+    .customwaterfall_settings[open] {
         border: 1px solid #2F80ED;
         box-shadow: 0 0 30px rgb(47 128 237 / 50%);
+        background: rgba(18, 29, 53, .9);
+        color: #fff;
+        min-height: 20rem;
+        position: fixed;
+        z-index: 999;
+        right: 2vw;
+        top: auto;
+        width: 20vw;
+    }
+    .customwaterfall_settings form {
+        overflow: auto;
+        max-height: 65vh;
+        min-height: 20rem;
     }
 }
 .customwaterfall_settings_hed {
     font-size: .9rem;
-    margin: 0 0 .8rem;
-    font-weight: normal;
-    padding: 0 0 .8em;
+    font-weight: bold;
+    cursor: pointer;
+}
+.customwaterfall_settings[open] .customwaterfall_settings_hed {
     border-bottom: 1px solid rgba(255,255,255,.2);
+    margin: 0 0 .8rem;
+    padding: 0 0 .8em;
 }
 .customwaterfall_settings fieldset {
     border: 0;
@@ -207,9 +233,6 @@ div.bar {
     margin: 0;
     display: block;
     padding: 0;
-}
-.customwaterfall_settings summary {
-    font-weight: bold;
 }
 .customwaterfall_settings label,
 .customwaterfall_settings label input[type=text] {


### PR DESCRIPTION
This page could still use some cleaning up but, some changes relevant to this particular ticket (#1452):

This update includes:
- markup updates to enclose the settings form in a details/summary, (open to any better ideas).
- some legend/fieldset updates to the markup
- CSS to display the form as a fixed panel on wider viewport sizes so that it's easier to see changes take effect as you work
- Added a download link after the waterfall image. 

Note: for the download link, I reused the existing pill style, which needed an explicit color added, hence the version bump.

fixes #1452