### PR TITLE
fix(login): product login redirects incorrectly

### DIFF
--- a/www/saml/login.php
+++ b/www/saml/login.php
@@ -6,11 +6,15 @@ header("Cache-Control: no-store, max-age=0");
 
 // Store the referer page in a session cookie and redirect to the saml login
 if (isset($_SERVER["HTTP_REFERER"])) {
+  $referer = $_SERVER["HTTP_REFERER"];
+  if (preg_match('/product.webpagetest.org/', $referer)) {
+    setcookie('samlsrc', base64_encode(getUrlProtocol() . '://www.webpagetest.org'));
+  } else {
     setcookie('samlsrc', base64_encode($_SERVER["HTTP_REFERER"]));
+  }
 }
 $login_url = GetSetting('saml_login', null);
 if (isset($login_url) && is_string($login_url) && strlen($login_url)) {
-    $protocol = getUrlProtocol();
     $url = getUrlProtocol() . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
     $login_url .= '?return_path=' . urlencode(str_replace('login.php', 'response.php', $url));
     header("Location: $login_url");


### PR DESCRIPTION
$_SERVER["HTTP_REFERER"] will include the host but not the entire path for the
"referer"ing website. This means that when somebody tries to log in from said
page, it will take them to a broken page when they're done.

This is not ideal.

Just go back to www site when you log in. The webflow-based product page
doesn't know how to deal with logged in users yet, anyway.