### PR TITLE
feat(client): gather test runs

### DIFF
--- a/www/src/TestRecord.php
+++ b/www/src/TestRecord.php
@@ -17,6 +17,7 @@ class TestRecord implements \JsonSerializable
     private string $test_start_time;
     private string $user;
     private ?string $api_key;
+    private int $test_runs;
 
     public function __construct(array $options = [])
     {
@@ -28,6 +29,7 @@ class TestRecord implements \JsonSerializable
         $this->test_start_time = $options['testStartTime'] ?? '';
         $this->user = $options['user'] ?? '';
         $this->api_key = $options['apiKey'] ?? null;
+        $this->test_runs = $options['testRuns'] ?? 1;
     }
 
     public function getId(): int
@@ -70,6 +72,11 @@ class TestRecord implements \JsonSerializable
         return $this->api_key;
     }
 
+    public function getTestRuns(): int
+    {
+        return $this->test_runs;
+    }
+
     public function jsonSerialize(): array
     {
         return [
@@ -80,7 +87,8 @@ class TestRecord implements \JsonSerializable
         'label' => $this->label,
         'testStartTime' => $this->test_start_time,
         'user' => $this->user,
-        'apiKey' => $this->api_key
+        'apiKey' => $this->api_key,
+        'testRuns' => $this->test_runs
         ];
     }
 }

--- a/www/src/Util.php
+++ b/www/src/Util.php
@@ -366,6 +366,7 @@ class Util
 
         return $countryList;
     }
+
     /**
      * Helper method to get the number of runs of a test to enforce limits
      *
@@ -380,5 +381,13 @@ class Util
             $total_runs++;
         }
         return $total_runs;
+    }
+
+    /**
+     * This is used to determine which hosts don't get counted in test runs
+     */
+    public static function getExemptHost(): string
+    {
+        return 'webpagetest.org';
     }
 }


### PR DESCRIPTION
This allows us to both see how many test runs were part of each test and
to also gather how many runs somebody has made since a certain time.
This makes for easier output for billing