### PR TITLE
Check for test.complete file

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -82,7 +82,7 @@ if (!defined('EMBED')) {
 //If we're looking at a test result, include the extra header section and sub-menu
 if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader) && !defined('EMBED')) {
     // make sure the test is actually complete
-    if (isset($test['test']['completeTime'])) {
+    if (isset($test['test']['completeTime']) || file_exists("$testPath/test.complete")) {
         if (!isset($testResults) || !isset($testInfo)) {
             $testInfo = TestInfo::fromFiles($testPath);
             $testResults = TestResults::fromFiles($testInfo);


### PR DESCRIPTION
Sometimes the completeTime isn't set on a test, but there is a test.complete file (need to dig to better understand why and when that happens).

Before, without checking for the file, we would error on pages without a testComplete time, showing a blank page.
![Screen Shot 2022-08-31 at 8 43 40 AM](https://user-images.githubusercontent.com/66536/187693247-f36af63b-2ea2-418f-8b71-4cc970c31b7a.png)

This lets us still show results by adding a check for the complete file.