### PR TITLE
Check for fetchPriority on LCP image before showing experiment

### DIFF
--- a/www/experiments/lcp.inc
+++ b/www/experiments/lcp.inc
@@ -53,7 +53,7 @@
                         $isBG = true;
                     }
                 }
-                
+
 
                 $expsToAdd = array();
                 $expsToAdd[] = (object) [
@@ -64,10 +64,8 @@
                     "expval" => array($lcpSource . "|as_image"),
                     "explabel" => array($lcpSource)
                 ];
-
-                
                 // priority Hints only help for foreground images
-                if( !$isBG && !$isVideo ){
+                if( !$isBG && !$isVideo && isset( $lcp['element']['fetchPriority']) && $lcp['element']['fetchPriority'] != 'high' ){
                     $expsToAdd[] = (object) [
                         "id" => '011',
                         'title' => 'Add Priority Hint',


### PR DESCRIPTION
fixes #2108 by not showing the experiment for adding fetchpriority experiment for an LCP image if there's one already in place