### PR TITLE
Display browser version for tests

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -279,9 +279,11 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
 
             $locationSimple = explode( "-", $test['testinfo']['locationLabel'] )[ 0 ];
             $connectivity = $test['test']['connectivity'];
-            $browser = $test['testinfo']['browser'];
+
+            $browser = $testResults->getBrowser();
+
             //check to make sure we have a browser icon
-            if (file_exists(__DIR__.'/images/test_icons/' . strtolower($browser) . '.svg')) {
+            if (file_exists(__DIR__.'/images/test_icons/' . strtolower($browser->getName()) . '.svg')) {
                 //exists so let's use it
                 $browserIcon = true;
             } else {
@@ -299,14 +301,20 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
                 <ul>
                     <?php 
                     echo '<li><strong>'.$device.'</strong>';
+                    //browser and version
+                    echo '<span class="test_presets_tag">';
                     if ($browserIcon) {
-                        echo '<img src="/images/test_icons/'. strtolower($browser) . '.svg" alt="'. $browser . '">';
+                        echo '<img src="/images/test_icons/'. strtolower($browser->getName()) . '.svg" alt="'. $browser->getName() . '">';
                     } else {
-                        echo '<span class="test_presets_tag">'.$browser.'</span>';
+                        echo $browser->getName();
                     }
-                    
+                    if ($browser->getVersion()) {
+                        echo 'v' . strtok($browser->getVersion(), '.');
+                    }
+                    echo '</span>';
+                    //connectivity
                     echo '<span class="test_presets_tag">'. $connectivity . '</span>';
-
+                    //location
                     echo '<span class="test_presets_tag">';
 
                     if( $flags[$test['test']['loc']] ){


### PR DESCRIPTION
This PR does two things.

1. Adds the browser version to our test info header
![Screen Shot 2022-01-28 at 11 19 37 AM](https://user-images.githubusercontent.com/66536/151602583-78ef4836-7f0e-4737-a0fd-637f11f92620.png)

2. Switches to using `getBrowser()` to retrieve the browser name.

