### PR TITLE
fix(plot results): Do not note a zero p-value as significant

### DIFF
--- a/www/graph_page_data.js
+++ b/www/graph_page_data.js
@@ -68,7 +68,7 @@ function drawChart(chart_metric) {
 function signifString(pValue) {
   if (pValue === null) {
     return "";
-  } else if (pValue < 0.05) {
+  } else if (pValue < 0.05 && pValue != 0.000) {
     return "TRUE";
   } else {
     return "FALSE";


### PR DESCRIPTION
P-Values of 0 shouldn't be marked as statistically significant. This fixes the issue by checking for a zero value directly.

Fixes #1622.