### PR TITLE
For testing Only: this is to capture the first host that is a successful response and not a redirect.

### DIFF
--- a/www/experiments.php
+++ b/www/experiments.php
@@ -175,6 +175,9 @@ $page_description = "Website performance test result$testLabel.";
                         $hmac = sha1($hashStr);
                         echo "<input type=\"hidden\" name=\"vh\" value=\"$hmac\">\n";
                     }
+                    
+                    // this is to capture the first host that is a successful response and not a redirect. that'll be the one we want to override in an experiment
+                    echo '<input type="hidden" name="initialHostNonRedirect" value="'. $initialHost .'">';
 
                     // used for tracking exp access
                     $expCounter = 0;

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -836,9 +836,10 @@ use WebPageTest\RateLimiter;
 
                   if( !$experiments_logged_in && !$experimentUrlException ){
                     $error = "Must be logged in to use experiments.";
-                  } else {               
-
-                    $test['script'] = "overrideHost\t%HOST%\t$experimentURL\r\n";
+                  } else { 
+                    // the first non-redirect host is passed in from experiments
+                    $hostToUse = isset( $req_initialHostNonRedirect ) ? $req_initialHostNonRedirect : '%HOST%';
+                    $test['script'] = "overrideHost\t". $hostToUse ."\t$experimentURL\r\n";
                     $scriptNavigate = "navigate\t%URL%\r\n";
                     $test['script'] .= $scriptNavigate;
                     


### PR DESCRIPTION
That'll be the one we want to override in an experiment.

use case is to run a metric times test without the www and see if it runs experiments on the eventual www url as it should.