### PR TITLE
Fix a typo on the "aria-labelledby" attribute

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -225,7 +225,7 @@ $loc = ParseLocations($locations);
                                         $selected = '';
                                         if ($name == $_COOKIE['testProfile'] || (!$_COOKIE['testProfile'] && $pIndex == 0))
                                         $selected = 'checked';
-                                        echo "<label class=\"test_preset_profile test_preset_profile-$name\"><input type=\"radio\" name=\"profile\" aria-labeledby=\"tt-$name\" value=\"$name\" $selected><span>{$profile['label']}</span><span role=\"tooltip\" id=\"tt-$name\" class=\"test_preset_profile_tt\">{$profile['description']}</span></label>";
+                                        echo "<label class=\"test_preset_profile test_preset_profile-$name\"><input type=\"radio\" name=\"profile\" aria-labelledby=\"tt-$name\" value=\"$name\" $selected><span>{$profile['label']}</span><span role=\"tooltip\" id=\"tt-$name\" class=\"test_preset_profile_tt\">{$profile['description']}</span></label>";
                                         $pIndex++;
                                     }
                                     }


### PR DESCRIPTION
I noticed a small typo in an attribute of the radio buttons on the homepage, so this is a fix for that.

![Accessibility overview in Polypane highlighting a typo](https://user-images.githubusercontent.com/41970/151511835-ed8fd59b-0bae-42e9-8f9e-4533ed058414.png)

