### PR TITLE
fix(details) Fixes layout issues on graph full results when more than one test is viewed.

### DIFF
--- a/www/graph_page_data.php
+++ b/www/graph_page_data.php
@@ -119,7 +119,9 @@ $common_label = implode(" ", $common_labels);
             
             if (count($testsId) != 1) {
               ?>
-              <div class="box">
+              <div id="test_results-container" class="box">
+                <div class="test_results">
+                  <div class="test_results-content">
               <?php
             }
             ?>
@@ -296,6 +298,15 @@ $common_label = implode(" ", $common_labels);
             ?>
             </div>
           </div>
+          <?php
+          // this is not great, admittedly. Right now some divs are opened in header and closed in footer
+          // if a single test is being viewed. We'll need to pull that out at some point to clean this up.
+          if (count($testsId) != 1) {
+              ?>
+              </div></div>
+              <?php
+}
+              ?>
             <?php include('footer.inc'); ?>
             <script type="text/javascript" src="//www.google.com/jsapi"></script>
             <script type="text/javascript">


### PR DESCRIPTION
Fixes #1583 

A few div's are opened in the header.inc file if only a single test is being viewed, and then closed in footer.inc
We need those elements either way, so for now, we're conditionally adding them in the PHP file.