### PR TITLE
Fix reflected XSS issue on Filmstrip compare page

### DIFF
--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -492,14 +492,6 @@ function ScreenShotTable()
     
     $has_layout_shifts = false;
 
-
-
-
-
-    $endTime = 'visual';
-    if( array_key_exists('end', $_REQUEST) && strlen($_REQUEST['end']) )
-        $endTime = htmlspecialchars(trim($_REQUEST['end']));
-    
     $show_shifts = false;
     if (isset($_REQUEST['highlightCLS']) && $_REQUEST['highlightCLS'])
         $show_shifts = true;

--- a/www/video/filmstrip.inc.php
+++ b/www/video/filmstrip.inc.php
@@ -19,7 +19,7 @@ $error = null;
 $endTime = 'visual';
 $supports60fps = false;
 if( array_key_exists('end', $_REQUEST) && strlen($_REQUEST['end']) )
-    $endTime = trim($_REQUEST['end']);
+    $endTime = htmlspecialchars(trim($_REQUEST['end']));
 
 $compTests = explode(',', $_REQUEST['tests']);
 foreach($compTests as $t) {


### PR DESCRIPTION
Let's apply a little bit of clean-up to the $end parameter on the filmstrip page to avoid XSS issues.