### PR TITLE
Make render-blocking requests for css and js more reliable in browsers that do not provide that information

### DIFF
--- a/www/experiments/render-blocking-3rd-party.inc
+++ b/www/experiments/render-blocking-3rd-party.inc
@@ -6,6 +6,7 @@ $blocking3pReqs = array();
 $blocking3pHosts = array();
 $potentiallyBlocking3pReqs = array();
 $potentiallyB3pHosts = array();
+$possibleRenderBlockers = $testStepResult->getMetric('possibly-render-blocking-reqs');
 $blockingIndicator = false;
 
 foreach ($requests as $request) {
@@ -20,8 +21,10 @@ foreach ($requests as $request) {
                 && ($request['contentType'] === "text/css" || $request['requestType'] === "script" || $request['request_type'] === "Script")
                 && $request['all_end'] < $startRender
     ) {
-        array_push($potentiallyBlocking3pReqs, $request['full_url']);
-        array_push($potentiallyBlocking3pHosts, $request['host']);
+        if( in_array( $request['full_url'], $possibleRenderBlockers ) ){
+            array_push($potentiallyBlocking3pReqs, $request['full_url']);
+            array_push($potentiallyBlocking3pHosts, $request['host']);
+        }
     }
 }
 

--- a/www/experiments/render-blocking-css.inc
+++ b/www/experiments/render-blocking-css.inc
@@ -5,7 +5,9 @@
     $blockingCSSReqs = array();
     $potentiallyBlockingCSSReqs = array();
     $startRender = $testStepResult->getMetric("render");
+    $possibleRenderBlockers = $testStepResult->getMetric('possibly-render-blocking-reqs');
     $blockingIndicator = false;
+
 foreach ($requests as $request) {
     if (isset($request['renderBlocking'])) {
         $blockingIndicator = true;
@@ -18,7 +20,12 @@ foreach ($requests as $request) {
             }
         }
     } elseif (!isset($request['renderBlocking']) && $request['contentType'] === "text/css" && $request['all_end'] < $startRender) {
-        array_push($potentiallyBlockingCSSReqs, documentRelativePath($request['url'], $requests[0]['url']));
+        $docRelUrl = documentRelativePath($request['url'], $requests[0]['url']);
+        foreach ($possibleRenderBlockers as $cssUrl) {
+            if( strpos( $cssUrl, $docRelUrl ) ){
+                array_push($potentiallyBlockingCSSReqs, $docRelUrl);
+            }
+        }
     }
 }
 if (!$blockingIndicator) {

--- a/www/experiments/render-blocking-scripts.inc
+++ b/www/experiments/render-blocking-scripts.inc
@@ -5,23 +5,30 @@ $requests = $testStepResult->getRequests();
 $blockingJSReqs = array();
 $potentiallyBlockingJSReqs = array();
 $startRender = $testStepResult->getMetric("render");
+$possibleRenderBlockers = $testStepResult->getMetric('possibly-render-blocking-reqs');
 $blockingIndicator = false;
-
 
 
 foreach ($requests as $request) {
     if (isset($request['renderBlocking'])) {
+        $docRelUrl = documentRelativePath($request['url'], $requests[0]['url']);
+
         $blockingIndicator = true;
         if (
             ($request['renderBlocking'] === "blocking" || $request['renderBlocking'] === "in_body_parser_blocking")
             && (isset($request['requestType']) && $request['requestType'] === "script" || $request['request_type'] === "Script")
         ) {
             if (initiatedByRoot($request)) {
-                array_push($blockingJSReqs, documentRelativePath($request['url'], $requests[0]['url']));
+                array_push($blockingJSReqs, $docRelUrl);
             }
         }
     } elseif (!isset($request['renderBlocking']) && (isset($request['requestType']) && $request['requestType'] === "script" || $request['request_type'] === "Script") && $request['all_end'] < $startRender) {
-        array_push($potentiallyBlockingJSReqs, documentRelativePath($request['url'], $requests[0]['url']));
+        $docRelUrl = documentRelativePath($request['url'], $requests[0]['url']);
+        foreach ($possibleRenderBlockers as $scriptUrl) {
+            if( strpos( $scriptUrl, $docRelUrl ) ){
+                array_push($potentiallyBlockingJSReqs, $docRelUrl);
+            }
+        }
     }
 }
 

--- a/www/settings/custom_metrics/possibly-render-blocking-reqs.js
+++ b/www/settings/custom_metrics/possibly-render-blocking-reqs.js
@@ -1,0 +1,5 @@
+let possibleScripts = Array.from(document.querySelectorAll("script[src]:not([defer]):not([async]):not([type=module]")).map(elem => elem.src );
+let possibleStyleSheets = Array.from(document.querySelectorAll("link[href][rel=stylesheet]:not([rel=alternative])")).map(elem => {
+    return matchMedia(elem.media).matches ? elem.href : '';
+});
+return possibleScripts.concat( possibleStyleSheets );


### PR DESCRIPTION
This adds and utilizes a new custom metric that collects scripts and links in the page that have render-blocking qualities.

This list is not a guarantee to contain render-blockers, as these may have been added dynamically by the time this runs. Still, we can use this list to compare in browsers that don't send a render-blocking flag on requests, so we can be more confident that a request that arrived before start render was actually render-blocking. Browsers such as chromium currently give us that information directly so we do not need this in those browsers.