### PR TITLE
fix(auth): refresh endpoint gets 400 when no token

### DIFF
--- a/tests/CPClientTest.php
+++ b/tests/CPClientTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use WebPageTest\CPClient;
 use WebPageTest\AuthToken;
 use WebPageTest\Exception\ClientException;
+use WebPageTest\Exception\UnauthorizedException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
@@ -191,7 +192,7 @@ final class CPClientTest extends TestCase
             ]
         ));
 
-        $this->expectException(ClientException::class);
+        $this->expectException(UnauthorizedException::class);
         $client->refreshAuthToken($refresh_token);
     }
 

--- a/www/src/CPClient.php
+++ b/www/src/CPClient.php
@@ -127,7 +127,7 @@ class CPClient
         try {
             $response = $this->auth_client->request('POST', '/auth/connect/token', $body);
         } catch (GuzzleException $e) {
-            if ($e->getCode() == 401) {
+            if ($e->getCode() == 400 || $e->getCode() == 401) {
                 throw new UnauthorizedException();
             }
             throw new ClientException($e->getMessage());


### PR DESCRIPTION
If there's no token in the grant store, we get back a 400, not a 401.