### PR TITLE
bugfix: set the billing cycle select to annual.  Webkit is not our friend

### DIFF
--- a/www/js/signup-price-changer.js
+++ b/www/js/signup-price-changer.js
@@ -95,4 +95,8 @@
     var submitButton = document.getElementById("submit-pro-plan");
     new PlanPriceUpdater(form, submitButton);
   }
+  window.addEventListener('pageshow',  function () {
+    var billingCycleSelect = document.getElementById('billing-cycle');
+    billingCycleSelect.value="annual"; // thanks webkit... for being the worst at cache
+  });
 })();

--- a/www/templates/account/signup/step-1.php
+++ b/www/templates/account/signup/step-1.php
@@ -54,7 +54,7 @@
                         <div>
                             <label for="billing-cycle"> Plan:</label>
                             <select id="billing-cycle" name="billing-cycle">
-                                <option value="annual" selected>Annual</option>
+                                <option value="annual">Annual</option>
                                 <option value="monthly">Monthly</option>
                             </select>
                         </div>


### PR DESCRIPTION
To test:
on signup select a MONTHLY plan

use the browser's back button and you should see the billing cycle select set to ANNUAL, not monthly, Monthly was the bug