### PR TITLE
Fix the issue with early hints display when comma's are in the URLs

### DIFF
--- a/www/waterfall.js
+++ b/www/waterfall.js
@@ -238,12 +238,12 @@ function SelectRequest(step, request) {
     ) {
       //let's create a nice clean list of hints
       let hints = r["early_hint_headers"][1].substring(6);
-      hints = hints.split(",");
+      hints = hints.split(/(?=\<)/);
 
       details += "<b>Early Hints: </b>";
       details += "<ul class='hints'>";
       hints.forEach((hint) => {
-        details += "<li>" + htmlEncode(hint) + "</li>";
+        details += "<li>" + htmlEncode(hint.replace(/\,/, '')) + "</li>";
       });
       details += "</ul><br>";
     }


### PR DESCRIPTION
Previously, we were splitting the early_hint_headers by comma `,`. But in situations where comma's were used in the URL specified, that broke display.

This commit instead splits the headers by using a positive lookahead matching the `<` character. That way the `<` is still included in the individual strings. Then we strip out the last character for each hint if that character is a comma, just for cleanliness. This fixes #2248