### PR TITLE
fix tag-label design

### DIFF
--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -4186,10 +4186,12 @@ ul.meta_exp_applied_list {
 }
 
 span.test_presets_tag-label {
+  display: inline-block !important;
   background: #fce075 !important;
   color: #333333 !important;
   max-width: 10em;
   text-overflow: ellipsis;
+  white-space: nowrap;
   overflow: hidden;
 }
 


### PR DESCRIPTION
The tag label does not display the text properly if the text has more than 21 characters:

![image](https://user-images.githubusercontent.com/67703565/182487035-90d05939-fcd0-4f8b-9c09-97d831cabe11.png)

To fix the problem I added the _white-space: nowrap;_ to the tag class:

![image](https://user-images.githubusercontent.com/67703565/182487224-1a8e0c56-9cc5-4a38-8a6c-9dadd662fc59.png)

But even though the text is larger than the container, the ellipsis is not being displayed:

![image](https://user-images.githubusercontent.com/67703565/182488446-554e2397-1847-439b-99fe-7afbf596179d.png)

That's because the _text-overflow: ellipsis;_ is not working properly for this tag, because it is assigned as a flex element, and [text-overflow works for block elements only](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow#formal_definition)
To fix I have added the _display: inline-block !important_.

That's how the tag will look when a text overflow occurs:  

![image](https://user-images.githubusercontent.com/67703565/182489808-cad93cb0-18e1-4ed0-a3a4-172a3e766f68.png)

 