### PR TITLE
feat(privacy): removing private

### DIFF
--- a/batchtool/wpt_batch.py
+++ b/batchtool/wpt_batch.py
@@ -74,7 +74,7 @@ def RunBatch(options):
   """Run one-off batch processing of WebpageTest testing."""
 
   test_params = {'f': 'xml',
-                 'private': 1,
+                 'private': 0,
                  'priority': 6,
                  'video': options.video,
                  'fvonly': options.fvonly,

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -3667,7 +3667,7 @@ function TestArchiveExpired($id) {
 /**
  * Generate a unique test ID
  */
-function GenerateTestID($private=true, $locationShard=null) {
+function GenerateTestID($private=false, $locationShard=null) {
   $test_num;
   $id = uniqueId($test_num);
   if( $private )

--- a/www/index.php
+++ b/www/index.php
@@ -487,17 +487,6 @@ $loc = ParseLocations($locations);
                                     <li>
                                       <label for="videoCheck"><input type="checkbox" name="video" id="videoCheck" class="checkbox" checked=checked> Capture Video</label>
                                     </li>
-                                    <?php
-                                    if (!GetSetting('forcePrivate')) {
-                                    ?>
-                                    <li>
-                                        <label for="keep_test_private"><input type="checkbox" name="private" id="keep_test_private" class="checkbox" <?php if (((int)@$_COOKIE["testOptions"] & 1) || array_key_exists('hidden', $_REQUEST) || GetSetting('defaultPrivate')) echo " checked=checked"; ?>> Keep Test Private</label>
-                                    </li>
-                                    <?php
-                                    } else {
-                                      echo "<li>All test results are configured to be private by default.</li>";
-                                    }
-                                    ?>
                                     <li>
                                         <label for="label">Label</label>
                                         <?php

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -183,15 +183,12 @@
             if ($run_time_limit)
               $test['run_time_limit'] = (int)$run_time_limit;
             $test['connections'] = isset($req_connections) ? (int)$req_connections : 0;
-            if (isset($req_private)) {
-              $test['private'] = $req_private;
-            } elseif (GetSetting('defaultPrivate')) {
-              $test['private'] = 1;
-            } else {
-              $test['private'] = 0;
-            }
-            if (GetSetting('forcePrivate'))
-              $test['private'] = 1;
+            // Currently, we do nothing to designate the difference between public and private tests
+            // This creates a problem in that people assume their tests are actually private.
+            // But they're more private in the way that github gists are private, we don't advertise
+            // them, but they're accessible to those that know the url. Until we can create a truly
+            // private test, we are going to treat all tests as public
+            $test['private'] = 0;
             if (isset($req_web10))
               $test['web10'] = $req_web10;
             if (isset($req_ignoreSSL))
@@ -534,10 +531,6 @@
                 $is_bulk_test = true;
             }
 
-            // login tests are forced to be private
-            if( isset($test['login']) && strlen($test['login']) )
-                $test['private'] = 1;
-
             if (!$test['mobile'] && (!$test['browser_width'] || !$test['browser_height']) && isset($_REQUEST['resolution'])) {
               $resolution = $_REQUEST['resolution'];
               $parts = explode('x', $resolution);
@@ -564,20 +557,6 @@
                   }
                 }
               }
-            }
-
-            // Tests that include credentials in the URL (usually indicated by @ in the host section) are forced to be private
-            $atPos = strpos($test['url'], '@');
-            if ($atPos !== false) {
-              $queryPos = strpos($test['url'], '?');
-              if ($queryPos === false || $queryPos > $atPos) {
-                $test['private'] = 1;
-              }
-            }
-
-            // If API requests explicitly mark tests as not-private, allow it
-            if (($_SERVER['REQUEST_METHOD'] == 'GET' || $xml || $json) && isset($_REQUEST['private']) && !$_REQUEST['private'] && !GetSetting('forcePrivate')) {
-                $test['private'] = 0;
             }
 
             // default batch and API requests to a lower priority
@@ -2040,7 +2019,7 @@ function LogTest(&$test, $testId, $url)
         'guid' => @$testId,
         'url' => @$url,
         'location' => @$test['locationText'],
-        'private' => @$test['private'],
+        'private' => 0,
         'testUID' => @$test['uid'],
         'testUser' => $user_info,
         'video' => @$video,
@@ -2066,7 +2045,7 @@ function LogTest(&$test, $testId, $url)
         'guid' => @$testId,
         'url' => @$url,
         'location' => @$test['locationText'],
-        'private' => TRUE,
+        'private' => 0,
         'testUID' => @$test['uid'],
         'testUser' => $USER_EMAIL,
         'video' => @$video,

--- a/www/testlog.php
+++ b/www/testlog.php
@@ -191,8 +191,6 @@ exit;
                             <label><input id="all" type="checkbox" name="all" <?php check_it($all);?> onclick="this.form.submit();"> Show tests from all users</label> &nbsp;&nbsp;
                             <?php
                         }
-                        if ($includePrivate)
-                        echo '<input id="private" type="hidden" name="private" value="1">';
                     if (isset($_REQUEST['ip']) && $_REQUEST['ip'])
                         echo '<input type="hidden" name="ip" value="1">';
                     if (isset($_REQUEST['local']) && $_REQUEST['local'])


### PR DESCRIPTION
NOTE: THERE ARE PLANS TO ADD BACK TESTS THAT ARE USER-SCOPED LEVEL OF
PRIVATE

Currently, WPT has two privacy settings: private and public. Public
tests once showed up on the Test History page where _anybody_ could see
them. That was fun, but it's no longer the case for us.

So, now every test we run is private.

BUT, there's a caveat to that. Our version of private just means "we
don't list the URL anymore." It does not gate test results on their user
capabilities.

This is misleading. So, since there is no difference in how we treat
public vs private tests, I'm getting rid of the concept of private tests
until we hook up tests that are actually within the authorized visibility
set of the user.