### PR TITLE
feat(context): add User instance to $request

### DIFF
--- a/tests/models/RequestContextTest.php
+++ b/tests/models/RequestContextTest.php
@@ -2,12 +2,22 @@
 
 use PHPUnit\Framework\TestCase;
 use WebPageTest\RequestContext;
+use WebPageTest\User;
 
 final class RequestContextTest extends TestCase {
   public function testConstructorSetsValues() : void {
     $global_req = [];
     $request = new RequestContext($global_req);
     $this->assertEquals($global_req, $request->getRaw());
+  }
+  public function testSetGetUser() : void {
+    $global_req = [];
+    $email = 'foo@foo.com';
+    $user = new User();
+    $user->setEmail($email);
+    $request = new RequestContext($global_req);
+    $request->setUser($user);
+    $this->assertEquals($email, $request->getUser()->getEmail());
   }
 }
 

--- a/tests/models/UserTest.php
+++ b/tests/models/UserTest.php
@@ -1,36 +1,43 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use WebPageTest\User;
 
-final class UserTest extends TestCase {
-  public function testConstructorSetsValues() : void {
-    $user = new User();
-    $this->assertTrue($user->isAnon());
-    $this->assertFalse($user->isAdmin());
-    $this->assertFalse($user->isPaidApiUser());
-  }
+final class UserTest extends TestCase
+{
+    public function testConstructorSetsValues(): void
+    {
+        $user = new User();
+        $this->assertTrue($user->isAnon());
+        $this->assertFalse($user->isAdmin());
+        $this->assertFalse($user->isPaidApiUser());
+    }
 
-  public function testSettingEmail () : void {
-    $user = new User();
-    $email = 'foo@bar.com';
-    $user->setEmail($email);
-    $this->assertEquals($email, $user->getEmail());
-    $this->assertFalse($user->isAnon());
-  }
+    public function testSettingEmail(): void
+    {
+        $user = new User();
+        $email = 'foo@bar.com';
+        $user->setEmail($email);
+        $this->assertEquals($email, $user->getEmail());
+        $this->assertFalse($user->isAnon());
+    }
 
-  public function testSettingOwnerId () : void {
-    $user = new User();
-    $owner_id = 1234;
-    $user->setOwnerId($owner_id);
-    $this->assertEquals($owner_id, $user->getOwnerId());
-    $this->assertTrue($user->isPaidApiUser());
-  }
+    public function testSettingOwnerId(): void
+    {
+        $user = new User();
+        $owner_id = 1234;
+        $user->setOwnerId($owner_id);
+        $this->assertEquals($owner_id, $user->getOwnerId());
+        $this->assertTrue($user->isPaidApiUser());
+    }
 
-  public function testSettingAdmin () : void {
-    $user = new User();
-    $this->assertFalse($user->isAdmin());
-    $user->setAdmin(true);
-    $this->assertTrue($user->isAdmin());
-  }
+    public function testSettingAdmin(): void
+    {
+        $user = new User();
+        $this->assertFalse($user->isAdmin());
+        $user->setAdmin(true);
+        $this->assertTrue($user->isAdmin());
+    }
 }

--- a/tests/models/UserTest.php
+++ b/tests/models/UserTest.php
@@ -6,31 +6,31 @@ use WebPageTest\User;
 final class UserTest extends TestCase {
   public function testConstructorSetsValues() : void {
     $user = new User();
-    $this->assertTrue($user->is_anon());
-    $this->assertFalse($user->is_admin());
-    $this->assertFalse($user->is_paid_api_user());
+    $this->assertTrue($user->isAnon());
+    $this->assertFalse($user->isAdmin());
+    $this->assertFalse($user->isPaidApiUser());
   }
 
   public function testSettingEmail () : void {
     $user = new User();
     $email = 'foo@bar.com';
-    $user->set_email($email);
-    $this->assertEquals($email, $user->get_email());
-    $this->assertFalse($user->is_anon());
+    $user->setEmail($email);
+    $this->assertEquals($email, $user->getEmail());
+    $this->assertFalse($user->isAnon());
   }
 
   public function testSettingOwnerId () : void {
     $user = new User();
     $owner_id = 1234;
-    $user->set_owner_id($owner_id);
-    $this->assertEquals($owner_id, $user->get_owner_id());
-    $this->assertTrue($user->is_paid_api_user());
+    $user->setOwnerId($owner_id);
+    $this->assertEquals($owner_id, $user->getOwnerId());
+    $this->assertTrue($user->isPaidApiUser());
   }
 
   public function testSettingAdmin () : void {
     $user = new User();
-    $this->assertFalse($user->is_admin());
-    $user->set_admin(true);
-    $this->assertTrue($user->is_admin());
+    $this->assertFalse($user->isAdmin());
+    $user->setAdmin(true);
+    $this->assertTrue($user->isAdmin());
   }
 }

--- a/www/common.inc
+++ b/www/common.inc
@@ -393,3 +393,4 @@ if (is_file('./settings/custom_common.inc.php')) {
 
 // Create global request context for future use
 $request = new RequestContext($_REQUEST);
+$request->setUser($current_user);

--- a/www/common.inc
+++ b/www/common.inc
@@ -198,7 +198,7 @@ if ($supportsSaml) {
   $USER_EMAIL = $_COOKIE['google_email'];
 }
 
-$current_user->set_email($USER_EMAIL);
+$current_user->setEmail($USER_EMAIL);
 
 if (!$admin) {
   $this_user = null;
@@ -214,7 +214,7 @@ if (!$admin) {
       if (is_array($admin_users) && count($admin_users)) {
         foreach($admin_users as $substr) {
           if (stripos($this_user, $substr) !== false) {
-            $current_user->set_admin(true);
+            $current_user->setAdmin(true);
             $admin = true;
             break;
           }
@@ -231,7 +231,7 @@ $owner = null;
 if ($supportsSaml) {
   $isFirstVisit = false;
   $owner = GetSamlAccount();
-  $current_user->set_owner_id($owner);
+  $current_user->setOwnerId($owner);
 } 
 if (!$owner) {
   if( isset($_COOKIE['google_id']) && strlen($_COOKIE['google_id']) ) {

--- a/www/models/RequestContext.php
+++ b/www/models/RequestContext.php
@@ -2,15 +2,29 @@
 
 namespace WebPageTest;
 
+use WebPageTest\User;
+
 class RequestContext {
   private array $raw;
+  private ?User $user;
 
   function __construct (array $global_request) {
     $this->raw = $global_request;
+    $this->user = null;
   }
 
   function getRaw () : array {
     return $this->raw;
+  }
+
+  function getUser () : ?User {
+    return $this->user;
+  }
+
+  function setUser (?User $user) : void {
+    if (isset($user)) {
+      $this->user = $user;
+    }
   }
 
 }

--- a/www/models/User.php
+++ b/www/models/User.php
@@ -13,43 +13,43 @@ class User {
     $this->owner_id = 2445; // owner id of 2445 is for unpaid users
   }
 
-  public function get_email () : ?string {
+  public function getEmail () : ?string {
     return $this->email;
   }
 
-  public function set_email (?string $email) : void {
+  public function setEmail (?string $email) : void {
     if (isset($email)) {
       $this->email = $email;
     }
   }
 
-  public function set_admin (bool $is_admin) : void {
+  public function setAdmin (bool $is_admin) : void {
     $this->is_admin = $is_admin;
   }
 
-  public function get_owner_id () : int {
+  public function getOwnerId () : int {
     return $this->owner_id;
   }
 
   /**
    * @var string|int $owner_id
    */
-  public function set_owner_id ($owner_id) : void {
+  public function setOwnerId ($owner_id) : void {
     $this->owner_id = intval($owner_id);
   }
 
   /**
    * 2445 is the owner id for any user that is unpaid
    */
-  public function is_paid_api_user () : bool {
+  public function isPaidApiUser () : bool {
     return $this->owner_id != 2445;
   }
 
-  public function is_admin () : bool {
+  public function isAdmin () : bool {
     return $this->is_admin;
   }
 
-  public function is_anon () : bool {
+  public function isAnon () : bool {
     return $this->email == null;
   }
 

--- a/www/models/User.php
+++ b/www/models/User.php
@@ -1,56 +1,67 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebPageTest;
 
-class User {
-  private ?string $email;
-  private bool $is_admin;
-  private int $owner_id;
+class User
+{
+    private ?string $email;
+    private bool $is_admin;
+    private int $owner_id;
 
-  function __construct () {
-    $this->email = null;
-    $this->is_admin = false;
-    $this->owner_id = 2445; // owner id of 2445 is for unpaid users
-  }
-
-  public function getEmail () : ?string {
-    return $this->email;
-  }
-
-  public function setEmail (?string $email) : void {
-    if (isset($email)) {
-      $this->email = $email;
+    public function __construct()
+    {
+        $this->email = null;
+        $this->is_admin = false;
+        $this->owner_id = 2445; // owner id of 2445 is for unpaid users
     }
-  }
 
-  public function setAdmin (bool $is_admin) : void {
-    $this->is_admin = $is_admin;
-  }
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
 
-  public function getOwnerId () : int {
-    return $this->owner_id;
-  }
+    public function setEmail(?string $email): void
+    {
+        if (isset($email)) {
+            $this->email = $email;
+        }
+    }
 
-  /**
-   * @var string|int $owner_id
-   */
-  public function setOwnerId ($owner_id) : void {
-    $this->owner_id = intval($owner_id);
-  }
+    public function setAdmin(bool $is_admin): void
+    {
+        $this->is_admin = $is_admin;
+    }
 
-  /**
-   * 2445 is the owner id for any user that is unpaid
-   */
-  public function isPaidApiUser () : bool {
-    return $this->owner_id != 2445;
-  }
+    public function getOwnerId(): int
+    {
+        return $this->owner_id;
+    }
 
-  public function isAdmin () : bool {
-    return $this->is_admin;
-  }
+    /**
+     * @var string|int $owner_id
+     */
+    public function setOwnerId($owner_id): void
+    {
+        $this->owner_id = intval($owner_id);
+    }
 
-  public function isAnon () : bool {
-    return $this->email == null;
-  }
+    /**
+     * 2445 is the owner id for any user that is unpaid
+     */
+    public function isPaidApiUser(): bool
+    {
+        return $this->owner_id != 2445;
+    }
 
+    public function isAdmin(): bool
+    {
+        return $this->is_admin;
+    }
+
+    public function isAnon(): bool
+    {
+        return $this->email == null;
+    }
 }


### PR DESCRIPTION
This allows us to use $request->getUser() throughout the code to get the
current user.

This will be helpful when we're managing logging in locally

Also included: use PSR-12 coding standards for User class methods.