### PR TITLE
Auth improvements

### DIFF
--- a/www/common/AttachClient.php
+++ b/www/common/AttachClient.php
@@ -12,12 +12,6 @@ use WebPageTest\Exception\UnauthorizedException;
 
     $host = Util::getSetting('host');
 
-    /**
-     * Force logout for old users. Remove this at end of June 2022
-     */
-    $saml_cookie = Util::getSetting('saml_cookie', 'samlu');
-    setcookie($saml_cookie, "", time() - 3600, '/', $host);
-
     $client = new CPClient(Util::getSetting('cp_services_host'), array(
         'auth_client_options' => array(
             'base_uri' => Util::getSetting('cp_auth_host'),

--- a/www/cpauth/account.php
+++ b/www/cpauth/account.php
@@ -26,7 +26,8 @@ if (is_null($access_token)) {
     $protocol = $request_context->getUrlProtocol();
     $host = Util::getSetting('host');
     $route = '/login';
-    $redirect_uri = "{$protocol}://{$host}{$route}?redirect_uri={$protocol}://{$host}/account";
+    $query = http_build_query(["redirect_uri" => "/account"]);
+    $redirect_uri = "{$protocol}://{$host}{$route}?{$query}";
 
     header("Location: {$redirect_uri}");
     exit();

--- a/www/cpauth/login.php
+++ b/www/cpauth/login.php
@@ -6,9 +6,10 @@ require_once __DIR__ . '/../common.inc';
 
 use WebPageTest\Util;
 
+$host = Util::getSetting('host');
+
 if (!Util::getSetting('cp_auth')) {
     $protocol = $request_context->getUrlProtocol();
-    $host = Util::getSetting('host');
     $route = '/';
     $redirect_uri = "{$protocol}://{$host}{$route}";
 
@@ -17,7 +18,7 @@ if (!Util::getSetting('cp_auth')) {
 }
 
 $auth_host = Util::getSetting('cp_auth_host');
-$redirect_uri = "$auth_host/auth/WptAccount/Login";
+$redirect_uri = "{$auth_host}/auth/WptAccount/Login?ReturnUrl=https://{$host}/cpauth";
 
 header("Location: $redirect_uri");
 exit();

--- a/www/cpauth/login.php
+++ b/www/cpauth/login.php
@@ -17,6 +17,17 @@ if (!Util::getSetting('cp_auth')) {
     exit();
 }
 
+if (isset($_GET['redirect_uri'])) {
+    $comeback_route = $_GET['redirect_uri'];
+    setcookie(
+        Util::getCookieName('comeback_route'),
+        htmlspecialchars($comeback_route, ENT_QUOTES),
+        time() + 3600,
+        "/",
+        $host
+    );
+}
+
 $auth_host = Util::getSetting('cp_auth_host');
 $redirect_uri = "{$auth_host}/auth/WptAccount/Login?ReturnUrl=https://{$host}/cpauth";
 

--- a/www/cpauth/oauth.php
+++ b/www/cpauth/oauth.php
@@ -53,7 +53,14 @@ use WebPageTest\RequestContext;
     setcookie($cp_access_token_cookie_name, $auth_token->access_token, time() + $auth_token->expires_in, "/", $host);
     setcookie($cp_refresh_token_cookie_name, $auth_token->refresh_token, time() + 60 * 60 * 24 * 30, "/", $host);
 
-    header("Location: {$protocol}://{$host}");
+    $redirect_uri = "{$protocol}://{$host}";
+
+    if (isset($_COOKIE[Util::getCookieName('comeback_route')])) {
+        $redirect_uri .= htmlspecialchars($_COOKIE[Util::getCookieName('comeback_route')], ENT_QUOTES);
+        setcookie(Util::getCookieName('comeback_route'), "", time() - 3600, "/", $host);
+    }
+
+    header("Location: {$redirect_uri}");
 
     exit();
 })($request_context);

--- a/www/cpauth/signup.php
+++ b/www/cpauth/signup.php
@@ -114,6 +114,18 @@ use WebPageTest\Handlers\Signup as SignupHandler;
     $vars['is_plan_free'] = $is_plan_free;
     $vars['step'] = $signup_step;
 
+    $host = Util::getSetting('host');
+    if (isset($_GET['redirect_uri'])) {
+        $comeback_route = $_GET['redirect_uri'];
+        setcookie(
+            Util::getCookieName('comeback_route'),
+            htmlspecialchars($comeback_route, ENT_QUOTES),
+            time() + 3600,
+            "/",
+            $host
+        );
+    }
+
     switch ($signup_step) {
         case 2:
             echo SignupHandler::getStepTwo($request_context, $vars);


### PR DESCRIPTION
This PR has 3 different auth improvements:

1) Add ReturnUrl to our login redirect to the CP side. This allows use the authentication service to redirect back to a WHITELISTED url of our choice.

2) Remove the samlu saml cookie clearer. We don't use this cookie anymore. We don't have this login type anymore. It's been more than 30 days. It should've expired for everybody anyway.

3). If we're redirecting somebody to a login or signup flow, we can add redirect_uri to that and they'll come back to that path when they are finished instead of just the home page.