### PR TITLE
Add API key to the testlog admin view

### DIFF
--- a/www/testlog.php
+++ b/www/testlog.php
@@ -410,6 +410,8 @@ exit;
                                                           echo '<td class="uid">' . "$testUser ($testUID)" . '</td>';
                                                       } elseif( isset($email) ) {
                                                         echo '<td class="uid">' . htmlspecialchars($email) . '</td>';
+                                                      } elseif( isset($key) ) {
+                                                        echo '<td class="uid">' . htmlspecialchars($key) . '</td>';
                                                       } else {
                                                           echo '<td class="uid"></td>';
                                                       }


### PR DESCRIPTION
Let's make sure that admin's can also see the API key, if present, in the admin view of the test log.