### PR TITLE
fix(config): change sessions so anybody can use it

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -12,7 +12,7 @@ use WebPageTest\User;
 use WebPageTest\RequestContext;
 use WebPageTest\Exception\ClientException;
 
-if (Util::getSetting('cp_auth')) {
+if (Util::getSetting('php_sessions')) {
   // Start session handling for this request
   session_start();
 }
@@ -36,6 +36,8 @@ if (Util::getSetting('cp_auth')) {
     }
     /*
      * for when we ship to prod
+     *
+     * error_log($e->getMessage);
      * throw $e;
      *
      */


### PR DESCRIPTION
Just turn on `php_sessions` and then you can use $_SESSION-based stuff
in your private instance or whatever.

Also, we're going to make sure we error log our errors before we have a
big blow out on 500s