### PR TITLE
Don't unnecessarily shard a single-run test

### DIFF
--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1529,9 +1529,12 @@ function AddTestJob($location, $job, $test, $testId) {
           if ($test['runs'] > 1 && substr($job, 0, 1) == '{') {
             $json = json_decode($job, true);
           }
-          for ($run = 1; $run <= $test['runs']; $run++) {
+          $submit_count = $test['runs'];
+          if (GetSetting('disable_sharding'))
+            $submit_count = 1;
+          for ($run = 1; $run <= $submit_count; $run++) {
             // Submit multiple job files for a multi-run test so they can run in parallel
-            if (isset($json)) {
+            if ($submit_count > 1 && isset($json)) {
               $json['run'] = $run;
               $job = json_encode($json);
             }


### PR DESCRIPTION
and added a setting to disable test sharding.

The main impact this has for a single-run test is that the agent will send the first and repeat view results back together instead of incrementally.  For multi-run tests with the setting turned on it lets the agent collect the full test result for possible edge-processing before sending it back.