### PR TITLE
Fix custom network bug

### DIFF
--- a/www/home_header.php
+++ b/www/home_header.php
@@ -4,7 +4,7 @@
             <?php
 
             if ($experiments_paid && $experiments_logged_in) {
-                ?>
+            ?>
                 <div class="home_feature_hed home_feature_hed-pro home_feature_hed-pro-loggedin">
                     <div class="home_feature_hed_text">
                         <h1 class="attention"><span class="home_feature_hed_text_leadin">Welcome to </span> <img class="home_feature_hed_text_logo" width="105" height="14" src="/images/wpt-logo-pro.svg" alt="WebPageTest Pro"></h1>
@@ -26,87 +26,88 @@
                 <div class="home_feature_hed home_feature_hed-pro">
                     <div class="home_feature_hed_text">
                         <h1 class="attention"><span class="home_feature_hed_text_leadin">Say hello to </span> <img class="home_feature_hed_text_logo" width="105" height="14" src="/images/wpt-logo-pro.svg" alt="WebPageTest Pro"></h1>
-                                    <p>All of the WebPageTest features you already love, <span class="home_feature_hed_text_line">plus <b>API Access</b> &amp; <b>No-Code Experiments!</b></span></p>
+                        <p>All of the WebPageTest features you already love, <span class="home_feature_hed_text_line">plus <b>API Access</b> &amp; <b>No-Code Experiments!</b></span></p>
                         <a class="pill" href="/signup" style="padding: .9em 1.5em;">View Plans &amp; Learn More &gt;&gt;</a>
                     </div>
                     <div class="home_feature_hed_visual">
-                            <video width="1152" height="720" playsinline="" id="intro" poster="/images/pro-intro.jpg" preload="none">
-                                <source src="/images/pro-intro-1152.mp4" media="(min-width: 800px)">
-                                <source src="/images/pro-intro-480.mp4">
-                                <!--<track default="" kind="captions" srclang="en" src="/images/pro-intro.vtt">-->
-                            </video>
-                            <button class="play" id="playbtn">Play/Pause Video</button>
+                        <video width="1152" height="720" playsinline="" id="intro" poster="/images/pro-intro.jpg" preload="none">
+                            <source src="/images/pro-intro-1152.mp4" media="(min-width: 800px)">
+                            <source src="/images/pro-intro-480.mp4">
+                            <!--<track default="" kind="captions" srclang="en" src="/images/pro-intro.vtt">-->
+                        </video>
+                        <button class="play" id="playbtn">Play/Pause Video</button>
                     </div>
                 </div>
             <?php } ?>
         </div>
 
 
-        
 
-       
 
-    </div>
+
 
     </div>
 
-    <script>
-        setInterval(() => {
-            if( document.body.querySelector(".home_feature_hed-main") && !document.body.classList.contains("playing") && matchMedia("(prefers-reduced-motion: no-preference)").matches ){
-                document.body.classList.toggle("feature-pro");
+</div>
+
+<script>
+    setInterval(() => {
+        if (document.body.querySelector(".home_feature_hed-main") && !document.body.classList.contains("playing") && matchMedia("(prefers-reduced-motion: no-preference)").matches) {
+            document.body.classList.toggle("feature-pro");
+        }
+    }, 8000);
+
+
+    (function() {
+        var intro = document.querySelector("video");
+        var playbtn = document.querySelector(".play");
+
+        if (intro) {
+            function activate() {
+                intro.controls = true;
+                document.body.classList.add("playing");
             }
-        },8000);
 
+            function deactivate() {
+                intro.controls = false;
+                intro.pause();
+                document.body.classList.remove("playing");
+            }
 
-        (function(){
-                var intro = document.querySelector("video");
-                var playbtn = document.querySelector(".play");
-                
-                function activate(){
-                    intro.controls = true;
-                    document.body.classList.add("playing");
-                }
-                function deactivate(){
-                    intro.controls = false;
+            intro.addEventListener("play", function(e) {
+                activate();
+                playbtn.classList.add("active");
+            });
+            intro.addEventListener("pause", function(e) {
+                playbtn.classList.remove("active");
+            });
+            intro.addEventListener("ended", function(e) {
+                this.controls = false;
+                deactivate();
+                document.body.classList.remove("playing");
+            });
+            playbtn.addEventListener("click", function(e) {
+                e.preventDefault();
+                if (intro.paused) {
+                    intro.play();
+                } else {
                     intro.pause();
-                    document.body.classList.remove("playing");
                 }
-                
-                intro.addEventListener( "play", function(e){
-                    activate();
-                    playbtn.classList.add("active");
-                });
-                intro.addEventListener( "pause", function(e){
-                    playbtn.classList.remove("active");
-                });
-                intro.addEventListener( "ended", function(e){
-                    this.controls = false;
-                    deactivate();
-                    document.body.classList.remove("playing");
-                });
-                playbtn.addEventListener( "click", function(e){
+            });
+
+            document.body.addEventListener("mousedown", function(e) {
+                if (this.classList.contains("playing") && e.target !== intro && e.target !== playbtn) {
                     e.preventDefault();
-                    if(intro.paused){
-                        intro.play();
-                    } else {
-                        intro.pause();
-                    }
-                });
-                
-                document.body.addEventListener("mousedown",function( e ){
-                    if( this.classList.contains("playing") && e.target !== intro && e.target !== playbtn  ){
-                        e.preventDefault();
-                        deactivate();
-                    }
-                });
-                document.body.addEventListener("keydown",function( e ){
-                    if( this.classList.contains("playing") && e.keyCode === 27 ){
-                        e.preventDefault();
-                        deactivate();
-                    }
-                });
-            }());
+                    deactivate();
+                }
+            });
+            document.body.addEventListener("keydown", function(e) {
+                if (this.classList.contains("playing") && e.keyCode === 27) {
+                    e.preventDefault();
+                    deactivate();
+                }
+            });
+        }
 
-    </script>
-
-    
+    }());
+</script>

--- a/www/js/test.js
+++ b/www/js/test.js
@@ -373,8 +373,11 @@ function ConnectionChanged() {
     }
 
     // enable/disable the fields as necessary
-    if (connection == "custom") $("#bwTable").show();
-    else $("#bwTable").hide();
+    if (connection == "custom") {
+      $("#bwTable").removeClass("hidden");
+    } else {
+      $("#bwTable").addClass("hidden");
+    }
 
     $("#backlog").text(backlog);
     if (backlog < 5)


### PR DESCRIPTION
We've got a bug where the custom network boxes no longer show when a custom network type is selected. This brings them back and also sneaks in one fix for a JS error that happens when the intro video isn't available.

Before:
![Screen Shot 2022-07-29 at 10 29 56 AM](https://user-images.githubusercontent.com/66536/181793295-000f8442-82ed-4f51-8394-0f9c210cb71d.png)

After:
![Screen Shot 2022-07-29 at 10 30 12 AM](https://user-images.githubusercontent.com/66536/181793335-d6878a2d-1748-4572-94b3-2ba5442caf39.png)

