### PR TITLE
feat(signup): Error handling

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -17,18 +17,18 @@ if (Util::getSetting('cp_auth')) {
   session_start();
 }
 
-$notification_alert = null;
+$client_error = null;
 if (Util::getSetting('cp_auth')) {
-  $notification_alert = $_SESSION['notification_alert'] ?? null;
-  unset($_SESSION['notification_alert']);
+  $client_error = $_SESSION['client_error'] ?? null;
+  unset($_SESSION['client_error']);
 
   set_exception_handler(function($e) {
     if(is_a($e, ClientException::class)) {
      $route = $e->getRoute();
      $message = $e->getMessage();
      $host = Util::getSetting('host');
-     unset($_SESSION['notification_alert']);
-     $_SESSION['notification_alert'] = $message;
+     unset($_SESSION['client_error']);
+     $_SESSION['client_error'] = $message;
      $protocol = "https";
      $location = "{$protocol}://{$host}{$route}";
      header('Location: ' . $location);

--- a/www/header.inc
+++ b/www/header.inc
@@ -46,9 +46,11 @@ if ($id && isset($test) && is_array($test) &&
 if (!defined('EMBED')) {
 ?>
 <?php
-$alert = $notification_alert ?? Util::getSetting('alert');
-if ($alert) {
-    echo '<div class="alert-banner">' . $alert . '</div>';
+$alert = Util::getSetting('alert');
+if (isset($client_error)) {
+  echo '<div class="error-banner">' . $alert . '</div>';
+} elseif ($alert) {
+  echo '<div class="alert-banner">' . $alert . '</div>';
 }
 ?>
 

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -6638,3 +6638,46 @@ div.bar {
     text-decoration: underline;
     background: #f9f9f9;
 }
+
+
+.error-banner {
+    font-size: 0.875em;
+    max-width: 100%;
+    background-color: #fce8e6;
+    color: #0E1E38;
+    text-align: center;
+}
+
+.error-banner div {
+    padding: .8em 1em 1.2em;
+}
+
+.error-banner p {
+    margin: 0 auto;
+    font-size: .9em;
+}
+
+.error-banner img {
+    max-height: 2em;
+    display: inline-block;
+    max-width: 5em;
+    margin-right: .7em;
+    position: relative;
+    top: .8em;
+    margin-top: -1em;
+}
+
+.error-banner a {
+    display: block;
+    color: #0E1E38;
+}
+
+@media screen and (min-width:35em) {
+    .error-banner {
+        grid-column: 1 / 13;
+    }
+    .error-banner a,
+    .error-banner-twitch a {
+        display: inline-block;
+    }
+}

--- a/www/src/CPSignupClient.php
+++ b/www/src/CPSignupClient.php
@@ -9,11 +9,14 @@ use GuzzleHttp\Exception\ClientException;
 use WebPageTest\SignupToken;
 use GraphQL\Client as GraphQLClient;
 use Exception as BaseException;
+use GraphQL\Exception\QueryError;
 use GraphQL\Query;
 use GraphQL\Mutation;
 use GraphQL\Variable;
 use WebPageTest\Plan;
 use WebPageTest\Customer;
+use WebPageTest\Exception\ClientException as ExceptionClientException;
+use WebPageTest\Exception\ConflictException;
 
 class CPSignupClient
 {
@@ -121,8 +124,12 @@ class CPSignupClient
 
         $variables_array = array('wptAccount' => $wpt_account);
 
-        $results = $this->graphql_client->runQuery($gql, true, $variables_array);
-        return $results->getData()['wptAccountCreate'];
+        try {
+            $results = $this->graphql_client->runQuery($gql, true, $variables_array);
+            return $results->getData()['wptAccountCreate'];
+        } catch (QueryError $e) {
+            throw new \WebPageTest\Exception\ClientException($e->getMessage());
+        }
     }
 
     /**

--- a/www/src/CPSignupClient.php
+++ b/www/src/CPSignupClient.php
@@ -15,8 +15,6 @@ use GraphQL\Mutation;
 use GraphQL\Variable;
 use WebPageTest\Plan;
 use WebPageTest\Customer;
-use WebPageTest\Exception\ClientException as ExceptionClientException;
-use WebPageTest\Exception\ConflictException;
 
 class CPSignupClient
 {

--- a/www/src/Handlers/Signup.php
+++ b/www/src/Handlers/Signup.php
@@ -16,6 +16,7 @@ use GuzzleHttp\Exception\RequestException;
 use WebPageTest\BillingAddress;
 use WebPageTest\Customer;
 use WebPageTest\Exception\ClientException;
+use WebPageTest\Exception\ConflictException;
 
 class Signup
 {
@@ -141,12 +142,11 @@ class Signup
             'email' => $body->email,
             'password' => $body->password
             ));
-          // TODO: handle user already registered (send to login?)
 
             $redirect_uri = $request_context->getSignupClient()->getAuthUrl($data['loginVerificationId']);
             return $redirect_uri;
-        } catch (\Exception $e) {
-            throw $e;
+        } catch (ClientException $e) {
+            throw new ClientException($e->getMessage(), '/signup/2');
         }
     }
 

--- a/www/templates/layouts/header.inc
+++ b/www/templates/layouts/header.inc
@@ -54,9 +54,11 @@ $tab ??= "";
 if (!defined('EMBED')) {
 ?>
 <?php
-$alert = $notification_alert ?? Util::getSetting('alert');
-if ($alert) {
-    echo '<div class="alert-banner">' . $alert . '</div>';
+$alert = Util::getSetting('alert');
+if (isset($client_error)) {
+  echo '<div class="error-banner">' . $alert . '</div>';
+} elseif ($alert) {
+  echo '<div class="alert-banner">' . $alert . '</div>';
 }
 ?>
 <wpt-header>


### PR DESCRIPTION
This covers a few different kinds of error. If the user manages to put in
incorrect or bad data, this will show. Also, if the user uses an email
that's already been used, an error will show.

This leads us to an interesting place where we need to think out how we
want to handle global (banner) vs local (in the form itself?) errors and
how we make those easy enough to get into.

For global, this PR addresses the top bar by making it a tint of red with a dark text. This catches the eye quite a bit better than our normal alert banner.

(merge https://github.com/WPO-Foundation/webpagetest/pull/1848 first)