### PR TITLE
(fix block-domains): Add a list of blocked domains to the test info header

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -333,7 +333,13 @@ if (strlen($id)) {
       $dom = array_key_exists('domElement', $test['testinfo']) ? htmlspecialchars($test['testinfo']['domElement']) : null;
       $login = array_key_exists('login', $test['testinfo']) ? htmlspecialchars($test['testinfo']['login']) : null;
       $blockString = array_key_exists('block', $test['testinfo']) ? htmlspecialchars($test['testinfo']['block']) : null;
+      // there could be some domains blocked by default, mostly crytpo-miner stuff (this is why we can't have nice things)
+      // so we need to compare what our domain string is to what our default list is
+      $blockDomains = GetSetting('blockDomains');
       $blockDomainsString = array_key_exists('blockDomains', $test['testinfo']) ? htmlspecialchars($test['testinfo']['blockDomains']) : null;
+      if (strlen($blockDomainsString) && strlen($blockDomains)) {
+        $blockDomainsString = str_replace($blockDomains, '', $blockDomainsString);
+      }
       $label = array_key_exists('label', $test['testinfo']) ? htmlspecialchars($test['testinfo']['label']) : null;
       $browser = array_key_exists('browser', $test['testinfo']) ? htmlspecialchars($test['testinfo']['browser']) : null;
       $connectivity = array_key_exists('connectivity', $test['testinfo']) ? htmlspecialchars($test['testinfo']['connectivity']) : null;

--- a/www/header.inc
+++ b/www/header.inc
@@ -277,7 +277,9 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
             if( array_key_exists('script', $test['test']) && strlen($test['test']['script']) )
                 echo '<b>Scripted test</b><br>';
             if( strlen($blockString) )
-                echo "Blocked: <b>$blockString</b><br>";
+                echo "Blocked URLs: <b>$blockString</b><br>";
+            if( strlen($blockDomainsString) )
+                echo "Blocked Domains: <b>$blockDomainsString</b><br>";
             if (isset($test['testinfo']['context']) && strlen($test['testinfo']['context']))
             {
                 echo 'Context: ';

--- a/www/templates/layouts/main_hed.inc
+++ b/www/templates/layouts/main_hed.inc
@@ -130,6 +130,8 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
                 echo '<b>Scripted test</b><br>';
             if( strlen($blockString) )
                 echo "Blocked: <b>$blockString</b><br>";
+            if( strlen($blockDomainsString) )
+                echo "Blocked Domains: <b>$blockDomainsString</b><br>";
             if (isset($test['testinfo']['context']) && strlen($test['testinfo']['context']))
             {
                 echo 'Context: ';


### PR DESCRIPTION
We show blocked URL patterns in our Test info summary when it applies, but not a list of blocked domains. 

This commit adds the blocked domains to the bar, like so:
![Screen Shot 2021-11-30 at 10 10 38 AM](https://user-images.githubusercontent.com/66536/144084239-5e627b78-0105-4d52-b9fd-a019dadb73b1.png)

Since we have a long list of domains we block by default (hey there people trying to use webpagetest for mining crypto), we first compare the blocked domains list against our list of default blocked domains, so that we only show the specific domains that the user specified.
