### PR TITLE
fix(rate-limit): check runs, not tests

### DIFF
--- a/tests/CheckMonthlyRateLimitTest.php
+++ b/tests/CheckMonthlyRateLimitTest.php
@@ -28,9 +28,9 @@ final class CheckMonthlyRateLimitTest extends TestCase {
    * @requires extension apcu
    */
   public function testCheckFirstTime() : void {
-    $ip = '127.0.0.0';
+    $ip = '127.0.0.2';
     $cmrl = new CheckMonthlyRateLimit($ip, 40, 20);
-    $passes = $cmrl->check();
+    $passes = $cmrl->check(1);
     $this->assertTrue($passes);
   }
 
@@ -39,11 +39,38 @@ final class CheckMonthlyRateLimitTest extends TestCase {
    * @requires extension apcu
    */
   public function testCheckPastLimit() : void {
-    $ip = '127.0.0.0';
+    $ip = '127.0.0.3';
     $cmrl = new CheckMonthlyRateLimit($ip, 2, 20);
-    $passes = $cmrl->check();
-    $passes = $cmrl->check();
-    $passes = $cmrl->check();
+    $passes = $cmrl->check(1);
+    $passes = $cmrl->check(1);
+    $passes = $cmrl->check(1);
+    $this->assertFalse($passes);
+  }
+
+  /**
+   *
+   * @requires extension apcu
+   */
+  public function testCheckLastNumberGoesPastButStillPasses() : void {
+    $ip = '127.0.0.4';
+    $cmrl = new CheckMonthlyRateLimit($ip, 40, 20);
+    $passes = $cmrl->check(20);
+    $passes = $cmrl->check(19);
+    $passes = $cmrl->check(20);
+    $this->assertTrue($passes);
+  }
+
+  /**
+   *
+   * @requires extension apcu
+   */
+  public function testCheckPastLimitLargeNumbers() : void {
+    $ip = '127.0.0.5';
+    $cmrl = new CheckMonthlyRateLimit($ip, 40, 20);
+    $passes = $cmrl->check(20);
+    $passes = $cmrl->check(19);
+    $passes = $cmrl->check(20);
+    $passes = $cmrl->check(1);
     $this->assertFalse($passes);
   }
 }

--- a/www/ratelimit/check_monthly_rate_limit.php
+++ b/www/ratelimit/check_monthly_rate_limit.php
@@ -11,12 +11,15 @@ class CheckMonthlyRateLimit {
     $this->bucket = array();
   }
 
-  function check () : bool {
+  function check (?int $run_count) : bool {
+    $times_to_add = $run_count ? $run_count : 1;
     $bucket = $this->fetch_bucket();
     if (count($bucket) >= $this->limit) {
       return false;
     } else {
-      $bucket[] = time();
+      for ($i = 0; $i < $times_to_add; $i++) {
+        $bucket[] = time();
+      }
       $this->store_bucket($bucket);
     }
     return true;

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -3084,8 +3084,11 @@ function CheckRateLimit($test, &$error) {
     return true;
   }
 
+  $runcount = max(1, $test['runs']);
+  $multiplier = $test['fvonly'] ? 1 : 2;
+  $total_runs = $runcount * $multiplier;
   $cmrl = new CheckMonthlyRateLimit($test['ip']);
-  $passesMonthly = $cmrl->check();
+  $passesMonthly = $cmrl->check($total_runs);
 
   if(!$passesMonthly) {
     $error = '<p>You\'ve reached the limit for logged-out tests this month, but don\'t worry! You can keep testing once you log in, which will give you access to other nice features like:</p>';
@@ -3104,10 +3107,7 @@ function CheckRateLimit($test, &$error) {
       $count = 0;
     }
     if ($count < $limit) {
-      $runcount = max(1, $test['runs']);
-      if (!$test['fvonly'])
-        $runcount *= 2;
-      $count += $runcount;
+      $count += $total_runs;
       CacheStore($cache_key, $count, 1800);
     } else {
       $register = GetSetting('saml_register');


### PR DESCRIPTION
With the current code, somebody could potentially run 900 test runs (well,
more since the cache is in-memory) before they hit the limit. Let's
count every run.