### PR TITLE
Add the test label to the top of test result pages

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -240,6 +240,7 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
         $showUrl = $numSteps > 1 ? $gradeRunResults->getStepResult(1)->getUrl() : $url;
         $shortUrl = str_replace('http://', '',  FitText($showUrl, 180));
         $shortUrl = $numSteps > 1 ? ($shortUrl . " ($numSteps steps)") : $shortUrl;
+
             echo "<h2>Web page performance test result for<br>";
             if (GetSetting('nolinks')) {
                 echo "<span class=\"page-tested\">$shortUrl</span>";
@@ -248,7 +249,8 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
             }
             echo "</h2>";
 
-            echo "<p class=\"heading_details\"><strong>From:</strong> {$test['test']['location']}";
+            echo "<p class=\"heading_details\">";
+            echo "<strong>From:</strong> {$test['test']['location']}";
             if (isset($test['testinfo']['mobile']) && $test['testinfo']['mobile'] === 1)
             {
             	echo " - Mobile";
@@ -292,6 +294,9 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
                 }
                 echo '<br>';
             }
+            if ( $test['testinfo']['label'] ) {
+                echo '<strong>Test Label: </strong>' . $test['testinfo']['label']  . '</strong>';
+              }
         echo '</div>';
         echo '</div>';
 


### PR DESCRIPTION
Fixes #1588

Long-term, it would be nice to give this a more visual treatment and have it consistent between the test history and test results, but that styling makes it look actionable (like a button or link) and we'll have to address that later.

So, for now, simply outputting it as text.

![Screen Shot 2021-10-21 at 10 44 44 AM](https://user-images.githubusercontent.com/66536/138312092-129fdd54-2205-4096-a2c9-300c80d59f36.png)


