### PR TITLE
_blank-ify tips take 2

### DIFF
--- a/www/tips_data/http2_in_action.html
+++ b/www/tips_data/http2_in_action.html
@@ -1,1 +1,32 @@
-<a href="http://mng.bz/EejO" onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}" target="_blank"><img style="float:left; padding-right:1em;" src="/tips_data/http2_in_action.png"></a> Manning has published "<a href="http://mng.bz/EejO" onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}" target="_blank">HTTP/2 in Action</a>" by <a href="https://twitter.com/tunetheweb" onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}">Barry Pollard</a><br><br><i>HTTP/2 in Action</i> teaches you everything you need to know to use HTTP/2 effectively and how to optimize web performance for your site. Using tools like WebPageTest, this practical guide explores real world examples allowing you to get most out of this recent performance upgrade to the web.<br><br>The full list of contents is available from <a href="http://mng.bz/EejO" onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}" target="_blank">Manning</a> and WebPageTest users get 40% off with the discount code <code>webpagetest40%</code>.
+<a
+  href="http://mng.bz/EejO"
+  onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}"
+  target="_blank"
+  ><img
+    style="float: left; padding-right: 1em"
+    src="/tips_data/http2_in_action.png"
+/></a>
+Manning has published "<a
+  href="http://mng.bz/EejO"
+  onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}"
+  target="_blank"
+  >HTTP/2 in Action</a
+>" by
+<a
+  href="https://twitter.com/tunetheweb"
+  onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}"
+  target="_blank"
+  >Barry Pollard</a
+><br /><br /><i>HTTP/2 in Action</i> teaches you everything you need to know to
+use HTTP/2 effectively and how to optimize web performance for your site. Using
+tools like WebPageTest, this practical guide explores real world examples
+allowing you to get most out of this recent performance upgrade to the web.<br /><br />The
+full list of contents is available from
+<a
+  href="http://mng.bz/EejO"
+  onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.H2Book']);}}catch(err){}"
+  target="_blank"
+  >Manning</a
+>
+and WebPageTest users get 40% off with the discount code
+<code>webpagetest40%</code>.

--- a/www/tips_data/node-wrapper.html
+++ b/www/tips_data/node-wrapper.html
@@ -1,4 +1,23 @@
-<a href="https://product.webpagetest.org/api?utm_campaign=WPT%20Website%20CTAs&utm_source=website&utm_medium=tips&utm_content=waitingscreentip"><img style="float:right; margin-left:2em; width: 200px;" src="/tips_data/automate-perf-testing.png"></a>
-<p>Integrate WebPageTest with your existing CI/CD tooling? </p>
-<p>WebPageTest API Wrapper is a NPM package that wraps WebPageTest API for NodeJS as a module and a command-line tool. It provides some syntactic sugar over the raw API, enabling easier integration into your existing workflows, including built in polling for results, pingback support and more.</p> 
-<p>Check out one of our <a href="https://product.webpagetest.org/api?utm_campaign=WPT%20Website%20CTAs&utm_source=website&utm_medium=tips&utm_content=waitingscreentip">API subscriptions</a> and unlock the full potential of WebPageTest! </p> 
+<a
+  href="https://product.webpagetest.org/api?utm_campaign=WPT%20Website%20CTAs&utm_source=website&utm_medium=tips&utm_content=waitingscreentip"
+  target="_blank"
+  ><img
+    style="float: right; margin-left: 2em; width: 200px"
+    src="/tips_data/automate-perf-testing.png"
+/></a>
+<p>Integrate WebPageTest with your existing CI/CD tooling?</p>
+<p>
+  WebPageTest API Wrapper is a NPM package that wraps WebPageTest API for NodeJS
+  as a module and a command-line tool. It provides some syntactic sugar over the
+  raw API, enabling easier integration into your existing workflows, including
+  built in polling for results, pingback support and more.
+</p>
+<p>
+  Check out one of our
+  <a
+    href="https://product.webpagetest.org/api?utm_campaign=WPT%20Website%20CTAs&utm_source=website&utm_medium=tips&utm_content=waitingscreentip"
+    target="_blank"
+    >API subscriptions</a
+  >
+  and unlock the full potential of WebPageTest!
+</p>

--- a/www/tips_data/responsible_javascript.html
+++ b/www/tips_data/responsible_javascript.html
@@ -1,1 +1,42 @@
-<picture><source srcset="/tips_data/responsible-javascript-2x.webp 2x, /tips_data/responsible-javascript-1x.webp 1x" type="image/webp"><a href="https://abookapart.com/products/responsible-javascript" onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.ResponsibleJavaScript']);}}catch(err){}" target="_blank"><img style="float:left; padding-right:1em;" width="221" height="330" srcset="/tips_data/responsible-javascript-2x.png 2x, /tips_data/responsible-javascript-1x.png 1x" src="/tips_data/responsible-javascript-1x.png"></a></picture>A Book Apart has published "<a href="https://abookapart.com/products/responsible-javascript" onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.ResponsibleJavaScript']);}}catch(err){}" target="_blank">Responsible JavaScript</a>" by <a href="https://twitter.com/malchata" onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.ResponsibleJavaScript']);}}catch(err){}">Jeremy Wagner</a><br><br>JavaScript plays a powerful role in creating rich interactive experiences. But its power comes at a cost: longer load times, sluggish pages, and inaccessible content. The more we rely on client-side rendering, the more likely we are to exclude visitors with older devices, slower connections, or those who have disabled JavaScript altogether.<br><br>If we want people to fully experience the sites we have worked so hard to craft, then we must be judicious in our use of JavaScript. In thoughtful detail, Jeremy Wagner shows how JavaScript can be used to progressively enhance server-side functionality, while improving speed and access for more visitors. By centering user needs every step of the way&mdash;from toolchains to metrics to testing&mdash;we can all contribute to a more inclusive, accessible, and resilient web.
+<picture
+  ><source
+    srcset="
+      /tips_data/responsible-javascript-2x.webp 2x,
+      /tips_data/responsible-javascript-1x.webp 1x
+    "
+    type="image/webp" />
+  <a
+    href="https://abookapart.com/products/responsible-javascript"
+    onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.ResponsibleJavaScript']);}}catch(err){}"
+    target="_blank"
+    ><img
+      style="float: left; padding-right: 1em"
+      width="221"
+      height="330"
+      srcset="
+        /tips_data/responsible-javascript-2x.png 2x,
+        /tips_data/responsible-javascript-1x.png 1x
+      "
+      src="/tips_data/responsible-javascript-1x.png" /></a></picture
+>A Book Apart has published "<a
+  href="https://abookapart.com/products/responsible-javascript"
+  onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.ResponsibleJavaScript']);}}catch(err){}"
+  target="_blank"
+  >Responsible JavaScript</a
+>" by
+<a
+  href="https://twitter.com/malchata"
+  onclick="try{if(_gaq!=undefined){_gaq.push(['_trackEvent','Outbound','Click','Tip.ResponsibleJavaScript']);}}catch(err){}"
+  target="_blank"
+  >Jeremy Wagner</a
+><br /><br />JavaScript plays a powerful role in creating rich interactive
+experiences. But its power comes at a cost: longer load times, sluggish pages,
+and inaccessible content. The more we rely on client-side rendering, the more
+likely we are to exclude visitors with older devices, slower connections, or
+those who have disabled JavaScript altogether.<br /><br />If we want people to
+fully experience the sites we have worked so hard to craft, then we must be
+judicious in our use of JavaScript. In thoughtful detail, Jeremy Wagner shows
+how JavaScript can be used to progressively enhance server-side functionality,
+while improving speed and access for more visitors. By centering user needs
+every step of the way&mdash;from toolchains to metrics to testing&mdash;we can
+all contribute to a more inclusive, accessible, and resilient web.


### PR DESCRIPTION
Take 1 missed a few links missing target=_blank, now a script found them.

Testing: 
1. went to https://www.webpagetest.org/tips.php
2. ran in the console
```js
document.querySelectorAll('.tip.box a').forEach(a => a.target !== '_blank' ? console.log(a) : null)
```

Also formatted the html :)