### PR TITLE
fix(rate-limit): change length of default month

### DIFF
--- a/tests/CheckMonthlyRateLimitTest.php
+++ b/tests/CheckMonthlyRateLimitTest.php
@@ -10,7 +10,7 @@ final class CheckMonthlyRateLimitTest extends TestCase {
     $cmrl = new CheckMonthlyRateLimit($ip);
     $this->assertEquals('127.0.0.1', $cmrl->ip);
     $this->assertEquals(50, $cmrl->limit);
-    $this->assertEquals(2678400, $cmrl->day_cycle_ttl);
+    $this->assertEquals(2419200, $cmrl->day_cycle_ttl);
     $this->assertEquals('rladdr_per_month_127.0.0.1', $cmrl->cache_key);
   }
 

--- a/www/ratelimit/check_monthly_rate_limit.php
+++ b/www/ratelimit/check_monthly_rate_limit.php
@@ -3,7 +3,7 @@
 require_once(__DIR__ . '/../common/cache_utils.php');
 
 class CheckMonthlyRateLimit {
-  function __construct (string $ip, int $limit = 50, int $days = 31) {
+  function __construct (string $ip, int $limit = 50, int $days = 28) {
     $this->ip = $ip;
     $this->limit = $limit;
     $this->day_cycle_ttl = $days * (24 * 60 * 60);


### PR DESCRIPTION
This isn't targeting people who shoot out 60 tests a month, it's a call
to action for people who are running hundreds, so let's be lenient on
the length of a "month". 28 days is fine