### PR TITLE
Remove sticky column headers (and the vertical scroll as well) on overflow tables. 

### DIFF
--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -4426,7 +4426,6 @@ th.header {
 .scrollableTable {
     overflow: auto;
     scroll-snap-type: both mandatory;
-    max-height: 80vh;
     width: 100%;
     max-width: 100%;
     padding-bottom: .8em;


### PR DESCRIPTION
This change removes a max-height on overflow tables, such as those at the bottom of the summary, which will mean that column headers will no longer be able to stick as you scroll, but more of the table will show by default.

We'd debated having sticky column headers and decided it's better than not in many cases, but the downsides are tables can have overflow that's not immediately obvious. For now, we can disable this for the vertical heights. Horizontal overflow will still have sticky row headers, which is more crucial on mobile sizes.