### PR TITLE
Use url param to auto-fill in URL field in test form

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -197,7 +197,9 @@ $loc = ParseLocations($locations);
                             
                             <label for="url" class="vis-hidden">Enter URL to test</label>
                             <?php
+
                             if (isset($_REQUEST['url']) && strlen($_REQUEST['url'])) {
+                                $url = htmlentities($_REQUEST['url']);
                                 echo "<input type='text' name='url' id='url' inputmode='url' placeholder='$placeholder' value='$url' class='text large' autocorrect='off' autocapitalize='off' onkeypress='if (event.keyCode == 32) {return false;}'>";
                             } else {
                                 echo "<input type='text' name='url' id='url' inputmode='url' placeholder='$placeholder' class='text large' autocorrect='off' autocapitalize='off' onkeypress='if (event.keyCode == 32) {return false;}'>";


### PR DESCRIPTION
Fixes #1682 

If we see a URL param passed, this will grab it, pass it through `htmlentities` and then drop it in the URL field.