### PR TITLE
Make screen-read locations less repetitive

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -338,7 +338,7 @@ if( !strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
                     echo '<span class="test_presets_tag">';
 
                     if( $flags[$test['test']['loc']] ){
-                        echo '<img src="/images/test_icons/flags/' . $flags[$test["test"]["loc"]] . '.svg" alt="' . $locationSimple . '" title="'. $locationSimple .'">';
+                        echo '<img src="/images/test_icons/flags/' . $flags[$test["test"]["loc"]] . '.svg" alt="">';
                     }
                     
                     echo $locationSimple;


### PR DESCRIPTION
The previous markup looked like:

```html
<span class="test_presets_tag">
  <img src="/images/test_icons/flags/US.svg" alt="Virginia, USA " title="Virginia, USA ">
  Virginia, USA 
</span>
```

While `alt` and `title` are normally helpful for solitary icons, in this case the location is displayed as plain text next to the flag. Screen readers would repeat the location name at least twice, and up to 3 times depending on verbosity settings.

The tooltip functionality of `title` was also suppressed by the wrapping `<label>` and/or the custom hover bubbles, so removing it should change nothing.