### PR TITLE
Fix unused preloads by allowing for empty initiator

### DIFF
--- a/www/experiments/common.inc
+++ b/www/experiments/common.inc
@@ -95,7 +95,7 @@ $requestsInitial = $testStepResult->getRequests();
 function initiatedByRoot($request)
 {
     global $rootURL;
-    return strcasecmp($request['initiator'], $rootURL) === 0;
+    return strcasecmp($request['initiator'], $rootURL) === 0 || $request['initiator'] == '';
 }
 
 

--- a/www/experiments/unused-preloads.inc
+++ b/www/experiments/unused-preloads.inc
@@ -10,13 +10,12 @@ foreach ($requests as $request) {
     }
 }
 
-
 //Today this opp only works in Chrome or Edge so to avoid showing it as
 //ok when it might not be, we'll just not do it in other browsers
 if ($browser == 'Chrome' || $browser == 'Edge') {
     if (count($unusedPreloads) > 0) {
         $assessment[$category]["opportunities"][] = array(
-            "title" =>  count($unusedPreloads) . " resource" . (count($unusedPreloads) > 1 ? "s are" : " is") . " being preloaded, but is not used during page load.",
+            "title" =>  count($unusedPreloads) . " resource" . (count($unusedPreloads) > 1 ? "s are" : " is") . " being preloaded, but ". (count($unusedPreloads) > 1 ? "are" : "is") . " not used during page load.",
             "desc" =>  "Preloaded resources are fetched at a high priority, delaying the arrival of other resources in the page. In the case where a preloaded resource is never actually used by the page, that means potentially critical requests will be delayed, slowing down the initial loading of your site.",
             "examples" =>  array_unique($unusedPreloads),
             "experiments" =>  array(


### PR DESCRIPTION
Sometimes we were incorrectly reporting no unused preloads, because the initiator was empty. This makes sure that we still report on those (this would also have reduced our render-blocking counts)