### PR TITLE
Fix waterfall request clicks being off by 1 in small screens

### DIFF
--- a/www/pagestyle2.css
+++ b/www/pagestyle2.css
@@ -7885,7 +7885,6 @@ td.legend {
     margin: auto;
     overflow: hidden;
     overflow-x: auto;
-    padding-top: 1em;
   }
   div.waterfall-container img.waterfall-image {
     width: 1012px;


### PR DESCRIPTION
Fixes bug #1631

Before: click request #2 and request #3 show up in the dialog
After: peaches

Thanks to @tigt for doing the investigation!

Before:
<img width="664" alt="Screen Shot 2022-08-24 at 7 55 44 PM" src="https://user-images.githubusercontent.com/51308/186544202-1833f02a-c930-4d3b-b3a5-c33a5457d612.png">
After:
<img width="556" alt="Screen Shot 2022-08-24 at 7 54 53 PM" src="https://user-images.githubusercontent.com/51308/186544149-d9664382-fcd7-46ca-ad1e-54ae54a874e4.png">
