### PR TITLE
switch container selector for request blocking links

### DIFF
--- a/www/waterfall.js
+++ b/www/waterfall.js
@@ -469,7 +469,7 @@ $(".waterfall-transparency").on("input", function () {
 });
 
 if (document.getElementById("urlEntry")) {
-  $(".waterfall-container").on("click", "a[data-spof]", function (e) {
+  $("#test_results-container").on("click", "a[data-spof]", function (e) {
     $("#urlEntry").append(
       '<input type="hidden" name="spof" value="' +
         $(this).attr("data-spof") +
@@ -484,7 +484,7 @@ if (document.getElementById("urlEntry")) {
 
     return false;
   });
-  $(".waterfall-container").on("click", "a[data-block]", function (e) {
+  $("#test_results-container").on("click", "a[data-block]", function (e) {
     if ($("#requestBlockingSettings h2").length <= 0) {
       createRequestBlockingBox();
     }
@@ -515,7 +515,7 @@ if (document.getElementById("urlEntry")) {
 
     return false;
   });
-  $(".waterfall-container").on("click", "a[data-block-domain]", function (e) {
+  $("#test_results-container").on("click", "a[data-block-domain]", function (e) {
     if ($("#requestBlockingSettings h2").length <= 0) {
       createRequestBlockingBox();
     }


### PR DESCRIPTION
Right now request blocking doesn't work on multi-step tests because there were too many .waterfall-container elements. This fixes that by choosing a parent that has only one instance on the page.