### PR TITLE
fix(perf): if cp endpoint is taking long to respond, time out faster

### DIFF
--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1687,10 +1687,10 @@ function cp_http_get($url, $cpid) {
     curl_setopt($ch, CURLOPT_HTTPHEADER, array("CPID: $cpid"));
     curl_setopt($ch, CURLOPT_FAILONERROR, true);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);
     curl_setopt($ch, CURLOPT_DNS_CACHE_TIMEOUT, 600);
     curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 600);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 60);
     curl_setopt($ch, CURLOPT_HEADERFUNCTION, function($curl, $header) use (&$headers) {
       $len = strlen($header);
       $header = explode(':', $header, 2);


### PR DESCRIPTION
It shouldn't take longer than a fraction of a second for a connection
timeout or a response for the things we're trying to call for. This long
timeout leaves us hanging when there are failures