### PR TITLE
Z-Index Tweak for Experiment Settings

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -137,7 +137,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
-define('VER_CSS', 154);                // version of the sitewide css file
+define('VER_CSS', 155);                // version of the sitewide css file
 define('VER_JS', 40);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -2508,7 +2508,7 @@ th.header {
 .scrollableTable th,
 .scrollableTable td {
     /* scroll-snap-align: start; */
-    
+
     min-width: 4.5rem;
     position: relative;
     z-index: 10;
@@ -3751,6 +3751,7 @@ div.bar {
     border-radius: 3px;
     font-size: .9em;
     box-shadow: 0px 6.4px 14.4px rgb(0 0 0 / 13%), 0px 1.2px 3.6px rgb(0 0 0 / 11%);
+    z-index: 2000;
 }
 #experimentSettings.inactive {
     display: none;


### PR DESCRIPTION
This fixes #1609 by adjusting the z-index value used on the experiment settings dialog on the waterfall.

To test:

1. Go to a waterfall result page (ex: https://www.webpagetest.org/result/211222_BiDcGH_6dc09ebed349331a69f65e9f36334e53/1/details/#waterfall_view_step1)
2. Click on a request to open the request dialog
3. Go to the Experiments tab and select Block URL to pull up the experiment dialog
4. Scroll around and make sure the experiments dialog is behind the request dialog, but doesn't fall behind any of the tables.