### PR TITLE
Bring back the blocked list and a few others

### DIFF
--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1099,6 +1099,8 @@ function GetTestInfoHtml($includeScript = true)
     global $test;
     global $isOwner;
     global $dom;
+    global $blockDomainsString;
+    global $blockString;
     global $login;
     global $admin;
     global $privateInstall;
@@ -1118,6 +1120,8 @@ function GetTestInfoHtml($includeScript = true)
         $html .= '<li>Test runs: ' . $test['test']['runs'] . '</li>';
     if( isset($test['test']['authenticated']) && (int)$test['test']['authenticated'] == 1)
         $html .= '<li>Authenticated: ' . htmlspecialchars($login) . '</li>';
+    if( (int)$test['test']['connections'] !== 0)
+        echo '<li>Browser Connections: ' . $test['test']['connections'] . '</li>';
     if (isset($test['testinfo']['addCmdLine']) && strlen($test['testinfo']['addCmdLine']))
         $html .= '<li>Command Line: ' . htmlspecialchars($test['testinfo']['addCmdLine']) . '</li>';
     
@@ -1136,6 +1140,24 @@ function GetTestInfoHtml($includeScript = true)
       $html .= GetScriptBlock();
       $html .= '</li>';
     }
+    if( strlen($blockString) ) {
+      $html .= '<li>Blocked:<pre>';
+      $blockedStrings = explode(",",$blockString);
+      foreach ($blockedStrings as $string) {
+        $html .= $string . "\n";
+      }
+      $html .= '</pre></li>';
+    }
+    if( strlen($blockDomainsString) ) {
+      $html .= '<li>Blocked Domains:<pre>';
+      $blockedStrings = explode(",",$blockDomainsString);
+      foreach ($blockedStrings as $string) {
+        $html .= $string . "\n";
+      }
+      $html .= '</pre></li>';
+    }
+    $html .= 'Scripted Test:';
+    $html .= '<pre>' . htmlspecialchars($test['testinfo']['script']) . '</pre>';
     // TODO FIND CUSTOM METRICS HERE
     if (array_key_exists('customMetrics', $test['testinfo']) && is_array($test['testinfo']['customMetrics']) && count($test['testinfo']['customMetrics']))
          $html .= '<li><a href="/custom_metrics.php?' . "test=". $test['testinfo']['id'] ."&run=1&cached=0" . '">Custom Metrics</a></li>';

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1121,7 +1121,7 @@ function GetTestInfoHtml($includeScript = true)
     if (isset($test['testinfo']['addCmdLine']) && strlen($test['testinfo']['addCmdLine']))
         $html .= '<li>Command Line: ' . htmlspecialchars($test['testinfo']['addCmdLine']) . '</li>';
     
-    if( isset($test['testinfo']['connectivity']) && !strcasecmp($test['testinfo']['connectivity'], 'custom') )
+    if( isset($test['testinfo']['connectivity']) && strcasecmp($test['testinfo']['connectivity'], 'custom') != 0 )
     {
         $html .= "<li>Connectivity: {$test['testinfo']['bwIn']}/{$test['testinfo']['bwOut']} Kbps, {$test['testinfo']['latency']}ms Latency";
         if( $test['testinfo']['plr'] )

--- a/www/header.inc
+++ b/www/header.inc
@@ -315,7 +315,12 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
             <div class="test_presets">
                 <ul>
                     <?php 
-                    echo '<li><strong>'.$device.'</strong>';
+                    if ( $test['testinfo']['label'] ) {
+                        echo '<li><strong>'.$test['testinfo']['label'].'</strong>';
+                    } else {
+                        echo '<li><strong>'.$device.'</strong>';
+                    }
+                    
                     //browser and version
                     echo '<span class="test_presets_tag">';
                     if ($browserIcon) {
@@ -349,18 +354,12 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
                     
                 </ul>
             </div>
+        </div>
 
 
 
     <?php
     
-             echo "<details class=\"heading_details\"><summary>More info</summary><p>";
-
-            if ( $test['testinfo']['label'] ) {
-                echo '<strong>Test Label: </strong>' . $test['testinfo']['label']  . '</strong>';
-              }
-
-        echo '</p></details></div>';
         echo '<div class="header_screenshots">';
         
         require_once __DIR__ . '/screen_shot_embed.php';

--- a/www/header.inc
+++ b/www/header.inc
@@ -355,33 +355,7 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
     <?php
     
              echo "<details class=\"heading_details\"><summary>More info</summary><p>";
-            
-            if( $dom )
-                echo 'DOM Element: <b>' . $dom . '</b><br>';
-            if( array_key_exists('authenticated', $test['test']) && (int)$test['test']['authenticated'] == 1)
-                echo '<b>Authenticated: ' . $login . '</b><br>';
-            if( (int)$test['test']['connections'] !== 0)
-                 echo '<b>' . $test['test']['connections'] . ' Browser connections</b><br>';
-            if( array_key_exists('script', $test['test']) && strlen($test['test']['script']) )
-                echo '<b>Scripted test</b><br>';
-            if( strlen($blockString) )
-                echo "Blocked: <b>$blockString</b><br>";
-            if (isset($test['testinfo']['context']) && strlen($test['testinfo']['context']))
-            {
-                echo 'Context: ';
-                $contextText = htmlspecialchars($test['testinfo']['context']);
-                if (isset($test['testinfo']['context_url']) && strlen($test['testinfo']['context_url'])) {
-                    $contextUrl = $test['testinfo']['context_url'];
-                    if (GetSetting('nolinks')) {
-                        echo "<span class=\"medium colored\">$contextText</span>";
-                    } else {
-                        echo "<a class=\"url\" rel=\"nofollow\" title=\"$contextUrl\" href=\"$contextUrl\">$contextText</a>";
-                    }
-                } else {
-                    echo $contextText;
-                }
-                echo '<br>';
-            }
+
             if ( $test['testinfo']['label'] ) {
                 echo '<strong>Test Label: </strong>' . $test['testinfo']['label']  . '</strong>';
               }


### PR DESCRIPTION
Turns out a few things were all lumped together here, so I made a few changes here.

First, it brings back the list of blocked strings and blocked domains, if any were set, closing #1736. Second, it adds the connectivity information (packet loss rate, bandwidth, latency) to the more info section. Finally, it closes #1730 by checking to see if there's a test label and, if so, using it instead of the device type to identify the test.

It also complete eliminates the hidden details that was lurking about, keeping things a bit tidier.

Before:
![Screen Shot 2022-02-04 at 2 01 37 PM](https://user-images.githubusercontent.com/66536/152595455-33acdd4f-c809-4c6d-a637-23bbd892dbb7.png)

After:
![Screen Shot 2022-02-04 at 2 03 57 PM](https://user-images.githubusercontent.com/66536/152595764-53ba6f05-e6bf-4ca6-bb1a-1891cf4b58f0.png)

