### PR TITLE
1536 - offer checkbox to preserve UA when ttfb is seemingly skewed for bots

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -149,7 +149,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
-define('VER_CSS', 143);                // version of the sitewide css file
+define('VER_CSS', 146);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/common.inc
+++ b/www/common.inc
@@ -149,7 +149,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
-define('VER_CSS', 146);                // version of the sitewide css file
+define('VER_CSS', 149);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/include/TestResults.php
+++ b/www/include/TestResults.php
@@ -316,7 +316,7 @@ class TestResults {
     return $runResults;
   }
 
-  private function getMetricFromRuns($metric, $cached, $successfulOnly) {
+  public function getMetricFromRuns($metric, $cached, $successfulOnly) {
     $values = array();
     foreach ($this->filterRunResults($cached, $successfulOnly) as $run) {
       $value = $run->aggregateMetric($metric, $successfulOnly);

--- a/www/include/TestResults.php
+++ b/www/include/TestResults.php
@@ -316,6 +316,11 @@ class TestResults {
     return $runResults;
   }
 
+  /**
+   * @param string $metric Name of the metric to consider
+   * @param bool $cached False if first views should be considered for selecting, true for repeat views
+   * @param bool $successfulOnly True if only successful runs should be returned
+   */
   public function getMetricFromRuns($metric, $cached, $successfulOnly) {
     $values = array();
     foreach ($this->filterRunResults($cached, $successfulOnly) as $run) {

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -329,7 +329,7 @@ footer ul li{
 }
 .testinfo_command-bar {
     display: grid;
-    grid-template-columns: 1fr 1fr 4fr;
+    grid-template-columns: 1fr 4fr 1fr;
     margin-bottom: 1em;
     background: #f9f9f9;
     margin: -1.25em -1.875em 0 -1.875em;
@@ -350,6 +350,12 @@ footer ul li{
 }
 .testinfo_meta, .testinfo_forms {
     padding: 1em 0;
+}
+.testinfo_forms summary {
+    font-weight: bold;
+}
+.testinfo_forms details {
+    margin-bottom: 1rem;
 }
 .testinfo_artifacts-list{
     padding: .2em 0;

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -352,7 +352,16 @@ footer ul li{
     padding: 1em 0;
 }
 .testinfo_forms summary {
+    font-weight: normal;
+}
+.testinfo_forms summary strong {
     font-weight: bold;
+    color: #e33535;
+}
+.testinfo_forms details > div {
+    padding: .4em 1.3em 0;
+    font-size: .9em;
+    color: #222;
 }
 .testinfo_forms details {
     margin-bottom: 1rem;

--- a/www/result.inc
+++ b/www/result.inc
@@ -129,15 +129,14 @@ $page_description = "Website performance test result$testLabel.";
                           echo "<input type=\"hidden\" name=\"vh\" value=\"$hmac\">\n";
                         }
 
-                        // if TTFB is extra slow, perhaps something fishy is going on with the site's bot detection.
-                        // Show a message that offers an option to re-run with a default UA
-                        $slowttfb_threshold = 3000;
-                        // TODO: The following array lookup is placeholder! 
-                        // We need a public function to get median TTFB here in a stable manner instead.
-                        if( $pageData[1][0][ "TTFB" ] > $slowttfb_threshold ) { 
+                        // if TTFB is extra slow (all runs had a ttfb greater than thresold below), then perhaps a site/cdn is purposefully slowing responsse times for bots.
+                        // Show a message that offers an option to re-run the tests with a default UA
+                        $slowttfbThreshold = 3000;
+                        $firstByteTimes = $testResults->getMetricFromRuns("TTFB", false, false );
+                        if ( count( $firstByteTimes ) > 0 && min( $firstByteTimes ) > $slowttfbThreshold ) { 
                           echo <<<EOT
                             <details>
-                              <summary>Note! This test had an unusually high first-byte time. Check for accuracy...</summary> 
+                              <summary><strong>Note:</strong> This test had an unusually-high first-byte time. Check for accuracy...</summary> 
                               <div>
                               <p>Some networks intentionally slow performance for bots like the WebPageTest agent. If you suspect this is happening, you can try re-running your test with the browser's original User Agent string to see if it helps.</p>
                               <p><label><input type="checkbox" name="keepua"> Preserve original User Agent string in re-run</label></p>

--- a/www/result.inc
+++ b/www/result.inc
@@ -128,6 +128,23 @@ $page_description = "Website performance test result$testLabel.";
                           $hmac = sha1($hashStr);
                           echo "<input type=\"hidden\" name=\"vh\" value=\"$hmac\">\n";
                         }
+
+                        // if TTFB is extra slow, perhaps something fishy is going on with the site's bot detection.
+                        // Show a message that offers an option to re-run with a default UA
+                        $slowttfb_threshold = 3000;
+                        // TODO: The following array lookup is placeholder! 
+                        // We need a public function to get median TTFB here in a stable manner instead.
+                        if( $pageData[1][0][ "TTFB" ] > $slowttfb_threshold ) { 
+                          echo <<<EOT
+                            <details>
+                              <summary>Note! This test had an unusually high first-byte time. Check for accuracy...</summary> 
+                              <div>
+                              <p>Some networks intentionally slow performance for bots like the WebPageTest agent. If you suspect this is happening, you can try re-running your test with the browser's original User Agent string to see if it helps.</p>
+                              <p><label><input type="checkbox" name="keepua"> Preserve original User Agent string in re-run</label></p>
+                            </details>
+                          EOT;
+                        }
+
                         if (strlen($siteKey)) {
                           echo "<button data-sitekey=\"$siteKey\" data-callback='onRecaptchaSubmit' class=\"g-recaptcha\">Re-run the test</button>";
                         } else {


### PR DESCRIPTION
Not yet ready to merge!

First pass on messaging for a checkbox that we'll offer when a result has slow ttfb and  seems to be skewed for bots. 

Live example of this message showing in a slow result: 
![image](https://user-images.githubusercontent.com/214783/134027426-b8d7e3d3-4a3c-4bc6-aa94-e01192c9e9de.png)
![image](https://user-images.githubusercontent.com/214783/134027520-d934a105-39ca-4f60-9966-f44cdd0cdc31.png)
