### PR TITLE
Specify PHP version with Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     "require": {
         "guzzlehttp/guzzle": "^7.4",
         "gmostafa/php-graphql-client": "^1.13",
-        "php": "^7.2.5"
+        "php": "^7.4.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     },
     "require": {
         "guzzlehttp/guzzle": "^7.4",
-        "gmostafa/php-graphql-client": "^1.13"
+        "gmostafa/php-graphql-client": "^1.13",
+        "php": "^7.2.5"
     }
 }


### PR DESCRIPTION
When looking through the codebase, I often wondered what PHP features were fair game to use, such as `http_response_code()` instead of the easier-to-mess-up `header('HTTP/…')`. [Specifying PHP’s minimum version in `composer.json`](https://mikemadison.net/blog/2020/11/17/configuring-php-version-with-composer) helps with questions like that, and should produce friendlier and easier-to-understand errors if the code is run with an older PHP runtime.

I set the version to the minimum that [Guzzle 7.4](https://packagist.org/packages/guzzlehttp/guzzle#7.4.0) requires, since that looked like a safe bet.