### PR TITLE
fix(auth): force saml logout

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -225,7 +225,7 @@ $USER_EMAIL = null;
 // Supported Authentication types
 $supportsAuth = false;
 $supportsSaml = Util::getSetting('saml_login') !== false;
-$supportsCPAuth = Util::getSetting('cp_auth') !== false;
+$supportsCPAuth = Util::getSetting('cp_auth');
 $supportsGoogleOAuth = Util::getSetting('google_oauth_client_id') && Util::getSetting('google_oauth_client_secret');
 $supportsAuth = $supportsSaml || $supportsCPAuth || $supportsGoogleOAuth;
 

--- a/www/common/AttachClient.php
+++ b/www/common/AttachClient.php
@@ -12,6 +12,12 @@ use WebPageTest\Exception\UnauthorizedException;
 
     $host = Util::getSetting('host');
 
+    /**
+     * Force logout for old users. Remove this at end of June 2022
+     */
+    $saml_cookie = Util::getSetting('saml_cookie', 'samlu');
+    setcookie($saml_cookie, "", time() - 3600, '/', $host);
+
     $client = new CPClient(Util::getSetting('cp_services_host'), array(
         'auth_client_options' => array(
             'base_uri' => Util::getSetting('cp_auth_host'),

--- a/www/cpauth/logout.php
+++ b/www/cpauth/logout.php
@@ -37,6 +37,7 @@ use WebPageTest\RequestContext;
         setcookie($cp_refresh_token_cookie_name, "", time() - 3600, "/", $host);
     }
 
+    header('Clear-Site-Data: "cache", "cookies", "storage", "executionContexts"');
     header("Location: {$redirect_uri}");
     exit();
 })($request_context);


### PR DESCRIPTION
NOTE: THIS IS FOR RIGHT WHEN WE FLIP TO cp_auth

Make sure people don't have cookies for both sets of auth at the same
time.

Also make it so cpauth logout clears all site data.