### PR TITLE
Fix sup link break,and sup mobile word wrap

### DIFF
--- a/www/css/account.css
+++ b/www/css/account.css
@@ -1632,6 +1632,8 @@ dl.faq button[aria-expanded="true"]::after {
   color: #666666;
   font-size: 1rem;
   line-height: 1.25rem;
+}
+p sup {
   display: block;
 }
 


### PR DESCRIPTION
The issue:
![Screen Shot 2022-07-27 at 12 33 23 PM](https://user-images.githubusercontent.com/607541/181356767-9837ffc7-031b-4cbd-a620-f67b5cff9216.png)

The other issue whose fix caused the above issue:
![Screen Shot 2022-07-27 at 12 33 55 PM](https://user-images.githubusercontent.com/607541/181356853-487405be-e919-44e5-b22a-454ea10771b2.png)

