### PR TITLE
Add Total Connection Time to the Request Details Dialog

### DIFF
--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -5688,6 +5688,12 @@ div.request-dialog-radio {
 .request-details a {
     word-break: break-all;
 }
+.request-details h3{
+    margin-bottom: 0;
+    margin-top: .5em;
+    text-decoration: underline;
+    font-size: 1em;
+}
 
 .jqmWindow {
     display: none;

--- a/www/waterfall.js
+++ b/www/waterfall.js
@@ -174,30 +174,30 @@ function SelectRequest(step, request) {
             details += '<b>Request Start: </b>' + (r['load_start'] / 1000.0).toFixed(3) + ' s<br>';
         if (IsValidDuration(r['dns_ms'])) {
             details += '<b>DNS Lookup: </b>' + htmlEncode(r['dns_ms']) + ' ms<br>';
-            totalConnectionTime += parseFloat(r['dns_ms']);
+            totalConnectionTime += Number(r['dns_ms']);
         } else if( r['dns_end'] !== undefined && r['dns_start'] !== undefined && r['dns_end'] > 0 ) {
             var dnsTime = r['dns_end'] - r['dns_start'];
-            totalConnectionTime+= parseFloat(dnsTime);
+            totalConnectionTime+= Number(dnsTime);
             details += '<b>DNS Lookup: </b>' + dnsTime + ' ms<br>';
         }
         if (IsValidDuration(r['connect_ms'])) {
             details += '<b>Initial Connection: </b>' + htmlEncode(r['connect_ms']) + ' ms<br>';
-            totalConnectionTime+= parseFloat(r['connect_ms']);
+            totalConnectionTime+= Number(r['connect_ms']);
             if (r['is_secure'] !== undefined && r['is_secure'] && IsValidDuration(r['ssl_ms'])) {
                 details += '<b>SSL Negotiation: </b>' + htmlEncode(r['ssl_ms']) + ' ms<br>';
-                totalConnectionTime+= parseFloat(r['ssl_ms']);
+                totalConnectionTime+= Number(r['ssl_ms']);
             }
         } else if( r['connect_end'] !== undefined && r['connect_start'] !== undefined && r['connect_end'] > 0 ) {
             var connectTime = r['connect_end'] - r['connect_start'];
-            totalConnectionTime+= parseFloat(connectTime);
+            totalConnectionTime+= Number(connectTime);
             details += '<b>Initial Connection: </b>' + connectTime + ' ms<br>';
             if( r['ssl_end'] !== undefined && r['ssl_start'] !== undefined && r['ssl_end'] > 0 ) {
                 var sslTime = r['ssl_end'] - r['ssl_start'];
-                totalConnectionTime+= parseFloat(r['sslTime']);
+                totalConnectionTime+= Number(r['sslTime']);
                 details += '<b>SSL Negotiation: </b>' + sslTime + ' ms<br>';
             }
         }
-        if (IsValidDuration(totalConnectionTime) && totalConnectionTime > 0) {
+        if (!Number.isNaN(totalConnectionTime) && totalConnectionTime > 0) {
             details += '<b>Total Connection Time: </b>' + htmlEncode(totalConnectionTime) + ' ms<br>';
         }
         if (IsValidDuration(r['ttfb_ms'])) {

--- a/www/waterfall.js
+++ b/www/waterfall.js
@@ -197,7 +197,7 @@ function SelectRequest(step, request) {
                 details += '<b>SSL Negotiation: </b>' + sslTime + ' ms<br>';
             }
         }
-        if (!Number.isNaN(totalConnectionTime) && totalConnectionTime > 0) {
+        if (typeof totalConnectionTime === 'number' && !Number.isNaN(totalConnectionTime) && totalConnectionTime > 0) {
             details += '<b>Total Connection Time: </b>' + htmlEncode(totalConnectionTime) + ' ms<br>';
         }
         if (IsValidDuration(r['ttfb_ms'])) {


### PR DESCRIPTION
Closes #1755 by adding a Total Connection Time value to the request dialog box to make it easier see the combined impact of DNS+TCP+SSL.

Also broke up the long list of details to make it easier to scan.

Before:
![Screen Shot 2022-02-23 at 1 41 34 PM](https://user-images.githubusercontent.com/66536/155395581-b14c6f3a-2223-4c43-b97e-593beda2f950.png)

After:
![Screen Shot 2022-02-23 at 1 41 56 PM](https://user-images.githubusercontent.com/66536/155395648-40de716f-8940-42cf-894c-fb41d50c1171.png)

