### PR TITLE
Request details legend consistent with other legends

### DIFF
--- a/www/include/RequestDetailsHtmlSnippet.php
+++ b/www/include/RequestDetailsHtmlSnippet.php
@@ -33,8 +33,7 @@ class RequestDetailsHtmlSnippet {
   }
 
   private function _createLegend() {
-    $out = '<table border="1" bordercolor="silver" cellpadding="2px" cellspacing="0" ' .
-           'style="width:auto; font-size:11px; margin-left:auto; margin-right:auto;">';
+    $out = '<table class="waterfall-legend">';
     $out .= "\n<tbody>\n<tr>\n";
     $out .= $this->_createLegendCell("#dfffdf", "Before Start Render");
     $out .= $this->_createLegendCell("#dfdfff", "Before On Load");


### PR DESCRIPTION
### before:
<img width="669" alt="Screen Shot 2022-07-06 at 11 10 58 AM" src="https://user-images.githubusercontent.com/51308/177619318-e9e5c78e-e972-4bbb-9661-243cdaf27961.png">

### after:
<img width="746" alt="Screen Shot 2022-07-06 at 11 35 29 AM" src="https://user-images.githubusercontent.com/51308/177619474-ae43cd62-57aa-4b02-9af0-7098554d602d.png">

