### PR TITLE
Cancel tests interstitial

### DIFF
--- a/www/cancelTest.php
+++ b/www/cancelTest.php
@@ -1,84 +1,80 @@
 <?php
+
 // Copyright 2020 Catchpoint Systems Inc.
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 include 'common.inc';
 set_time_limit(30000);
 
-if( isset($test['test']) )
-{
-    if( $test['test']['batch'] )
-    {
+if (isset($test['test'])) {
+    if ($test['test']['batch']) {
         $count = 0;
         $tests = null;
-        if( gz_is_file("$testPath/tests.json") )
-        {
+        if (gz_is_file("$testPath/tests.json")) {
             $legacyData = json_decode(gz_file_get_contents("$testPath/tests.json"), true);
             $tests = array();
             $tests['variations'] = array();
             $tests['urls'] = array();
-            foreach( $legacyData as &$legacyTest )
+            foreach ($legacyData as &$legacyTest)
                 $tests['urls'][] = array('u' => $legacyTest['url'], 'id' => $legacyTest['id']);
-        }
-        elseif( gz_is_file("$testPath/bulk.json") )
+        } elseif (gz_is_file("$testPath/bulk.json")) {
             $tests = json_decode(gz_file_get_contents("$testPath/bulk.json"), true);
-        if( isset($tests) )
-        {
-            foreach( $tests['urls'] as &$testData )
-            {
-                if( CancelTest($testData['id']) )
+        }
+        if (isset($tests)) {
+            foreach ($tests['urls'] as &$testData) {
+                if (CancelTest($testData['id'])) {
                     $count++;
-
-                foreach( $testData['v'] as $variationIndex => $variationId )
-                {
-                    if( CancelTest($variationId) )
+                }
+                foreach ($testData['v'] as $variationIndex => $variationId) {
+                    if (CancelTest($variationId)) {
                         $count++;
+                    }
                 }
             }
         }
         echo "<h3 align=\"center\">$count Test(s) cancelled!</h3>";
-    }
-    else
-    {
-        if( CancelTest($id) )
+    } else {
+        if (CancelTest($id)) {
             echo '<h3 align="center">Test cancelled!</h3>';
-        else
-          echo '<h3>Sorry, the test could not be cancelled.  It might have already started or been cancelled</h3>';
+        } else {
+            echo '<h3>Sorry, the test could not be cancelled.  It might have already started or been cancelled</h3>';
+        }
     }
     echo '<form><input type="button" value="Back" onClick="history.go(-1);return true;"> </form>';
 }
 
 /**
-* Cancel and individual test
-*
-* @param mixed $id
-* @return bool
-*/
+ * Cancel and individual test
+ *
+ * @param mixed $id
+ * @return bool
+ */
 function CancelTest($id)
 {
-  $cancelled = false;
-  $lock = LockTest($id);
-  if ($lock) {
-    $testInfo = GetTestInfo($id);
-    if ($testInfo && !array_key_exists('started', $testInfo)) {
-      $testInfo['cancelled'] = time();
-      SaveTestInfo($id, $testInfo);
+    $cancelled = false;
+    $lock = LockTest($id);
+    if ($lock) {
+        $testInfo = GetTestInfo($id);
+        if ($testInfo && !array_key_exists('started', $testInfo)) {
+            $testInfo['cancelled'] = time();
+            SaveTestInfo($id, $testInfo);
 
-      // delete the actual test file.
-      if (array_key_exists('workdir', $testInfo)) {
-        $ext = 'url';
-        if( $testInfo['priority'] )
-            $ext = "p{$testInfo['priority']}";
-        $file_to_search = $testInfo['workdir'] . "/*.$id.$ext";
-        $found_files = glob($file_to_search);
-        if (1 === count($found_files))
-          $cancelled = @unlink($found_files[0]);
-      }
-      $testInfo['id'] = $id;
-      SendCallback($testInfo);
+            // delete the actual test file.
+            if (array_key_exists('workdir', $testInfo)) {
+                $ext = 'url';
+                if ($testInfo['priority']) {
+                    $ext = "p{$testInfo['priority']}";
+                }
+                $file_to_search = $testInfo['workdir'] . "/*.$id.$ext";
+                $found_files = glob($file_to_search);
+                if (1 === count($found_files)) {
+                    $cancelled = @unlink($found_files[0]);
+                }
+            }
+            $testInfo['id'] = $id;
+            SendCallback($testInfo);
+        }
+        UnlockTest($lock);
     }
-    UnlockTest($lock);
-  }
-  return $cancelled;
+    return $cancelled;
 }
-?>

--- a/www/cancelTest.php
+++ b/www/cancelTest.php
@@ -37,7 +37,9 @@ if (isset($test['test'])) {
         if (CancelTest($id)) {
             echo '<h3 align="center">Test cancelled!</h3>';
         } else {
-            echo '<h3>Sorry, the test could not be cancelled.  It might have already started or been cancelled</h3>';
+            if (isset($_SERVER["HTTP_REFERER"])) {
+                header("Location: " . $_SERVER["HTTP_REFERER"]);
+            }
         }
     }
     echo '<form><input type="button" value="Back" onClick="history.go(-1);return true;"> </form>';

--- a/www/cancelTest.php
+++ b/www/cancelTest.php
@@ -15,8 +15,9 @@ if (isset($test['test'])) {
             $tests = array();
             $tests['variations'] = array();
             $tests['urls'] = array();
-            foreach ($legacyData as &$legacyTest)
+            foreach ($legacyData as &$legacyTest) {
                 $tests['urls'][] = array('u' => $legacyTest['url'], 'id' => $legacyTest['id']);
+            }
         } elseif (gz_is_file("$testPath/bulk.json")) {
             $tests = json_decode(gz_file_get_contents("$testPath/bulk.json"), true);
         }


### PR DESCRIPTION
I dislike this fix :/ 

Instead of showing this:
![Screen Shot 2022-06-07 at 2 03 12 PM](https://user-images.githubusercontent.com/607541/172482176-9d44c587-003b-46d0-ae3a-1e2630d6454d.png)

it just refreshes the page which will show the page you see when you click on your test history link to a cancelled test
![Screen Shot 2022-06-07 at 2 03 41 PM](https://user-images.githubusercontent.com/607541/172482297-b9607455-84af-4e09-bedc-19614bf8e1a2.png)

