### PR TITLE
Hello Stylelint

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+www/chrome
+www/css/vendor

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,44 @@
+{
+  "rules": {
+    "at-rule-no-unknown": true,
+    "block-no-empty": true,
+    "color-no-invalid-hex": true,
+    "comment-no-empty": true,
+    "custom-property-no-missing-var-function": true,
+    "declaration-block-no-duplicate-custom-properties": true,
+    "declaration-block-no-duplicate-properties": [
+      true,
+      {
+        "ignore": ["consecutive-duplicates-with-different-values"]
+      }
+    ],
+    "declaration-block-no-shorthand-property-overrides": true,
+    "font-family-no-duplicate-names": true,
+    "font-family-no-missing-generic-family-keyword": true,
+    "function-calc-no-unspaced-operator": true,
+    "function-linear-gradient-no-nonstandard-direction": true,
+    "function-no-unknown": true,
+    "keyframe-block-no-duplicate-selectors": true,
+    "keyframe-declaration-no-important": true,
+    "media-feature-name-no-unknown": true,
+    "named-grid-areas-no-invalid": true,
+    "no-duplicate-at-import-rules": true,
+    "no-duplicate-selectors": true,
+    "no-empty-source": true,
+    "no-extra-semicolons": true,
+    "no-invalid-double-slash-comments": true,
+    "no-invalid-position-at-import-rule": true,
+    "no-irregular-whitespace": true,
+    "property-no-unknown": true,
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-element-no-unknown": true,
+    "selector-type-no-unknown": [
+      true,
+      {
+        "ignore": ["custom-elements"]
+      }
+    ],
+    "string-no-newline": true,
+    "unit-no-unknown": true
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "format:php": "phpcbf --extensions=php,inc --standard=PSR12 --ignore=www/lib/,www/ec2/ www/ tests/ bulktest/",
     "format:prettier": "npx prettier@2.7.1 --write 'www/**/*.css' 'www/**/*.js'",
     "format": "composer format:php && composer format:prettier",
+    "lint:css": "npx stylelint@14.9.1 'www/**/*.css'",
     "lint": "phpcs --standard=PSR12 www/src www/cpauth www/common",
     "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
     "test": "phpunit --configuration tests/phpunit.xml"

--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -6397,7 +6397,6 @@ th.header {
   font-weight: bold;
 }
 
-*/
 /* visual comparison page */
 
 #visual_comparison .industry {


### PR DESCRIPTION
1. Add `composer lint:css`
2. Use the lint config from https://github.com/stylelint/stylelint-config-recommended excluding `no-descending-specificity`
3. Fix one stray comment in `pagestyles2.css` that was tripping the parser

I excluded https://stylelint.io/user-guide/rules/list/no-descending-specificity/ because it makes the linter chokes on `pagestyles2.css` (I didn't realize this file is 10K lines long!) and it also finds too many things to fix. I'm thinking we can start fixing with the current config of rules, then add `no-descending-specificity`, then "upgrade" to https://github.com/stylelint/stylelint-config-standard

Most of the current problems are of the duplicates variety, either duplicate properties within the same block or duplicate selectors sprinkled in the same file. And a bunch of empty blocks too.

Currently `composer lint:css` may have overwhelming output, so probably a good idea is to start with individual files like:
`$ npx stylelint@14.9.1 www/wpt-header.css`