### PR TITLE
fix(Util): Type Error when null passed

### DIFF
--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -20,6 +20,13 @@ final class UtilTest extends TestCase
         $this->assertEquals('WebPagetest', $value);
     }
 
+    public function testGetSettingWithNullDefault(): void
+    {
+        $override_settings_file = __DIR__ . '/fixtures/settings.ini';
+        $value = Util::getSetting('product', null, $override_settings_file);
+        $this->assertEquals('WebPagetest', $value);
+    }
+
     public function testCacheFetch(): void
     {
         $value = 'silly-thing';

--- a/www/src/Util.php
+++ b/www/src/Util.php
@@ -14,7 +14,7 @@ class Util
        throw new \Exception("Util should not be instantiated. It only has static methods.");
     }
 
-    public static function getSetting(string $setting, bool $default = false, $override_settings_file = "")
+    public static function getSetting(string $setting, $default = false, string $override_settings_file = "")
     {
         if (empty(self::$SETTINGS)) {
             self::$SETTINGS = self::cacheFetch(self::SETTINGS_KEY) ?? [];


### PR DESCRIPTION
Get rid of the type for now, we need to have a mixed type in there,
because default response can be whatever we want, but that's php 8