### PR TITLE
fix(composer): don't run in the background. fail fast

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
       "lint": "phpcs --standard=PSR12 www/src www/cpauth www/common",
       "format:prettier": "npx prettier@2.7.1 --write 'www/**/*.css' 'www/**/*.js'",
       "format:php": "phpcbf --extensions=php,inc --standard=PSR12 --ignore=www/lib/,www/ec2/ www/ tests/ bulktest/",
-      "format": "composer format:php & composer format:prettier",
+      "format": "composer format:php && composer format:prettier",
       "pre-autoload-dump": "Google\\Task\\Composer::cleanup"
     },
     "require": {


### PR DESCRIPTION
Single `&` caused `composer format` to run in the background, so it would hang if there were problems.