### PR TITLE
Add support for passing through arbitrary metadata with the test

### DIFF
--- a/www/page_data.inc
+++ b/www/page_data.inc
@@ -471,6 +471,11 @@ function loadPageStepData($localPaths, $testInfo = null) {
       }
     }
 
+    // See if there is metadata that needs to be added
+    if (isset($testInfo) && isset($testInfo['metadata'])) {
+      $ret['metadata'] = $testInfo['metadata'];
+    }
+
     // see if there is test-level lighthouse data to attach
     // Don't cache the lighthouse bit because the file may come in after other results are cached
     $lighthouse_audits_file = $localPaths->lighthouseAuditsFile();

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -435,6 +435,16 @@
               $test['addCmdLine'] .= "--host-resolver-rules=\"$req_hostResolverRules,EXCLUDE localhost,EXCLUDE 127.0.0.1\"";
             }
 
+            // Store an opaque metadata string/JSON object if one was provided (up to 10KB)
+            if (isset($_REQUEST['metadata']) && is_string($_REQUEST['metadata']) && strlen($_REQUEST['metadata'] <= 10240)) {
+              $metadata = $_REQUEST['metadata'];
+              $metadata_json = json_decode($metadata, true);
+              if (isset($metadata_json) && is_array($metadata_json)) {
+                $metadata = $metadata_json;
+              }
+              $test['metadata'] = $metadata;
+            }
+
             // see if we need to process a template for these requests	
             if (isset($req_k) && strlen($req_k) && isset($api_keys)) {
               if (count($api_keys) && array_key_exists($req_k, $api_keys) && array_key_exists('template', $api_keys[$req_k])) {	


### PR DESCRIPTION
This allows for API consumers to pass through test metadata (string or JSON) that is echoed back in the JSON and HAR results.

Api docs coming shortly.

Fix #1662