### PR TITLE
this fixes #2132 for basic auth specifically, but is not yet optimized. This logic could stand to be central and shared

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -925,6 +925,16 @@ else {
                             $recipeScript .= ";";
                         }
                     }
+                    
+                    // Handle HTTP Basic Auth
+                    // TODO centralize this logic as it's borrowed from above temporarily
+                    if ((isset($test['login']) && strlen($test['login'])) || (isset($test['password']) && strlen($test['password']))) {
+                        $header = "Authorization: Basic " . base64_encode("{$test['login']}:{$test['password']}");
+                        if (!isset($script) || !strlen($script))
+                            $script = "navigate\t$url";
+                        $script = "addHeader\t$header\r\n" . $script;
+                    }
+                    // END TODO centralize this logic as it's borrowed from above temporarily
 
 
 

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -934,6 +934,17 @@ else {
                             $script = "navigate\t$url";
                         $script = "addHeader\t$header\r\n" . $script;
                     }
+                    // Add custom headers
+                    if (isset($test['customHeaders']) && strlen($test['customHeaders'])) {
+                        if (!isset($script) || !strlen($script))
+                            $script = "navigate\t$url";
+                        $headers = preg_split("/\r\n|\n|\r/", $test['customHeaders']);
+                        $headerCommands = "";
+                        foreach ($headers as $header) {
+                            $headerCommands = $headerCommands . "addHeader\t" . $header . "\r\n";
+                        }
+                        $script = $headerCommands . $script;
+                    }
                     // END TODO centralize this logic as it's borrowed from above temporarily
 
 


### PR DESCRIPTION


Note: these changes will still not preserve a test['script'] field at all. They simply re-apply customHeaders and auth into the new script we're creating for an experiment. https://github.com/WPO-Foundation/webpagetest/issues/2132