### PR TITLE
Use Blade for test history and a Console.log tab

### DIFF
--- a/www/consolelog.php
+++ b/www/consolelog.php
@@ -1,0 +1,26 @@
+<?php
+
+// this output buffer hack avoids a bit of circularity
+// on one hand we want the contents of header.inc
+// on the other we want to get access to TestRunResults prior to that
+ob_start();
+define('NOBANNER', true); // otherwise Twitch banner shows 2x
+$tab = 'Test Result';
+$subtab = 'Console Log';
+include_once 'header.inc';
+$results_header = ob_get_contents();
+ob_end_clean();
+
+// all prerequisite libs were already required in header.inc
+$fileHandler = new FileHandler();
+$testInfo = TestInfo::fromFiles($testPath);
+$testRunResults = TestRunResults::fromFiles($testInfo, $run, $cached, $fileHandler);
+
+// template
+require_once __DIR__ . '/resources/view.php';
+echo view('pages.consolelog', [
+    'test_results_view' => true,
+    'body_class' => 'result',
+    'results_header' => $results_header,
+    'log' => $testRunResults->getStepResult(1)->getConsoleLog(),
+]);

--- a/www/header.inc
+++ b/www/header.inc
@@ -63,9 +63,9 @@ if (!defined('EMBED')) {
     $alert_expiration = Util::getSetting('alert_expiration');
     if (isset($client_error)) {
         echo '<div class="error-banner">' . $client_error . '</div>';
-    } elseif ($alert && $alert_expiration && new DateTime() < new DateTime($alert_expiration)) {
+    } elseif (!defined('NOBANNER') && $alert && $alert_expiration && new DateTime() < new DateTime($alert_expiration)) {
         echo '<div class="alert-banner">' . $alert . '</div>';
-    } elseif ($alert && empty($alert_expiration)) {
+    } elseif (!defined('NOBANNER') && $alert && empty($alert_expiration)) {
         echo '<div class="alert-banner">' . $alert . '</div>';
     }
 
@@ -79,14 +79,9 @@ if (!defined('EMBED')) {
 <div id="main">
 
 <?php
-
-
-
-
-
-
 //If we're looking at a test result, include the extra header section and sub-menu
 if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader) && !defined('EMBED')) {
+
     // make sure the test is actually complete
     if (isset($test['test']['completeTime'])) {
         if (!isset($testResults) || !isset($testInfo)) {
@@ -409,6 +404,7 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
 
             $tabs['Content'] = $menuUrlGenerator->resultPage("breakdown", $endParams);
             $tabs['Domains'] = $menuUrlGenerator->resultPage("domains", $endParams);
+            $tabs['Console Log'] = $menuUrlGenerator->resultPage("consolelog", $endParams);
             if ($gradedRunResults->hasBreakdownTimeline()) {
             // currently only supported by standard urls
                 $menuStandardUrlGenerator = UrlGenerator::create(false, "", $id, $run, !empty($cached));

--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -34,7 +34,7 @@ error_page 404 /404.php;
 # disable chunked encoding for mp4 files because it breaks flash video on firefox
 location ~* \.mp4 {
         expires max;
-        add_header Cache-Control "public";        
+        add_header Cache-Control "public";
         gzip off;
 }
 
@@ -123,6 +123,11 @@ rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/optimization_report$ /optimizati
 rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/optimization_report/$ /optimization_report.php?test=$1&run=$2 last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/optimization_report/cached$ /optimization_report.php?test=$1&run=$2&cached=1 last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/optimization_report/cached/$ /optimization_report.php?test=$1&run=$2&cached=1 last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog$ /consolelog.php?test=$1&run=$2 last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog/$ /consolelog.php?test=$1&run=$2 last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog/cached$ /consolelog.php?test=$1&run=$2&cached=1 last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog/cached/$ /consolelog.php?test=$1&run=$2&cached=1 last;
+
 rewrite ^/testlog$ /testlog/7/ permanent;
 rewrite ^/testlog/([0-9]+)$ /testlog/$1/ permanent;
 rewrite ^/testlog/([0-9]+)/$ /testlog.php?days=$1 last;

--- a/www/resources/views/default.blade.php
+++ b/www/resources/views/default.blade.php
@@ -17,17 +17,19 @@
     global $noanalytics;
 
     $page_title = $page_title ? $page_title : 'WebPageTest';
-    $body_class = $body_class ? ' class="' . $body_class . '"' : '';
+    $body_class = $body_class ? ' class=' . $body_class : '';
 
     ?>
     <title>{{ $page_title ?? 'WebPageTest' }}</title>
     <?php require_once __DIR__ . '/../../templates/layouts/head.inc'; ?>
+    @yield('style')
 </head>
 
 <body {{$body_class }}>
     <?php require_once __DIR__ . '/../../templates/layouts/header.inc'; ?>
     <div id="main">
         <?php require_once __DIR__ . '/../../templates/layouts/main_hed.inc'; ?>
+        <?php echo $results_header; ?>
         @yield('content')
         <?php require_once __DIR__ . '/../../footer.inc'; ?>
     </div>

--- a/www/resources/views/default.blade.php
+++ b/www/resources/views/default.blade.php
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <?php
+
+    require_once __DIR__ . '/../../common.inc';
+
+    global $USER_EMAIL;
+    global $supportsAuth;
+    global $supportsSaml;
+    global $supportsCPAuth;
+    global $request_context;
+    global $_SESSION;
+    global $client_error;
+    global $test_is_private;
+    global $noanalytics;
+
+    $page_title = $page_title ? $page_title : 'WebPageTest';
+    $body_class = $body_class ? ' class="' . $body_class . '"' : '';
+
+    ?>
+    <title>{{ $page_title ?? 'WebPageTest' }}</title>
+    <?php require_once __DIR__ . '/../../templates/layouts/head.inc'; ?>
+</head>
+
+<body {{$body_class }}>
+    <?php require_once __DIR__ . '/../../templates/layouts/header.inc'; ?>
+    <div id="main">
+        <?php require_once __DIR__ . '/../../templates/layouts/main_hed.inc'; ?>
+        @yield('content')
+        <?php require_once __DIR__ . '/../../footer.inc'; ?>
+    </div>
+    </body>
+
+</html>

--- a/www/resources/views/pages/consolelog.blade.php
+++ b/www/resources/views/pages/consolelog.blade.php
@@ -1,0 +1,89 @@
+@extends('default')
+
+@section('style')
+<style>
+    #console-log {
+        text-align: left;
+        width: 100%;
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    #console-log th {
+        padding: 0.2em 1em;
+        text-align: left;
+    }
+
+    #console-log td {
+        padding: 0.2em 1em;
+        max-width: 100px;
+    }
+
+    #console-log .message {
+        max-width: 700px;
+    }
+
+    #console-log .url {
+        max-width: 300px;
+    }
+
+    div.scrollable {
+        max-width: 100em;
+        margin: 0;
+        padding: 0;
+        overflow: auto;
+    }
+
+    tr.even {
+        background: whitesmoke;
+    }
+</style>
+@endsection
+
+@section('content')
+<?php $even = false; ?>
+<div id="test_results-container">
+    <div id="test-1" class="test_results">
+        <div class="test_results-content">
+            <div class="results_main_contain">
+                <div class="results_main">
+                    <div class="results_and_command">
+                        <div class="results_header">
+                            <h2>Console Log</h2>
+                        </div>
+                    </div>
+                    <div id="result" class="results_body">
+
+                        <div class="overflow-container">
+                            <table id="console-log" class="translucent">
+                                <tr>
+                                    <th>Source</th>
+                                    <th>Level</th>
+                                    <th>Message</th>
+                                    <th>URL</th>
+                                    <th>Line</th>
+                                </tr>
+                                @foreach ($log as &$log_entry)
+                                <?php $even = !$even ?>
+                                <tr @if ($even) class="even" @endif>
+                                    <td width="50" class="source">{{ $log_entry['source'] }} </td>
+                                    <td width="50" class="level">{{ $log_entry['level'] }} </td>
+                                    <td class="message">
+                                        <div class="scrollable">{{ $log_entry['text'] }}</div>
+                                    </td>
+                                    <td class="url">
+                                        <div class="scrollable"><a href={{ $log_entry['url'] }}>{{ $log_entry['url'] }}</a></div>
+                                    </td>
+                                    <td width="50" class="line">{{ @$log_entry['line'] }}</td>
+                                </tr>
+                                @endforeach
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/www/resources/views/pages/consolelog.blade.php
+++ b/www/resources/views/pages/consolelog.blade.php
@@ -57,6 +57,7 @@
 
                         <div class="overflow-container">
                             <table id="console-log" class="translucent">
+                                <thead>
                                 <tr>
                                     <th>Source</th>
                                     <th>Level</th>
@@ -64,6 +65,8 @@
                                     <th>URL</th>
                                     <th>Line</th>
                                 </tr>
+                                </thead>
+                                <tbody>
                                 @foreach ($log as &$log_entry)
                                 <?php $even = !$even ?>
                                 <tr @if ($even) class="even" @endif>
@@ -78,6 +81,7 @@
                                     <td width="50" class="line">{{ @$log_entry['line'] }}</td>
                                 </tr>
                                 @endforeach
+                                </tbody>
                             </table>
                         </div>
                     </div>

--- a/www/resources/views/pages/testhistory.blade.php
+++ b/www/resources/views/pages/testhistory.blade.php
@@ -18,7 +18,7 @@
             <input id="filter" name="filter" type="text" onkeyup="filterHistory()" placeholder="Search">
             @if ($is_logged_in)
                 <label for="days" class="a11y-hidden">Select how far back you want to see</label>
-                <select name="days">
+                <select name="days" id="days">
                     <option value="1" @if ($days === 1) selected @endif>1 Day</option>
                     <option value="7" @if ($days === 7) selected @endif>7 Days</option>
                     <option value="30" @if ($days === 30) selected @endif>30 Days</option>
@@ -49,7 +49,7 @@
                     <tbody id="historyBody">
                         @foreach ($test_history as $record)
                             <tr>
-                                <th><input type="checkbox" name="t[]" value="{{ $record->getTestId() }}" /></th>
+                                <th><input type="checkbox" name="t[]" value="{{ $record->getTestId() }}" aria-label="Select this test" /></th>
                                 <td class="url"><a href="/result/{{ $record->getTestId() }}/">{{ $record->getUrl() }}</a></td>
                                 <td class="date">{{ date_format(date_create($record->getStartTime()), 'M d, Y g:i:s A e') }}</td>
                                 <td class="location">{{ $record->getLocation() }}</td>

--- a/www/resources/views/pages/testhistory.blade.php
+++ b/www/resources/views/pages/testhistory.blade.php
@@ -1,0 +1,85 @@
+@extends('default')
+
+@section('content')
+
+<div class="history_hed">
+    <h1>Test History</h1>
+
+    <form name="filterLog" method="get" action="/testlog.php">
+
+        @if (!$is_logged_in)
+            <div class="logged-out-history">
+                <p>Test history is available for up to 30 days as long as your storage isn't cleared. By registering for a free account, you can keep test history for longer, compare tests, and review changes. Additionally, you will also be able to post on the <a href="https://forums.webpagetest.org">WebPageTest Forum</a> and contribute to the discussions there about features, test results and more.</p>
+                <a href="{{ $protocol }}://{{ $host }}/signup" ?>" class="btn-primary">Get Free Access</a>
+            </div>
+        @endif
+        <div class="history_filter">
+            <label for="filter">Filter test history:</label>
+            <input id="filter" name="filter" type="text" onkeyup="filterHistory()" placeholder="Search">
+            @if ($is_logged_in)
+                <label for="days" class="a11y-hidden">Select how far back you want to see</label>
+                <select name="days">
+                    <option value="1" @if ($days === 1) selected @endif>1 Day</option>
+                    <option value="7" @if ($days === 7) selected @endif>7 Days</option>
+                    <option value="30" @if ($days === 30) selected @endif>30 Days</option>
+                    <option value="128" @if ($days === 128) selected @endif>128 Days</option>
+                    <option value="365" @if ($days === 1) selected @endif>356 Days</option>
+                </select>
+            @endif
+        </div>
+    </form>
+</div>
+<div class="box">
+    <form name="compare" method="get" action="/video/compare.php">
+        <div class="history-controls">
+            <input id="CompareBtn" type="submit" value="Compare Selected Tests">
+        </div>
+        <div class="scrollableTable">
+            <table id="history" class="history pretty" border="0" cellpadding="5px" cellspacing="0">
+                <thead>
+                    <tr>
+                        <th class="pin"><span>Select to compare</span></th>
+                        <th class="url">URL</th>
+                        <th class="date">Run Date</th>
+                        <th class="location">Run From</th>
+                        <th class="label">Label</th>
+                    </tr>
+                </thead>
+                @if ($is_logged_in)
+                    <tbody id="historyBody">
+                        @foreach ($test_history as $record)
+                            <tr>
+                                <th><input type="checkbox" name="t[]" value="{{ $record->getTestId() }}" /></th>
+                                <td class="url"><a href="/result/{{ $record->getTestId() }}/">{{ $record->getUrl() }}</a></td>
+                                <td class="date">{{ date_format(date_create($record->getStartTime()), 'M d, Y g:i:s A e') }}</td>
+                                <td class="location">{{ $record->getLocation() }}</td>
+                                <td class="label">{{ $record->getLabel() }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                @endif
+            </table>
+        </div>
+
+
+        @if ($local)
+            <input type="hidden" name="local" value="1">
+        @endif
+        @isset($priority))
+            <input type="hidden" name="priority" value="{{ $priority }}">
+        @endisset
+    </form>
+</div>
+
+<script>
+    <?php
+    if ($is_logged_in) {
+        include __DIR__ . '/../../js/history-loggedin.js';
+    } else {
+        // if not logged in, build a local searchable test history from the data stored in indexeddb.
+        include __DIR__ . '/../../js/history.js';
+    }
+    ?>
+</script>
+
+@endsection

--- a/www/testlog.php
+++ b/www/testlog.php
@@ -88,9 +88,7 @@ function check_it($val)
 // single user history
 if (!$csv && ($is_logged_in || (!isset($user) && !isset($_COOKIE['google_email']) && Util::getSetting('localHistory')))) {
     $GLOBALS['tab'] = 'Test History';
-    $tpl = new Template('testhistory');
-    $tpl->setLayout('default');
-    echo $tpl->render('user', array(
+    $vars = [
         'is_logged_in' => $is_logged_in,
         'protocol' => $protocol,
         'host' => $host,
@@ -100,7 +98,17 @@ if (!$csv && ($is_logged_in || (!isset($user) && !isset($_COOKIE['google_email']
         'local' => isset($_REQUEST['local']) && $_REQUEST['local'],
         'body_class' => 'history',
         'page_title' => 'WebPageTest - Test History',
-    ));
+
+    ];
+    /*
+    // uncomment for Blade
+    require_once __DIR__ . '/resources/view.php';
+    echo view('pages.testhistory', $vars);
+    exit();
+    */
+    $tpl = new Template('testhistory');
+    $tpl->setLayout('default');
+    echo $tpl->render('user', $vars);
     exit();
 }
 


### PR DESCRIPTION
Currently commented out behind `// uncomment for Blade` because I need a better setup to test more thoroughly the logged in case.

But yes, it's working! Thanks to @jefflembeck's templates and because Blade lets you drop to just PHP I was able to reuse headers/footers/common as-is. And so no need for more competing code (see issue #2193)