### PR TITLE
small cleanup to error messages in general while focusing on #1601. 

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -149,7 +149,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
-define('VER_CSS', 153.3);                // version of the sitewide css file
+define('VER_CSS', 153.4);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -1780,9 +1780,15 @@ body.compact .box {
 }
 
 /* error page styles */
+.testerror {
+    text-align: left;
+    max-width: 34rem;
+    margin: 0 auto;
+    padding: 3rem;
+}
 .testerror h1 {
     color: #dc9739;
-    text-align: center;
+    text-align: left;
     margin: 1em 0;
 }
 .testerror h1 em {
@@ -1798,7 +1804,27 @@ body.compact .box {
 .testerror_login {
     margin: 0 auto;
     justify-content: center;
-    max-width: 20em;
+}
+.testerror_loginperks {
+    list-style: disc;
+    padding: 0 0 0 3em;
+}
+.testerror p,
+.testerror_loginperks {
+    line-height: 1.4;
+    margin: 0 0 1.5em;
+}
+.testerror_loginperks li {
+    margin-bottom: 0.5em;
+}
+.testerror_login {
+    margin: 3rem 0 0;
+    justify-content: center;
+    display: flex;
+    gap: 2em;
+    background: #f6f6f6;
+    padding: 1.5em;
+    border-radius: 8px;
 }
 
 /* compare page styles */

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -1779,6 +1779,28 @@ body.compact .box {
     }
 }
 
+/* error page styles */
+.testerror h1 {
+    color: #dc9739;
+    text-align: center;
+    margin: 1em 0;
+}
+.testerror h1 em {
+    display: block;
+    font-style: normal;
+    font-weight: 500;
+    font-size: .8em;
+    color: #333;
+    margin: .3em 0 .5em;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 1em;
+}
+.testerror_login {
+    margin: 0 auto;
+    justify-content: center;
+    max-width: 20em;
+}
+
 /* compare page styles */
 .video_runlabel {
     text-align: left;
@@ -1850,14 +1872,15 @@ body.compact #header_container {
 .test_results-content {
     padding: 1em 1.5em;
 }
-.test_menu + .test_results-content {
+.test_menu+.test_results-content {
     padding-top: 0;
 }
 @media (min-width: 50em) {
     .test_results-content {
         padding: 1em 3em 0;
     }
-    .test_menu + .test_results-content {
+    
+    .test_menu+.test_results-content {
         padding-top: 0;
     }
 }

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -2881,10 +2881,10 @@ function ErrorPage($error) {
                 <?php
                 include 'header.inc';
               ?>
-              <h1>There was an error with the test</h1>
-                        <div class="box">
-
-              <?php
+              
+              <div class="testerror box" style="text-align: center; max-width: 34rem; margin: 0 auto;padding: 3rem;">
+                <h1>Oops! <em>There was a problem with the test.</em></h1>
+                <?php
                 echo $error;
                 ?>
           </div>
@@ -3068,6 +3068,15 @@ function ReportAnalytics(&$test, $testId)
   }
 }
 
+function loggedOutLoginForm(){
+  $ret = '<ul class="testerror_login><li><a href="/saml/login.php">Login</a></li>';
+  $reg .= GetSetting('saml_register');
+  if ($reg) {
+      $ret .= "<li><a class='pill' href='$reg'>Sign-up</a></li>";
+  }
+  return $ret;
+}
+
 function CheckRateLimit($test, &$error) {
   global $USER_EMAIL;
   global $supportsSaml;
@@ -3092,7 +3101,7 @@ function CheckRateLimit($test, &$error) {
   $passesMonthly = $cmrl->check();
 
   if(!$passesMonthly) {
-    $error = "The test has been blocked for exceeding the volume of testing allowed by anonymous users from your IP address.<br>Please log in with a registered account.";
+    $error = '<p><strong>You\'ve hit the max on anonymous tests this month, but don\'t worry! You can keep testing...</strong> You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no hourly rate limits as well.</p>' . loggedOutLoginForm();
     return false;
   }
 
@@ -3113,11 +3122,12 @@ function CheckRateLimit($test, &$error) {
     } else {
       $register = GetSetting('saml_register');
       $apiUrl = GetSetting('api_url');
+      $error = '<p><strong>You\'ve hit the max on anonymous tests this hour, but don\'t worry! You can keep testing...</strong>You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no monthly rate limits as well.</p>';
+
       if ($supportsSaml && $register && $apiUrl) {
-        $error = "The test has been blocked for exceeding the volume of testing allowed by anonymous users from your IP address.<br>Please <a href='/saml/login.php'>log in</a> with a <a href='$register'>registered account</a> or wait an hour before retrying.<br>If you need to run tests programmatically there is also the <a href='$apiUrl'>WebPageTest API</a>.";
-      } else {
-        $error = "The test has been blocked for exceeding the volume of testing allowed by anonymous users from your IP address.<br>Please log in with a registered account or wait an hour before retrying.";
+        $error .= "<p>And also, if you need to run tests programmatically you might be interested in the <a href='$apiUrl'>WebPageTest API</a></p>";
       }
+      $error .= loggedOutLoginForm();
       $ret = false;
     }
   }

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -2882,7 +2882,7 @@ function ErrorPage($error) {
                 include 'header.inc';
               ?>
               
-              <div class="testerror box" style="text-align: center; max-width: 34rem; margin: 0 auto;padding: 3rem;">
+              <div class="testerror box">
                 <h1>Oops! <em>There was a problem with the test.</em></h1>
                 <?php
                 echo $error;
@@ -3069,13 +3069,22 @@ function ReportAnalytics(&$test, $testId)
 }
 
 function loggedOutLoginForm(){
-  $ret = '<ul class="testerror_login><li><a href="/saml/login.php">Login</a></li>';
+  $ret = '<ul class="testerror_login"><li><a href="/saml/login.php">Login</a></li>';
   $reg .= GetSetting('saml_register');
   if ($reg) {
       $ret .= "<li><a class='pill' href='$reg'>Sign-up</a></li>";
   }
   $ret .= "</ul>";
   return $ret;
+}
+
+function loggedInPerks(){
+  $msg = '<ul class="testerror_loginperks">';
+  $msg .= '<li>Access to 13 months of saved tests (<em>including this one!</em>), making it easier to compare tests and analyze trends.</li>';
+  $msg .= '<li>Ability to contribute to the <a href="https://forums.webpagetest.org/">WebPageTest Forum</a>.</li>';
+  $msg .= '<li>Access to upcoming betas and new features that will enhance your WebPageTest experience.</li>';
+  $msg .= '</ul>';
+  return $msg;
 }
 
 function CheckRateLimit($test, &$error) {
@@ -3102,7 +3111,9 @@ function CheckRateLimit($test, &$error) {
   $passesMonthly = $cmrl->check();
 
   if(!$passesMonthly) {
-    $error = '<p><strong>You\'ve hit the max on logged-out tests this month, but don\'t worry! You can keep testing...</strong> You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no hourly rate limits as well.</p>' . loggedOutLoginForm();
+    $error = '<p>You\'ve reached the limit for logged-out tests this month, but don\'t worry! You can keep testing once you log in, which will give you access to other nice features like:</p>';
+    $error .= loggedInPerks();
+    $error .= loggedOutLoginForm();
     return false;
   }
 
@@ -3123,7 +3134,10 @@ function CheckRateLimit($test, &$error) {
     } else {
       $register = GetSetting('saml_register');
       $apiUrl = GetSetting('api_url');
-      $error = '<p><strong>You\'ve hit the max on logged-out tests this hour, but don\'t worry! You can keep testing...</strong>You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no monthly rate limits as well.</p>';
+      $error = '<p>You\'ve reached the limit for logged-out tests per hour, but don\'t worry! You can keep testing once you log in, which will give you access to other nice features like:</p>';
+
+      $error .= loggedInPerks();
+
 
       if ($supportsSaml && $register && $apiUrl) {
         $error .= "<p>And also, if you need to run tests programmatically you might be interested in the <a href='$apiUrl'>WebPageTest API</a></p>";

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -3074,6 +3074,7 @@ function loggedOutLoginForm(){
   if ($reg) {
       $ret .= "<li><a class='pill' href='$reg'>Sign-up</a></li>";
   }
+  $ret .= "</ul>";
   return $ret;
 }
 
@@ -3101,7 +3102,7 @@ function CheckRateLimit($test, &$error) {
   $passesMonthly = $cmrl->check();
 
   if(!$passesMonthly) {
-    $error = '<p><strong>You\'ve hit the max on anonymous tests this month, but don\'t worry! You can keep testing...</strong> You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no hourly rate limits as well.</p>' . loggedOutLoginForm();
+    $error = '<p><strong>You\'ve hit the max on logged-out tests this month, but don\'t worry! You can keep testing...</strong> You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no hourly rate limits as well.</p>' . loggedOutLoginForm();
     return false;
   }
 
@@ -3122,7 +3123,7 @@ function CheckRateLimit($test, &$error) {
     } else {
       $register = GetSetting('saml_register');
       $apiUrl = GetSetting('api_url');
-      $error = '<p><strong>You\'ve hit the max on anonymous tests this hour, but don\'t worry! You can keep testing...</strong>You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no monthly rate limits as well.</p>';
+      $error = '<p><strong>You\'ve hit the max on logged-out tests this hour, but don\'t worry! You can keep testing...</strong>You\'ll just need to <a href="/saml/login.php">log in</a>, which gives you access to other nice features like saved test history and no monthly rate limits as well.</p>';
 
       if ($supportsSaml && $register && $apiUrl) {
         $error .= "<p>And also, if you need to run tests programmatically you might be interested in the <a href='$apiUrl'>WebPageTest API</a></p>";


### PR DESCRIPTION
Fixes #1601. This is set up to ideally allow populating $error with strings or HTML in cases where the error is going only to the web and not api/json.