### PR TITLE
fix(account): WPT Enterprise

### DIFF
--- a/www/common/AttachUser.php
+++ b/www/common/AttachUser.php
@@ -36,6 +36,7 @@ use WebPageTest\Exception\UnauthorizedException;
             $user->setPaid($data['activeContact']['isWptPaidUser']);
             $user->setVerified($data['activeContact']['isWptAccountVerified']);
             $user->setOwnerId($data['levelSummary']['levelId']);
+            $user->setEnterpriseClient(!!$data['levelSummary']['isWptEnterpriseClient']);
             $owner = $user->getOwnerId();
         } catch (UnauthorizedException $e) {
             error_log($e->getMessage());

--- a/www/cpauth/account.php
+++ b/www/cpauth/account.php
@@ -92,6 +92,7 @@ if ($request_method === 'POST') {
 
     $is_paid = $request_context->getUser()->isPaid();
     $is_verified = $request_context->getUser()->isVerified();
+    $is_wpt_enterprise = $request_context->getUser()->isWptEnterpriseClient();
     $user_id = $request_context->getUser()->getUserId();
     $user_contact_info = $request_context->getClient()->getUserContactInfo($user_id);
     $user_email = $request_context->getUser()->getEmail();
@@ -115,7 +116,11 @@ if ($request_method === 'POST') {
     $country_list = Util::getCountryList();
 
     if ($is_paid) {
-        $billing_info = $request_context->getClient()->getPaidAccountPageInfo();
+        if ($is_wpt_enterprise) {
+            $billing_info = $request_context->getClient()->getPaidEnterpriseAccountPageInfo();
+        } else {
+            $billing_info = $request_context->getClient()->getPaidAccountPageInfo();
+        }
         $customer_details = $billing_info['braintreeCustomerDetails'];
         $billing_frequency = $customer_details['billingFrequency'] == 12 ? "Annually" : "Monthly";
 
@@ -129,6 +134,7 @@ if ($request_method === 'POST') {
             $billing_info['plan_renewal'] = $plan_renewal_date->format('m/d/Y');
         }
 
+        $billing_info['is_wpt_enterprise'] = $is_wpt_enterprise;
         $billing_info['is_canceled'] = str_contains($customer_details['status'], 'CANCEL');
         $billing_info['billing_frequency'] = $billing_frequency;
         $client_token = $billing_info['braintreeClientToken'];

--- a/www/src/CPClient.php
+++ b/www/src/CPClient.php
@@ -175,6 +175,7 @@ class CPClient
                     'levelId',
                     'levelType',
                     'levelName',
+                    'isWptEnterpriseClient'
                   ])
               ]);
 
@@ -289,6 +290,53 @@ class CPClient
               ])
         ]);
 
+        try {
+            $results = $this->graphql_client->runQuery($gql, true);
+            return $results->getData();
+        } catch (QueryError $e) {
+            throw new ClientException(implode(",", $e->getErrorDetails()));
+        }
+    }
+
+    public function getPaidEnterpriseAccountPageInfo(): array
+    {
+          $gql = (new Query())
+          ->setSelectionSet([
+            'braintreeClientToken',
+            (new Query('wptApiKey'))
+              ->setSelectionSet([
+                'id',
+                'name',
+                'apiKey',
+                'createDate',
+                'changeDate'
+              ]),
+            (new Query('braintreeCustomerDetails'))
+                ->setSelectionSet([
+                    'customerId',
+                    'wptPlanId',
+                    'subscriptionId',
+                    'ccLastFour',
+                    'daysPastDue',
+                    'subscriptionPrice',
+                    'maskedCreditCard',
+                    'nextBillingDate',
+                    'billingPeriodEndDate',
+                    'numberOfBillingCycles',
+                    'ccExpirationDate',
+                    'ccImageUrl',
+                    'status',
+                    (new Query('discount'))
+                      ->setSelectionSet([
+                        'amount',
+                        'numberOfBillingCycles'
+                      ]),
+                    'remainingRuns',
+                    'planRenewalDate',
+                    'billingFrequency',
+                    'wptPlanName'
+                ])
+          ]);
         try {
             $results = $this->graphql_client->runQuery($gql, true);
             return $results->getData();

--- a/www/src/User.php
+++ b/www/src/User.php
@@ -13,6 +13,7 @@ class User
     private ?int $user_id;
     private bool $is_paid_and_in_good_standing;
     private bool $is_verified;
+    private bool $is_wpt_enterprise_client;
 
     public function __construct()
     {
@@ -23,6 +24,7 @@ class User
         $this->user_id = null;
         $this->is_paid_and_in_good_standing = false;
         $this->is_verified = false;
+        $this->is_wpt_enterprise_client = false;
     }
 
     public function getEmail(): ?string
@@ -119,5 +121,15 @@ class User
     public function setVerified(bool $is_verified): void
     {
         $this->is_verified = $is_verified;
+    }
+
+    public function isWptEnterpriseClient(): bool
+    {
+        return $this->is_wpt_enterprise_client;
+    }
+
+    public function setEnterpriseClient(bool $is_wpt_enterprise_client): void
+    {
+        $this->is_wpt_enterprise_client = $is_wpt_enterprise_client;
     }
 }

--- a/www/templates/account/includes/billing-data.php
+++ b/www/templates/account/includes/billing-data.php
@@ -44,6 +44,7 @@
   </div>
 </div>
 
+<?php if (!$is_wpt_enterprise): ?>
 <div class="card billing-history">
   <div class="info">
     <table class="sortable">
@@ -92,6 +93,7 @@
     </table>
   </div>
 </div>
+<?php endif;// (!$is_wpt_enterprise): ?>
 
 <div class="card api-consumers">
   <h3>API Consumers</h3>


### PR DESCRIPTION
If a user is WPT Enterprise, they do not have a braintree id and thus
get access denied when querying for braintree transaction history. This
is bad because our graphql client blows up on ANY errors existing.

So, let's make a different query if somebody is wpt enterprise to not
query for that if they are