### PR TITLE
fix(account): log out/in post payment

### DIFF
--- a/www/src/CPClient.php
+++ b/www/src/CPClient.php
@@ -409,14 +409,15 @@ class CPClient
           'company',
           'firstName',
           'lastName',
-          'email'
+          'email',
+          'loginVerificationId'
         ]);
 
         $variables_array = array('customer' => $customer->toArray());
 
         try {
             $results = $this->graphql_client->runQuery($gql, true, $variables_array);
-            return $results->getData();
+            return $results->getData()['wptAddSubscription'];
         } catch (QueryError $e) {
             throw new ClientException(implode(",", $e->getErrorDetails()));
         }

--- a/www/src/Handlers/Account.php
+++ b/www/src/Handlers/Account.php
@@ -141,12 +141,8 @@ class Account
         ]);
 
         try {
-            $request_context->getClient()->addWptSubscription($customer);
-            $protocol = $request_context->getUrlProtocol();
-            $host = Util::getSetting('host');
-            $route = '/account';
-            $redirect_uri = "{$protocol}://{$host}{$route}";
-
+            $data = $request_context->getClient()->addWptSubscription($customer);
+            $redirect_uri = $request_context->getSignupClient()->getAuthUrl($data['loginVerificationId']);
             header("Location: {$redirect_uri}");
             exit();
         } catch (BaseException $e) {


### PR DESCRIPTION
After a user pays, we need to re-login. This is due to a constraint in CP's auth
system. Of course, this now leaves us with an issue where we don't know,
when logging in through this system, where somebody left off. We can
maybe set that with a cookie?