### PR TITLE
Remove troublesome class from images table on images page

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -176,7 +176,7 @@ if (!$privateInstall) {
 
 // constants
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
-define('VER_CSS', '173.56');                // version of the sitewide css file
+define('VER_CSS', '173.57');                // version of the sitewide css file
 define('VER_JS', 41);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page

--- a/www/pageimages.php
+++ b/www/pageimages.php
@@ -67,7 +67,7 @@ $userImages = true;
         }
         ?>
         <p>Images are currently being served from the given URL, and might not necessarily match what was loaded at the time of the test.</p>
-        <div class="scrollableTable"><table class="images pretty">
+        <div class="scrollableTable"><table class="images">
           <?php
           foreach( $requests as &$request ) {
             if( array_key_exists('contentType', $request) &&

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -2786,6 +2786,7 @@ video:focus {
 
 .images td {
     overflow-x: auto;
+    text-align: left;
 }
 
 .images td:first-child {


### PR DESCRIPTION
This fixes #1944 by removing the unnecessary class on the images table and tweaking the CSS slightly.