### PR TITLE
1533 - Add support for Element Timing

### DIFF
--- a/www/graph_page_data.php
+++ b/www/graph_page_data.php
@@ -228,6 +228,7 @@ $common_label = implode(" ", $common_labels);
             );
             $customMetrics = null;
             $userTimings = null;
+            $elementTimings = null;
             $userMeasures = null;
             foreach ($pagesData as &$pageData) {
               foreach ($pageData as &$pageRun)
@@ -251,8 +252,14 @@ $common_label = implode(" ", $common_labels);
                       if (!isset($userMeasures))
                         $userMeasures = array();
                       $userMeasures[$metric] = 'User Timing Measure - ' . substr($metric, 18);
+                    } else if (substr($metric, 0, 14) == 'elementTiming.') {
+                      if (!isset($elementTimings))
+                        $elementTimings = array();
+                      $elementTimings[$metric] = 'Element Timing - ' . substr($metric,14);
                     }
                   }
+
+                  $elementTimingCount = count($elementTimings);
                   $timingCount = count($userTimings);
                   $measuresCount = count($userMeasures);
                 }
@@ -268,6 +275,12 @@ $common_label = implode(" ", $common_labels);
             if (isset($customMetrics) && is_array($customMetrics) && count($customMetrics)) {
               echo '<h1 id="custom">Custom Metrics</h1>';
               foreach($customMetrics as $metric => $label) {
+                InsertChart($metric, $label);
+              }
+            }
+            if (isset($elementTimings) && is_array($elementTimings) && count($elementTimings)) {
+              echo '<h1 id="ElementTiming"><a href="https://wicg.github.io/element-timing/" target="_blank" rel="noopener">Element Timings</a></h1>';
+              foreach($elementTimings as $metric => $label) {
                 InsertChart($metric, $label);
               }
             }

--- a/www/include/UserTimingHtmlTable.php
+++ b/www/include/UserTimingHtmlTable.php
@@ -118,9 +118,14 @@ class UserTimingHtmlTable {
   private function _userTimingsForStep($stepResult) {
     $data = $stepResult->getRawResults();
     $userTimings = array();
-    foreach($data as $metric => $value)
-      if (substr($metric, 0, 9) == 'userTime.')
+    foreach($data as $metric => $value) {
+      if (substr($metric, 0, 9) == 'userTime.') {
         $userTimings[substr($metric, 9)] = number_format($value / 1000, 3) . 's';
+      }
+      if (substr($metric, 0, 14) == 'elementTiming.') {
+        $userTimings[substr($metric, 14)] = number_format($value / 1000, 3) . 's';
+      }
+    }
     if (isset($data['custom']) && count($data['custom'])) {
       foreach($data['custom'] as $metric) {
         if (isset($data[$metric]) && !is_array($data[$metric])) {

--- a/www/include/WaterfallViewHtmlSnippet.php
+++ b/www/include/WaterfallViewHtmlSnippet.php
@@ -101,8 +101,8 @@ class WaterfallViewHtmlSnippet {
     if ((float)$this->stepResult->getMetric("loadEventStart"))
       $out .= $this->_legendBarTableCell("#C0C0FF", "On Load", 15);
     $out .= $this->_legendBarTableCell("#0000FF", "Document Complete", 4);
-    if ($show_ut && $this->stepResult->getMetric('userTime'))
-      $out .= '<td><div class="arrow-down"></div>User Timings</td>';
+    if ($show_ut && ($this->stepResult->getMetric('userTime') || $this->stepResult->getMetric('elementTiming')))
+      $out .= '<td><div class="arrow-down"></div>User & Element Timings</td>';
     $out .= "</tr>\n</table>\n<br>";
     $out .= '<table class="waterfall-legend" cellspacing="0">';
     $out .= "\n<tr>\n";

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -101,7 +101,6 @@ function loadPageStepData($localPaths, $testInfo = null) {
     }
     //set top level FCP
     TopLevelFCP($ret);
-    
     if (!empty($ret) && !$basic_results) {
       $startOffset = array_key_exists('testStartOffset', $ret) ? intval(round($ret['testStartOffset'])) : 0;
       loadUserTimingData($ret, $localPaths->userTimedEventsFile());
@@ -1091,6 +1090,25 @@ function ParseUserTiming($file, $browser_version, &$layout_shifts, &$page_data) 
             }
           }
         }
+        //let's grab the element timing stuff while we're here to avoid a separate loop
+        if (is_array($event) &&
+            isset($event['name']) &&
+            isset($event['ts']) &&
+            isset($event['args']['frame']) && in_array($event['args']['frame'], $main_frames) &&
+            $event['name'] === 'PerformanceElementTiming') {
+              
+              if (!isset($page_data['ElementTiming'])) {
+                $page_data['ElementTiming'] = array();
+              }
+              $elementTimingArr = array();
+              $elementTimingArr['identifier'] = $event['args']['data']['identifier'];
+              $elementTimingArr['time'] = $event['args']['data']['renderTime'];
+              $elementTimingArr['elementType'] = $event['args']['data']['elementType'];
+              $elementTimingArr['url'] = $event['args']['data']['url'];
+
+              $page_data['ElementTiming'][] = $elementTimingArr;
+
+            }
       }
 
       $total_layout_shift = null;

--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -1095,10 +1095,9 @@ function ParseUserTiming($file, $browser_version, &$layout_shifts, &$page_data) 
             isset($event['name']) &&
             isset($event['ts']) &&
             isset($event['args']['frame']) && in_array($event['args']['frame'], $main_frames) &&
-            $event['name'] === 'PerformanceElementTiming') {
-              
-              if (!isset($page_data['ElementTiming'])) {
-                $page_data['ElementTiming'] = array();
+            $event['name'] === 'PerformanceElementTiming') {                
+              if (!isset($page_data['elementTiming'])) {
+                $page_data['elementTiming'] = array();
               }
               $elementTimingArr = array();
               $elementTimingArr['identifier'] = $event['args']['data']['identifier'];
@@ -1106,7 +1105,8 @@ function ParseUserTiming($file, $browser_version, &$layout_shifts, &$page_data) 
               $elementTimingArr['elementType'] = $event['args']['data']['elementType'];
               $elementTimingArr['url'] = $event['args']['data']['url'];
 
-              $page_data['ElementTiming'][] = $elementTimingArr;
+              $page_data['elementTiming'][] = $elementTimingArr;
+              $page_data['elementTiming.' . $event['args']['data']['identifier']] = $event['args']['data']['renderTime'];
 
             }
       }

--- a/www/waterfall.inc
+++ b/www/waterfall.inc
@@ -319,13 +319,20 @@ function _GetMapOrImage($rows, $url, $page_events, $options, $is_image_map, $pag
 
     // get any user timings
     if (!isset($options['show_user_timing']) || $options['show_user_timing']) {
-      if (isset($page_data) && array_key_exists('userTime', $page_data)) {
-        foreach ($page_data as $key => $value) {
-          if (substr($key, 0, 9) == 'userTime.') {
-            $label = substr($key, 9);
-            if (!isset($user_times))
-              $user_times = array();
-            $user_times[$label] = $value;
+      if (isset($page_data)) {
+        if (array_key_exists('userTime', $page_data) || array_key_exists('elementTiming', $page_data)) {
+          foreach ($page_data as $key => $value) {
+            if (substr($key, 0, 9) == 'userTime.') {
+              $label = substr($key, 9);
+              if (!isset($user_times))
+                $user_times = array();
+              $user_times[$label] = $value;
+            } else if (substr($key, 0, 14) == 'elementTiming.') {
+              $label = substr($key, 14);
+              if (!isset($user_times))
+                $user_times = array();
+              $user_times[$label] = $value;
+            }
           }
         }
       }


### PR DESCRIPTION
Nice and shiny Element Timing API support thanks to Chrome's new trace events.

This PR closes #1533 by adding Element Timing to:

The JSON results:
```
"elementTiming": [
    {
        "identifier": "post-title",
        "time": 2070,
        "elementType": "text-paint",
        "url": ""
    },
    {
        "identifier": "post-hero",
        "time": 2200,
        "elementType": "image-paint",
        "url": "https:\/\/res.cloudinary.com\/webpagetest\/image\/upload\/f_auto,q_auto,c_fill,w_640,h_512\/august-roundup_plhjt4.png"
    }
],
"elementTiming.post-title": 2070,
"elementTiming.post-hero": 2200,
```

The custom waterfall page (using the same lines as the user timing API):
![Screen Shot 2021-09-24 at 10 32 03 AM](https://user-images.githubusercontent.com/66536/134701618-82cc8284-f765-4256-9406-4aa117cc64f9.png)

The plot full results page:
![Screen Shot 2021-09-24 at 10 33 54 AM](https://user-images.githubusercontent.com/66536/134701883-c0e14fb0-514c-4582-bcc1-1b6ab97ee7fb.png)


And the HTML table on results pages:

![Screen Shot 2021-09-24 at 10 34 48 AM](https://user-images.githubusercontent.com/66536/134702008-9a889935-6fbc-4a1c-8aa5-b5f0d92c0524.png)


