### PR TITLE
fix(location): don't lock this down

### DIFF
--- a/www/getLocations.php
+++ b/www/getLocations.php
@@ -3,20 +3,6 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 include 'common.inc';
-
-use WebPageTest\Util;
-
-if (Util::getSetting('cp_auth')) {
-  $user = $request_context->getUser();
-  if (!(isset($user) && $user->isAdmin())) {
-    http_response_code(403);
-    die('Forbidden');
-  }
-} elseif (!$admin) {
-    http_response_code(403);
-    die('Forbidden');
-}
-
 $remote_cache = array();
 if ($CURL_CONTEXT !== false) {
   curl_setopt($CURL_CONTEXT, CURLOPT_CONNECTTIMEOUT, 30);


### PR DESCRIPTION
This combines three reverts into one commit. If there are parts of this
we want to lock down in the future, we should figure that out

Revert "fix(403): use PHP's shortcut for this"

This reverts commit c2167d2119c6d89cdbd32319df4fe0bc7794fbbf.

Revert "Quick fix admin (#1816)"

This reverts commit d5c74c969561003c13b2de74296ded58ff1cfdd8.

Revert "fix(security): lock down getLocations.php behind admin (#1814)"

This reverts commit d1b4c2f5b24da24d34ce3c3b060765f33c994c48.