### PR TITLE
feat(history): enabled for logged in user

### DIFF
--- a/tests/CPClientTest.php
+++ b/tests/CPClientTest.php
@@ -269,7 +269,7 @@ final class CPClientTest extends TestCase {
     ));
 
     $data = $client->getUserDetails();
-    $this->assertEquals('263425', $data['id']);
+    $this->assertEquals('263425', $data['activeContact']['id']);
   }
 
   public function testGetUserDetailsWithError () : void {

--- a/www/common.inc
+++ b/www/common.inc
@@ -34,15 +34,14 @@ if (Util::getSetting('cp_auth')) {
      header('Location: ' . $location);
      exit();
     }
-    echo '<pre>';
-    var_dump($e);
-    echo '</pre>';
-
     /*
      * for when we ship to prod
      * throw $e;
      *
      */
+    echo '<pre>';
+    var_dump($e);
+    echo '</pre>';
     exit();
   });
 }
@@ -306,6 +305,20 @@ if (isset($_REQUEST['color'])) {
     $_REQUEST['color'] = $_REQUEST['color'];
 }
 
+if ($supportsSaml && !$supportsCPAuth) {
+  $request_context->setUser($saml_user);
+}
+
+/**
+ * Load app specific middleware
+ */
+if ($supportsCPAuth) {
+  require_once __DIR__ . '/common/AttachClient.php';
+  require_once __DIR__ . '/common/AttachUser.php';
+  require_once __DIR__ . '/common/AttachSignupClient.php';
+  require_once __DIR__ . '/common/CheckCSRF.php';
+}
+
 // Load the test-specific data
 $id = '';
 if (isset($_REQUEST['test']) && preg_match('/^[a-zA-Z0-9_]+$/', @$_REQUEST['test'])) {
@@ -435,13 +448,3 @@ if (is_file('./settings/custom_common.inc.php')) {
     include('./settings/custom_common.inc.php');
 }
 
-if ($supportsSaml && !$supportsCPAuth) {
-  $request_context->setUser($saml_user);
-}
-
-if ($supportsCPAuth) {
-  require_once __DIR__ . '/common/AttachClient.php';
-  require_once __DIR__ . '/common/AttachUser.php';
-  require_once __DIR__ . '/common/AttachSignupClient.php';
-  require_once __DIR__ . '/common/CheckCSRF.php';
-}

--- a/www/common/AttachUser.php
+++ b/www/common/AttachUser.php
@@ -10,6 +10,8 @@ use WebPageTest\Exception\UnauthorizedException;
 
 (function (RequestContext $request) {
     global $admin;
+    global $owner;
+
     $host = Util::getSetting('host');
     $cp_access_token_cookie_name = Util::getCookieName(CPOauth::$cp_access_token_cookie_key);
     $cp_refresh_token_cookie_name = Util::getCookieName(CPOauth::$cp_refresh_token_cookie_key);
@@ -29,10 +31,12 @@ use WebPageTest\Exception\UnauthorizedException;
     if (!is_null($access_token)) {
         try {
             $data = $request->getClient()->getUserDetails();
-            $user->setUserId($data['id']);
-            $user->setEmail($data['email']);
-            $user->setPaid($data['isWptPaidUser']);
-            $user->setVerified($data['isWptAccountVerified']);
+            $user->setUserId($data['activeContact']['id']);
+            $user->setEmail($data['activeContact']['email']);
+            $user->setPaid($data['activeContact']['isWptPaidUser']);
+            $user->setVerified($data['activeContact']['isWptAccountVerified']);
+            $user->setOwnerId($data['levelSummary']['levelId']);
+            $owner = $user->getOwnerId();
         } catch (UnauthorizedException $e) {
             error_log($e->getMessage());
           // if this fails, Refresh and retry

--- a/www/js/history-loggedin.js
+++ b/www/js/history-loggedin.js
@@ -1,0 +1,45 @@
+(function(window) {
+  window.filterHistory = filterHistory;
+
+  function filterHistory() {
+      const input = document.getElementById("filter");
+      const filter = input.value.toUpperCase();
+      const table = document.getElementById("historyBody");
+      const rows = table.getElementsByTagName("tr");
+
+      for (let i = 0; i < rows.length; i++) {
+          const row = rows[i];
+          if (row) {
+              txtValue = row.textContent || row.innerText;
+              if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                  row.style.display = "";
+              } else {
+                  row.style.display = "none";
+              }
+          }
+      }
+  }
+
+}(window));
+
+((window) => {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      handleDaySelector();
+    });
+  } else {
+    handleDaySelector();
+  }
+
+  function handleDaySelector () {
+    const daySelector = document.querySelector('select[name=days]')
+    daySelector.addEventListener('change', (e) => {
+      const days = e.target.value;
+      const protocol = window.location.protocol;
+      const hostname = window.location.hostname;
+      const redirectUri = protocol + "//" + hostname + "/testlog/" + days + "/";
+
+      window.location = redirectUri;
+    })
+  }
+})(window);

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -2455,6 +2455,12 @@ form[name=filterLog] select {
     margin-bottom: 2em;
 }
 
+form[name=filterLog] select[name=days] {
+    margin-bottom: 0;
+    padding-right: 30px;
+    display: block;
+}
+
 .history_filter {
     margin: 1em 0;
     border-top: 1px solid #eee;

--- a/www/src/TestRecord.php
+++ b/www/src/TestRecord.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebPageTest;
+
+/**
+ * A test history object, as tracked by CP
+ */
+class TestRecord implements \JsonSerializable
+{
+    private int $id;
+    private string $test_id;
+    private string $url;
+    private string $location;
+    private string $label;
+    private string $test_start_time;
+    private string $user;
+    private ?string $api_key;
+
+    public function __construct(array $options = [])
+    {
+        $this->id = $options['id'];
+        $this->test_id = $options['testId'];
+        $this->url = $options['url'];
+        $this->location = $options['location'];
+        $this->label = $options['label'];
+        $this->test_start_time = $options['testStartTime'];
+        $this->user = $options['user'];
+        $this->api_key = $options['apiKey'] ?? null;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTestId(): string
+    {
+        return $this->test_id;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getStartTime(): string
+    {
+        return $this->test_start_time;
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function getApiKey(): ?string
+    {
+        return $this->api_key;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+        'id' => $this->id,
+        'testId' => $this->test_id,
+        'url' => $this->url,
+        'location' => $this->location,
+        'label' => $this->label,
+        'testStartTime' => $this->test_start_time,
+        'user' => $this->user,
+        'apiKey' => $this->api_key
+        ];
+    }
+}

--- a/www/src/User.php
+++ b/www/src/User.php
@@ -8,7 +8,7 @@ class User
 {
     private ?string $email;
     private bool $is_admin;
-    private int $owner_id;
+    private ?string $owner_id;
     private ?string $access_token;
     private ?int $user_id;
     private bool $is_paid_and_in_good_standing;
@@ -18,7 +18,7 @@ class User
     {
         $this->email = null;
         $this->is_admin = false;
-        $this->owner_id = 2445; // owner id of 2445 was for unpaid users
+        $this->owner_id = "2445"; // owner id of 2445 was for unpaid users
         $this->access_token = null;
         $this->user_id = null;
         $this->is_paid_and_in_good_standing = false;
@@ -42,7 +42,7 @@ class User
         $this->is_admin = $is_admin;
     }
 
-    public function getOwnerId(): int
+    public function getOwnerId(): ?string
     {
         return $this->owner_id;
     }
@@ -52,7 +52,7 @@ class User
      */
     public function setOwnerId($owner_id): void
     {
-        $this->owner_id = intval($owner_id);
+        $this->owner_id = strval($owner_id);
     }
 
     public function isPaid(): bool

--- a/www/testlog.php
+++ b/www/testlog.php
@@ -3,20 +3,31 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 include 'common.inc';
+
+use WebPageTest\Util;
+
 if ($admin || $privateInstall) {
     set_time_limit(0);
 } else {
     set_time_limit(60);
 }
 
-if ($userIsBot || GetSetting('disableTestlog')) {
+if ($userIsBot || Util::getSetting('disableTestlog')) {
   header('HTTP/1.0 403 Forbidden');
   exit;
 }
 
+$test_history = [];
+$is_logged_in = Util::getSetting('cp_auth') && (!is_null($request_context->getClient()) && $request_context->getClient()->isAuthenticated());
+$days = (int)$_GET["days"];
+
+if ($is_logged_in) {
+  $test_history = $request_context->getClient()->getTestHistory($days);
+}
+
 // Redirect logged-in users to the hosted test history if one is configured
-if (isset($USER_EMAIL) && GetSetting('history_url') && !isset($_REQUEST['local'])) {
-    header('Location: ' . GetSetting('history_url'));
+if (!$is_logged_in && (isset($USER_EMAIL) && Util::getSetting('history_url') && !isset($_REQUEST['local']))) {
+    header('Location: ' . Util::getSetting('history_url'));
     exit;
 }
 
@@ -25,11 +36,11 @@ $page_description = "History of website performance speed tests run on WebPageTe
 
 $supportsGrep = false;
 $out = exec('grep --version', $output, $result_code);
-if ($result_code == 0 && isset($output) && is_array($output) && count($output))
+if ($result_code == 0 && isset($output) && is_array($output) && count($output)) {
   $supportsGrep = true;
+}
 
 
-$days      = (int)$_GET["days"];
 $from      = (isset($_GET["from"]) && strlen($_GET["from"])) ? $_GET["from"] : 'now';
 $filter    = $_GET["filter"];
 $filterstr = $filter ? preg_replace('/[^a-zA-Z0-9 \@\/\:\.\(\))\-\+]/', '', strtolower($filter)) : null;
@@ -68,43 +79,13 @@ if( $csv )
 {
     header ("Content-type: text/csv");
     echo '"Date/Time","Location","Test ID","URL","Label"' . "\r\n";
-} elseif (!isset($user) && !isset($_COOKIE['google_email']) && GetSetting('localHistory')) {
-    // For users not logged in, build a local searchable test history from the data stored in indexeddb.
+} elseif ($is_logged_in || (!isset($user) && !isset($_COOKIE['google_email']) && Util::getSetting('localHistory'))) {
 ?>
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
         <title>WebPageTest - Test Log</title>
         <?php $gaTemplate = 'Test Log'; include ('head.inc'); ?>
-        <style>
-            /* h4 {text-align: center;}
-            .history table {text-align:left;}
-            .history thead {text-align:left;}
-            .history th {white-space:nowrap; text-decoration:underline;}
-            .history td.date {white-space:nowrap;}
-            .history th.location {
-                padding-left: 1.5em;
-            }
-            .history td {
-                white-space:nowrap;
-                max-width: 20em;
-                overflow: hidden;
-            }
-            .history td.location {
-                padding-left: 1.5em;
-                white-space: normal;
-            }
-            .history td.url {
-                padding-left: 1em;
-                white-space: normal;
-                word-break: all;
-            }
-            .history .date {
-                padding-left: 1em;
-            }
-            .history td.ip {white-space:nowrap;}
-            .history td.uid {white-space:nowrap;} */
-        </style>
     </head>
     <body class="history">
             <?php
@@ -113,16 +94,29 @@ if( $csv )
             ?>
             <div class="history_hed">
             <h1>Test History</h1>
-            
+
             <form name="filterLog" method="get" action="/testlog.php">
+
+<?php if (!$is_logged_in): ?>
             <div class="logged-out-history">
                 <p>Test history is available for up to 30 days as long as your storage isn’t cleared. By registering for a free account, you can keep test history for longer, compare tests, and review changes. Additionally, you will also be able to post on the <a href="https://forums.webpagetest.org">WebPageTest Forum</a> and contribute to the discussions there about features, test results and more.</p>
                     <a href="https://app.webpagetest.org/ui/entry/wpt/signup?utm_source=forum&utm_medium=forum&utm_campaign=signup&utm_content=signup" class="btn-primary">Get Free Access</a>
                 </div>
-                <div class="history_filter">
-                    <label for="filter">Filter test history:</label>
-                         <input id="filter" name="filter" type="text" onkeyup="filterHistory()" placeholder="Search">
-                </div>
+<?php endif; ?>
+              <div class="history_filter">
+                <label for="filter">Filter test history:</label>
+                <input id="filter" name="filter" type="text" onkeyup="filterHistory()" placeholder="Search">
+<?php if ($is_logged_in): ?>
+                <label for="days" class="a11y-hidden">Select how far back you want to see</label>
+                 <select name="days">
+                    <option value="1" <?php if ($days == 1) echo "selected"; ?>>1 Day</option>
+                    <option value="7" <?php if ($days == 7) echo "selected"; ?>>7 Days</option>
+                    <option value="30" <?php if ($days == 30) echo "selected"; ?>>30 Days</option>
+                    <option value="182" <?php if ($days == 182) echo "selected"; ?>>6 Months</option>
+                    <option value="365" <?php if ($days == 365) echo "selected"; ?>>1 Year</option>
+                  </select>
+<?php endif; ?>
+              </div>
             </form>
             </div>
             <div class="box">
@@ -141,6 +135,19 @@ if( $csv )
                             <th class="label">Label</th>
                         </tr>
                     </thead>
+<?php if ($is_logged_in): ?>
+                    <tbody id="historyBody">
+  <?php foreach($test_history as $record): ?>
+                      <tr>
+                        <th><input type="checkbox" name="t[]" value="<?= $record->getTestId() ?>" /></th>
+                        <td class="url"><a href="/result/<?= $record->getTestId() ?>/"><?= $record->getUrl() ?></a></td>
+                        <td class="date"><?= date_format(date_create($record->getStartTime()), 'M d, Y g:i:s A e') ?></td>
+                        <td class="location"><?= $record->getLocation() ?></td>
+                        <td class="label"><?= $record->getLabel() ?></td>
+                      </tr>
+  <?php endforeach; ?>
+                    </tbody>
+<?php endif; ?>
                 </table>
                 </div>
                 <?php
@@ -153,9 +160,17 @@ if( $csv )
                 ?>
                 </form>
             </div>
+
 <script>
-        <?php include(__DIR__ . '/js/history.js'); ?>
-        </script>
+<?php
+if ($is_logged_in):
+  include(__DIR__ . '/js/history-loggedin.js');
+else:
+  // if not logged in, build a local searchable test history from the data stored in indexeddb.
+  include(__DIR__ . '/js/history.js');
+endif;
+?>
+</script>
         <?php include('footer.inc'); ?>
     </body>
 </html>
@@ -187,7 +202,7 @@ exit;
                         <input id="filter" name="filter" type="text" style="width:30em" value="<?php echo htmlspecialchars($filter); ?>">
                         <input id="SubmitBtn" type="submit" value="Update List"><br>
                         <?php
-                        if( ($admin || !GetSetting('forcePrivate')) && (isset($uid) || (isset($owner) && strlen($owner))) ) { ?>
+                        if( ($admin || !Util::getSetting('forcePrivate')) && (isset($uid) || (isset($owner) && strlen($owner))) ) { ?>
                             <label><input id="all" type="checkbox" name="all" <?php check_it($all);?> onclick="this.form.submit();"> Show tests from all users</label> &nbsp;&nbsp;
                             <?php
                         }


### PR DESCRIPTION
This change allows our logged in users to take advantage of the same
page that our current logged out users use, except without the indexdb!

We had to change the order in which a few things were loaded, as well,
just so we could make sure the $owner global was set properly. We also
changed types to better match what CP was providing us