### PR TITLE
Only show waterfall marker on filmstrip view

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -149,7 +149,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
-define('VER_CSS', 153.2);                // version of the sitewide css file
+define('VER_CSS', 153.3);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -2177,7 +2177,7 @@ th.header {
     margin-bottom: 1rem;
 }
 #videoContainer:before,
-.waterfall_marker:before {
+.compare_contain_wrap .waterfall_marker:before {
     content: "";
     border: 1px solid #f00;
     width: 10px;


### PR DESCRIPTION
Fixes #1593 

Makes sure we only show the waterfall marker on the filmstrip and compare views, not on the regular waterfall.