### PR TITLE
Fixed some mobile emulation UA strings

### DIFF
--- a/www/settings/mobile_devices.ini
+++ b/www/settings/mobile_devices.ini
@@ -8,7 +8,7 @@ width=360
 height=512
 dpr=3
 throttle_cpu=8
-ua="Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 8.1.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [Nexus5]
 label="Nexus 5"
@@ -17,7 +17,7 @@ width=360
 height=511
 dpr=3
 throttle_cpu=6.5
-ua="Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [Nexus5X]
 label="Nexus 5X"
@@ -26,7 +26,7 @@ width=411
 height=600
 dpr=2.6
 throttle_cpu=6
-ua="Mozilla/5.0 (Linux; Android 4.4.4; Nexus 5X Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 4.4.4; Nexus 5X Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [Pixel]
 label="Google Pixel"
@@ -35,7 +35,7 @@ width=411
 height=600
 dpr=2.6
 throttle_cpu=4.5
-ua="Mozilla/5.0 (Linux; Android 8.0.0; Pixel Build/OPR3.170623.008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPR3.170623.008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [PixelXL]
 label="Google Pixel XL"
@@ -44,7 +44,7 @@ width=411
 height=600
 dpr=3.5
 throttle_cpu=4.5
-ua="Mozilla/5.0 (Linux; Android 8.1.0; Pixel XL Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 8.1.0; Pixel XL Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [Pixel2]
 label="Google Pixel 2"
@@ -53,7 +53,7 @@ width=411
 height=600
 dpr=2.6
 throttle_cpu=4
-ua="Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [Pixel2XL]
 label="Google Pixel 2 XL"
@@ -62,7 +62,7 @@ width=411
 height=600
 dpr=3.5
 throttle_cpu=4
-ua="Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 XL Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 XL Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [MotoG]
 label="Motorola G (gen 1)"
@@ -71,7 +71,7 @@ width=360
 height=511
 dpr=2
 throttle_cpu=11
-ua="Mozilla/5.0 (Linux; Android 4.4.4; XT1034 Build/KXB21.14-L1.61) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 4.4.4; XT1034 Build/KXB21.14-L1.61) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [GalaxyS5]
 label="Samsung Galaxy S5"
@@ -80,7 +80,7 @@ width=360
 height=511
 dpr=3
 throttle_cpu=9
-ua="Mozilla/5.0 (Linux; Android 6.0.1; SM-G900T Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 6.0.1; SM-G900T Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [GalaxyS7]
 label="Samsung Galaxy S7"
@@ -89,7 +89,7 @@ width=360
 height=511
 dpr=4
 throttle_cpu=4.5
-ua="Mozilla/5.0 (Linux; Android 4.4.4; Android 6.0.1; SM-G930F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 8.1.0; SM-G930F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [GalaxyS8]
 label="Samsung Galaxy S8/S8+/Note 8"
@@ -98,7 +98,7 @@ width=360
 height=611
 dpr=4
 throttle_cpu=4
-ua="Mozilla/5.0 (Linux; Android 4.4.4; Android 6.0.1; SM-G950F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 8.1.0; SM-G950F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [MotoE]
 label="Motorola E"
@@ -107,7 +107,7 @@ width=360
 height=511
 dpr=1.5
 throttle_cpu=15
-ua="Mozilla/5.0 (Linux; Android 4.4.4; XT1021 Build/KXC21.5-53) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 4.4.4; XT1021 Build/KXC21.5-53) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [AndroidOne]
 label="Android One"
@@ -116,7 +116,7 @@ width=320
 height=440
 dpr=1.5
 throttle_cpu=15
-ua="Mozilla/5.0 (Linux; Android 4.4.4; Micromax AQ4501 Build/KPW53) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 4.4.4; Micromax AQ4501 Build/KPW53) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [Nexus7]
 label="Nexus 7"
@@ -125,7 +125,7 @@ width=600
 height=887
 dpr=2
 throttle_cpu=9
-ua="Mozilla/5.0 (Linux; Android 4.4.4; Nexus 7 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 4.4.4; Nexus 7 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 [Nexus7L]
 label="Nexus 7 - Landscape"
@@ -134,7 +134,7 @@ width=960
 height=527
 dpr=2
 throttle_cpu=9
-ua="Mozilla/5.0 (Linux; Android 4.4.4; Nexus 7 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.110 Mobile Safari/537.36"
+ua="Mozilla/5.0 (Linux; Android 4.4.4; Nexus 7 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Mobile Safari/537.36"
 
 ;
 ; iOS Devices
@@ -146,7 +146,7 @@ width=320
 height=460
 dpr=2
 throttle_cpu=2
-ua="Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+ua="Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/10.3 Mobile/15E148 Safari/604.1"
 
 [iPhone6]
 label="iPhone 6/7/8"
@@ -155,7 +155,7 @@ width=375
 height=559
 dpr=2
 throttle_cpu=1
-ua="Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+ua="Mozilla/5.0 (iPhone; CPU iPhone OS 15_0_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
 
 [iPhone6plus]
 label="iPhone 6+/7+/8+"
@@ -164,7 +164,7 @@ width=414
 height=622
 dpr=2
 throttle_cpu=1
-ua="Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+ua="Mozilla/5.0 (iPhone; CPU iPhone OS 15_0_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
 
 [iPhoneX]
 label="iPhone X"
@@ -173,7 +173,7 @@ width=375
 height=635
 dpr=2
 throttle_cpu=1
-ua="Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Mobile/15A372"
+ua="Mozilla/5.0 (iPhone; CPU iPhone OS 15_0_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
 
 [iPad]
 label="iPad"
@@ -182,7 +182,7 @@ width=768
 height=960
 dpr=2
 throttle_cpu=1
-ua="Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1"
+ua="Mozilla/5.0 (iPad; CPU iPhone OS 15_0_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
 
 [iPadMini2]
 label="iPad Mini"
@@ -191,4 +191,4 @@ width=768
 height=960
 dpr=2
 throttle_cpu=1
-ua="Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1"
+ua="Mozilla/5.0 (iPad; CPU iPhone OS 15_0_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"


### PR DESCRIPTION
The main fix was adding the Safari bit to the end of the iPhone UA strings.  Also updated Chrome versions (though they auto-update dynamically based on the actual browser anyway) and some Android version strings.