### PR TITLE
fix(account): cancel a subscription 

### DIFF
--- a/www/cpauth/account.php
+++ b/www/cpauth/account.php
@@ -128,6 +128,7 @@ if ($request_method === 'POST') {
             $billing_info['plan_renewal'] = $plan_renewal_date->format('m/d/Y');
         }
 
+        $billing_info['is_canceled'] = str_contains($customer_details['status'], 'CANCEL');
         $billing_info['billing_frequency'] = $billing_frequency;
         $client_token = $billing_info['braintreeClientToken'];
     } else {

--- a/www/css/account.css
+++ b/www/css/account.css
@@ -140,6 +140,13 @@ body.theme-b {
   content: ':';
 }
 
+.subscription-plan .cancel span {
+  padding: 0px 10px;
+  border-radius: 2px;
+  background-color: rgb(237, 47, 47);
+  color: rgb(255, 255, 255);
+}
+
 .billing-history {
   display: block;
 }
@@ -684,3 +691,4 @@ body.theme-b {
 .account-layout body {
   background-color: rgb(234, 234, 234);
 }
+

--- a/www/src/Handlers/Account.php
+++ b/www/src/Handlers/Account.php
@@ -202,15 +202,16 @@ class Account
     {
 
         $subscription_id = filter_input(INPUT_POST, 'subscription-id', FILTER_SANITIZE_STRING);
-        $protocol = $request_context->getUrlProtocol();
-        $host = Util::getSetting('host');
-        $route = '/account';
-        $redirect_uri = "{$protocol}://{$host}{$route}";
 
-        header("Location: {$redirect_uri}");
-        exit();
         try {
             $request_context->getClient()->cancelWptSubscription($subscription_id);
+            $protocol = $request_context->getUrlProtocol();
+            $host = Util::getSetting('host');
+            $route = '/account';
+            $redirect_uri = "{$protocol}://{$host}{$route}";
+
+            header("Location: {$redirect_uri}");
+            exit();
         } catch (BaseException $e) {
             error_log($e->getMessage());
             throw new ClientException("There was an error", "/account");

--- a/www/templates/account/includes/billing-data.php
+++ b/www/templates/account/includes/billing-data.php
@@ -8,8 +8,13 @@
         <?php echo isset($runs_renewal) ? "<li><strong>Runs Renewal</strong> {$runs_renewal}</li>" : "" ?>
         <li><strong>Price</strong> <?= "\${$braintreeCustomerDetails['subscriptionPrice']}"; ?></li>
         <li><strong>Payment</strong> <?= $billing_frequency ?></li>
+<?php if ($is_canceled): ?>
+        <li><strong>Plan Renewal</strong> <s><?= $plan_renewal ?></s></li>
+        <li class="cancel"><strong>Status</strong> <span><?= $braintreeCustomerDetails['status']; ?></span></li>
+<?php else: ?>
         <li><strong>Plan Renewal</strong> <?= $plan_renewal ?></li>
         <li><strong>Status</strong> <?= $braintreeCustomerDetails['status']; ?></li>
+<?php endif; ?>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
(Requires #1828 and #1829)

A user needs to be able to cancel their subscription. This includes some
style changes to reflect what we currently have on app.webpagetest plus
moving an ill-placed redirect (that was happening _before_ the call for
some reason).