### PR TITLE
feat(context): add request context to global scope

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "autoload": {
+        "psr-4": {"WebPageTest\\": "www/models/"}
+    },
     "require-dev": {
         "phpunit/phpunit": "^9"
     },

--- a/tests/models/RequestContextTest.php
+++ b/tests/models/RequestContextTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WebPageTest\RequestContext;
+
+final class RequestContextTest extends TestCase {
+  public function testConstructorSetsValues() : void {
+    $global_req = [];
+    $request = new RequestContext($global_req);
+    $this->assertEquals($global_req, $request->getRaw());
+  }
+}
+
+?>

--- a/tests/models/UserTest.php
+++ b/tests/models/UserTest.php
@@ -1,8 +1,7 @@
 <?php declare(strict_types=1);
 
-require_once __DIR__ . '/../../www/models/user.php';
-
 use PHPUnit\Framework\TestCase;
+use WebPageTest\User;
 
 final class UserTest extends TestCase {
   public function testConstructorSetsValues() : void {

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -8,6 +8,7 @@ $baseDir = dirname($vendorDir);
 return array(
     'phpDocumentor\\Reflection\\' => array($vendorDir . '/phpdocumentor/reflection-common/src', $vendorDir . '/phpdocumentor/reflection-docblock/src', $vendorDir . '/phpdocumentor/type-resolver/src'),
     'Webmozart\\Assert\\' => array($vendorDir . '/webmozart/assert/src'),
+    'WebPageTest\\' => array($baseDir . '/www/models'),
     'Symfony\\Polyfill\\Ctype\\' => array($vendorDir . '/symfony/polyfill-ctype'),
     'Psr\\Http\\Message\\' => array($vendorDir . '/psr/http-factory/src', $vendorDir . '/psr/http-message/src'),
     'Psr\\Http\\Client\\' => array($vendorDir . '/psr/http-client/src'),

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -24,6 +24,7 @@ class ComposerStaticInit14af0ddfbc16c4126602920a26b812c3
         'W' => 
         array (
             'Webmozart\\Assert\\' => 17,
+            'WebPageTest\\' => 12,
         ),
         'S' => 
         array (
@@ -59,6 +60,10 @@ class ComposerStaticInit14af0ddfbc16c4126602920a26b812c3
         'Webmozart\\Assert\\' => 
         array (
             0 => __DIR__ . '/..' . '/webmozart/assert/src',
+        ),
+        'WebPageTest\\' => 
+        array (
+            0 => __DIR__ . '/../..' . '/www/models',
         ),
         'Symfony\\Polyfill\\Ctype\\' => 
         array (

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => 'c2df17d3f3c56df0b59178ef04b433f636d1abe8',
+        'reference' => '8439d845b6c426235404731069e793a7bd52ccc7',
         'name' => '__root__',
         'dev' => true,
     ),
@@ -16,7 +16,7 @@
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => 'c2df17d3f3c56df0b59178ef04b433f636d1abe8',
+            'reference' => '8439d845b6c426235404731069e793a7bd52ccc7',
             'dev_requirement' => false,
         ),
         'doctrine/instantiator' => array(

--- a/www/common.inc
+++ b/www/common.inc
@@ -3,14 +3,16 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 
-// Load composer-based dependencies
+// Load models and composer-based dependencies
 require_once(__DIR__ . '/../vendor/autoload.php');
 
 // Load local deps
 require_once(__DIR__ . '/common_lib.inc');
 require_once(__DIR__ . '/plugins.php.inc');
 require_once(__DIR__ . '/util.inc');
-require_once(__DIR__ . '/models/user.php');
+
+use WebPageTest\User;
+use WebPageTest\RequestContext;
 
 // Disable caching by default
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0", true);
@@ -388,3 +390,6 @@ if (array_key_exists('medianMetric', $_REQUEST)) {
 if (is_file('./settings/custom_common.inc.php')) {
     include('./settings/custom_common.inc.php');
 }
+
+// Create global request context for future use
+$request = new RequestContext($_REQUEST);

--- a/www/models/RequestContext.php
+++ b/www/models/RequestContext.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace WebPageTest;
+
+class RequestContext {
+  private array $raw;
+
+  function __construct (array $global_request) {
+    $this->raw = $global_request;
+  }
+
+  function getRaw () : array {
+    return $this->raw;
+  }
+
+}
+?>

--- a/www/models/User.php
+++ b/www/models/User.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace WebPageTest;
+
 class User {
   private ?string $email;
   private bool $is_admin;


### PR DESCRIPTION
Also start autoloading and namespacing local models, I expect there to
be far more of these in the near future

Why? because I'd like to cut back on global variables and use this as a way to attach middleware-like pieces