### PR TITLE
Pass the test metadata through to the agent

### DIFF
--- a/www/.gitignore
+++ b/www/.gitignore
@@ -29,3 +29,4 @@
 /settings/custom.css
 *.log
 /settings/custom_metrics/*.js
+/settings/custom_metrics/bak

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -2564,6 +2564,9 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
               $crux_key = explode(',', $crux_keys);
               $job['crux_api_key'] = trim($crux_key[array_rand($crux_key)]);
             }
+            if (isset($test['metadata'])) {
+              $job['metadata'] = $test['metadata'];
+            }
             // Generate the job file name
             $ext = 'url';
             if( $test['priority'] )


### PR DESCRIPTION
This passes the test metadata through to the agent as part of the job file so the agent can add it to the resulting data directly (separate PR for the agent to do something useful with it).