### PR TITLE
fix(js): break caching on account js

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -183,6 +183,7 @@ define('VER_BUTTON_CSS', @md5_file(__DIR__ . '/css/button.css'));   // version o
 define('VER_JS', 41);                 // version of the sitewide javascript file
 define('VER_JS_TEST', 47);            // version of the javascript specific to the test pages
 define('VER_JS_RUNNING', 1);          // version of the javascript specific to the test running status page
+define('VER_JS_ACCOUNT', @md5_file(__DIR__ . '/js/account.js'));          // version of the javascript specific to the test running status page
 define('UNKNOWN_TIME', -1);           // Value used as a flag for an unknown time.
                                       // To find code that fails to check that a time
                                       // is unknown, change this constant to a large

--- a/www/templates/layouts/account.php
+++ b/www/templates/layouts/account.php
@@ -20,7 +20,7 @@
     <?php require_once __DIR__ . '/head.inc'; ?>
     <link rel="stylesheet" href="/css/button.css?v=<?= constant('VER_BUTTON_CSS') ?>" />
     <link rel="stylesheet" href="/css/account.css?v=<?= constant('VER_ACCOUNT_CSS') ?>" />
-    <script defer src="/js/account.js"></script>
+    <script defer src="/js/account.js?v=<?= constant('VER_JS_ACCOUNT') ?>"></script>
 </head>
 <body>
     <?php require_once __DIR__ . '/header.inc'; ?>


### PR DESCRIPTION
We should automate cache busting for account js (we should do this for all of them, but this is a good starter)