### PR TITLE
fix(testlog): make test history more resilient

### DIFF
--- a/www/testlog.php
+++ b/www/testlog.php
@@ -6,7 +6,9 @@ include 'common.inc';
 
 use WebPageTest\Util;
 
-if ($admin || $privateInstall) {
+$is_logged_in = Util::getSetting('cp_auth') && (!is_null($request_context->getClient()) && $request_context->getClient()->isAuthenticated());
+
+if ($admin || $privateInstall || $is_logged_in) {
     set_time_limit(0);
 } else {
     set_time_limit(60);
@@ -18,14 +20,13 @@ if ($userIsBot || Util::getSetting('disableTestlog')) {
 }
 
 $test_history = [];
-$is_logged_in = Util::getSetting('cp_auth') && (!is_null($request_context->getClient()) && $request_context->getClient()->isAuthenticated());
 $days = (int)$_GET["days"];
 
 if ($is_logged_in) {
   $test_history = $request_context->getClient()->getTestHistory($days);
 }
 
-// Redirect logged-in users to the hosted test history if one is configured
+// Redirect logged-in saml users to the hosted test history if one is configured
 if (!$is_logged_in && (isset($USER_EMAIL) && Util::getSetting('history_url') && !isset($_REQUEST['local']))) {
     header('Location: ' . Util::getSetting('history_url'));
     exit;


### PR DESCRIPTION
This is a test. We're trying to figure out why test history keeps going
down bigger queries or queries in general.

This involves removing the time limit on the page for logged in users
while simultaneously setting a large timeout for the backend calls.
We're also making the query and things around it a bit more resilient