### PR TITLE
feat(signup): smooth out error experience

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -19,24 +19,24 @@ if (Util::getSetting('php_sessions')) {
 
 $client_error = null;
 if (Util::getSetting('cp_auth')) {
-  $client_error = $_SESSION['client_error'] ?? null;
-  unset($_SESSION['client_error']);
+    $client_error = $_SESSION['client_error'] ?? null;
+    unset($_SESSION['client_error']);
 
-  set_exception_handler(function($e) {
-    if(is_a($e, ClientException::class)) {
-     $route = $e->getRoute();
-     $message = $e->getMessage();
-     $host = Util::getSetting('host');
-     unset($_SESSION['client_error']);
-     $_SESSION['client_error'] = $message;
-     $protocol = "https";
-     $location = "{$protocol}://{$host}{$route}";
-     header('Location: ' . $location);
-     exit();
-    }
-    error_log($e->getMessage);
-    throw $e;
-  });
+    set_exception_handler(function($e) {
+        if(is_a($e, ClientException::class)) {
+            $route = $e->getRoute();
+            $message = $e->getMessage();
+            $host = Util::getSetting('host');
+            unset($_SESSION['client_error']);
+            $_SESSION['client_error'] = $message;
+            $protocol = "https";
+            $location = "{$protocol}://{$host}{$route}";
+            header('Location: ' . $location);
+            exit();
+        }
+        error_log($e->getMessage);
+        throw $e;
+    });
 }
 
 // Load local deps

--- a/www/cpauth/signup.php
+++ b/www/cpauth/signup.php
@@ -43,18 +43,29 @@ use WebPageTest\Handlers\Signup as SignupHandler;
             case 3:
               // gather post body
                 $body = SignupHandler::validatePostStepThree();
+
+                // Save in session values in case somebody has an error
+                $_SESSION['signup-street-address'] = $body->street_address;
+                $_SESSION['signup-city'] = $body->city;
+                $_SESSION['signup-state'] = $body->state;
+                $_SESSION['signup-zipcode'] = $body->zipcode;
+
                 $redirect_uri = SignupHandler::postStepThree($request_context, $body);
 
-              // unset values
+                // unset values
                 unset($_SESSION['signup-first-name']);
                 unset($_SESSION['signup-last-name']);
                 unset($_SESSION['signup-company-name']);
                 unset($_SESSION['signup-email']);
                 unset($_SESSION['signup-password']);
                 unset($_SESSION['signup-plan']);
+                unset($_SESSION['signup-street-address']);
+                unset($_SESSION['signup-city']);
+                unset($_SESSION['signup-state']);
+                unset($_SESSION['signup-zipcode']);
 
 
-              // send to account page
+                // send to account page
                 header("Location: {$redirect_uri}");
                 break;
             default: // step 1 or whatever somebody tries to send

--- a/www/css/account.css
+++ b/www/css/account.css
@@ -762,6 +762,12 @@ body.theme-b {
     cursor: pointer;
 }
 
+.signup-flow-layout .form-input button[type=submit]:disabled,
+.signup-button:disabled {
+    cursor: auto;
+}
+
+
 a.button {
     text-decoration: none;
     display: block;

--- a/www/header.inc
+++ b/www/header.inc
@@ -48,7 +48,7 @@ if (!defined('EMBED')) {
 <?php
 $alert = Util::getSetting('alert');
 if (isset($client_error)) {
-  echo '<div class="error-banner">' . $alert . '</div>';
+  echo '<div class="error-banner">' . $client_error . '</div>';
 } elseif ($alert) {
   echo '<div class="alert-banner">' . $alert . '</div>';
 }

--- a/www/templates/account/signup/step-3.php
+++ b/www/templates/account/signup/step-3.php
@@ -9,16 +9,16 @@
         <div class="form-input address">
           <label for="street-address">Street Address</label>
           <div>
-            <input name="street-address" type="text" required />
+          <input name="street-address" type="text" value="<?= $street_address ?>" required />
           </div>
         </div>
         <div class="form-input city">
           <label for="city">City</label>
-          <input name="city" type="text" required />
+          <input name="city" type="text" value="<?= $city ?>" required />
         </div>
         <div class="form-input state">
           <label for="state">State</label>
-          <input name="state" type="text" required />
+          <input name="state" type="text" value="<?= $state ?>" required />
         </div>
         <div class="form-input country">
           <label for="country">Country</label>
@@ -31,7 +31,7 @@
         <div class="form-input zip">
           <label for="zipcode">Postal Code</label>
           <div>
-            <input type="text" name="zipcode" required />
+            <input type="text" name="zipcode" value="<?= $zipcode ?>" required />
           </div>
         </div>
       </div> <!-- /.billing-address-information-container -->
@@ -66,15 +66,15 @@
             <tbody>
                 <tr>
                     <?php if ($is_plan_free) : ?>
-                    <td>300</td>
-                    <td>Free</td>
+                        <td>300</td>
+                        <td>Free</td>
                     <?php else : ?>
-                    <td><?= $runs ?></td>
-                    <?php if ($billing_frequency == "Monthly") : ?>
-                    <td>$<?= "{$monthly_price} {$billing_frequency}" ?></td>
-                    <?php else : ?>
-                    <td><s>$<?= $other_annual ?></s> $<?= "{$annual_price} {$billing_frequency}" ?></td>
-                    <?php endif; ?>
+                        <td><?= $runs ?></td>
+                        <?php if ($billing_frequency == "Monthly") : ?>
+                        <td>$<?= "{$monthly_price} {$billing_frequency}" ?></td>
+                        <?php else : ?>
+                        <td><s>$<?= $other_annual ?></s> $<?= "{$annual_price} {$billing_frequency}" ?></td>
+                        <?php endif; ?>
                     <?php endif; ?>
                 </tr>
             </tbody>
@@ -110,10 +110,17 @@
 
       form.addEventListener('submit', function (event) {
         event.preventDefault();
+        var button = event.target.querySelector('button[type=submit]');
+        button.disabled = true;
+        button.setAttribute('disabled', 'disabled');
+        button.innerText = 'Submitted';
 
         dropinInstance.requestPaymentMethod(function (err, payload) {
           if (err) {
             // handle error
+            button.disabled = false;
+            button.removeAttribute('disabled');
+            button.innerText = 'Sign Up';
             console.error(err);
             return;
           }

--- a/www/templates/layouts/account.php
+++ b/www/templates/layouts/account.php
@@ -10,7 +10,7 @@ global $supportsSaml;
 global $supportsCPAuth;
 global $request_context;
 global $_SESSION;
-global $notification_alert;
+global $client_error;
 global $VER_CSS;
 
 $page_title = $page_title ? $page_title : 'WebPageTest';

--- a/www/templates/layouts/default.php
+++ b/www/templates/layouts/default.php
@@ -10,7 +10,7 @@ global $supportsSaml;
 global $supportsCPAuth;
 global $request_context;
 global $_SESSION;
-global $notification_alert;
+global $client_error;
 
 $page_title = $page_title ? $page_title : 'WebPageTest';
 ?>

--- a/www/templates/layouts/header.inc
+++ b/www/templates/layouts/header.inc
@@ -56,7 +56,7 @@ if (!defined('EMBED')) {
 <?php
 $alert = Util::getSetting('alert');
 if (isset($client_error)) {
-  echo '<div class="error-banner">' . $alert . '</div>';
+  echo '<div class="error-banner">' . $client_error . '</div>';
 } elseif ($alert) {
   echo '<div class="alert-banner">' . $alert . '</div>';
 }

--- a/www/templates/layouts/signup-flow-step-1.php
+++ b/www/templates/layouts/signup-flow-step-1.php
@@ -10,7 +10,7 @@ global $supportsSaml;
 global $supportsCPAuth;
 global $request_context;
 global $_SESSION;
-global $notification_alert;
+global $client_error;
 
 $page_title = $page_title ? $page_title : 'WebPageTest';
 ?>

--- a/www/templates/layouts/signup-flow.php
+++ b/www/templates/layouts/signup-flow.php
@@ -10,7 +10,7 @@
       global $USER_EMAIL;
       global $supportsAuth;
       global $supportsSaml;
-      global $notification_alert;
+      global $client_error;
 
       $page_title = $page_title ? $page_title : 'WebPageTest';
       ?>
@@ -20,12 +20,14 @@
 </head>
 
 <body>
-    <?php
-      $alert = $notification_alert ?? Util::getSetting('alert');
-      if ($alert) {
-            echo '<div class="alert-banner">' . $alert . '</div>';
-      }
-      ?>
+<?php
+$alert = Util::getSetting('alert');
+if (isset($client_error)) {
+  echo '<div class="error-banner">' . $client_error . '</div>';
+} elseif ($alert) {
+  echo '<div class="alert-banner">' . $alert . '</div>';
+}
+?>
     <wpt-header>
         <header>
             <a class="wptheader_logo" href="/">


### PR DESCRIPTION
This allows for an error to pop up at the top of the page when one is
called for during the signup experience. It also fills the information
back in when somebody has an error so they don't have to re-enter it.
It also disables the signup button while submission is happening so
people don't think there's something left to do.