### PR TITLE
Enterprise user account page + Sessions + Cleanup

### DIFF
--- a/www/assets/css/account.css
+++ b/www/assets/css/account.css
@@ -1412,7 +1412,8 @@ table.sortable th:not([aria-sort]) button:hover span::after {
 /* comparison table content */
 
 .icon.check {
-  background: #6ca71a url(/assets/images/src/icon_grading_check.svg) left 50% no-repeat;
+  background: #6ca71a url(/assets/images/src/icon_grading_check.svg) left 50%
+    no-repeat;
   color: #fff;
   border-radius: 100%;
   font-weight: 900;

--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -743,7 +743,8 @@ h3.grade_heading {
   height: 0.6em;
   display: inline-block;
   margin-right: 0.8rem;
-  background: url("/assets/images/src/icon_triangledown.svg") left center no-repeat;
+  background: url("/assets/images/src/icon_triangledown.svg") left center
+    no-repeat;
   background-size: 0.6em auto;
   transform: rotate(-90deg);
   padding-left: ;
@@ -782,7 +783,8 @@ p.grade_summary {
 }
 
 #Custom .grade_heading + p {
-  background: url(/assets/images/src/icon_science_bubbling.svg) left 50% no-repeat;
+  background: url(/assets/images/src/icon_science_bubbling.svg) left 50%
+    no-repeat;
   background-size: auto 2rem !important;
   background-position: left center !important;
 }
@@ -897,7 +899,8 @@ p.grade_summary {
 
 .experiments_bottlenecks > ol > li > details > summary:before {
   content: "";
-  background: #6ca71a url(/assets/images/src/icon_grading_check.svg) left 50% no-repeat;
+  background: #6ca71a url(/assets/images/src/icon_grading_check.svg) left 50%
+    no-repeat;
   color: #fff;
   border-radius: 100%;
   font-weight: 900;
@@ -916,7 +919,8 @@ p.grade_summary {
   > li.experiments_details-bad
   > details
   > summary:before {
-  background: #d26122 url(/assets/images/src/icon_grading_alert.svg) left 50% no-repeat;
+  background: #d26122 url(/assets/images/src/icon_grading_alert.svg) left 50%
+    no-repeat;
   background-size: contain;
 }
 
@@ -936,7 +940,8 @@ h4.experiments_list_hed {
   font-size: 1.3em;
   padding-bottom: 0;
   padding-left: 2.5em;
-  background: url(/assets/images/src/icon_science_bubbling.svg) left bottom no-repeat;
+  background: url(/assets/images/src/icon_science_bubbling.svg) left bottom
+    no-repeat;
   background-size: 1.6em;
   min-height: em;
   padding: 0em 0 0 1.7em;
@@ -1110,8 +1115,8 @@ h4.experiments_list_hed-recs {
   padding-top: 0.6em;
   padding-bottom: 0.6em;
   padding-left: 1.5em;
-  background: transparent url(/assets/images/src/icon_lock.svg) left 0.8rem top 50%
-    no-repeat;
+  background: transparent url(/assets/images/src/icon_lock.svg) left 0.8rem top
+    50% no-repeat;
   background-size: 1.5rem auto;
 }
 
@@ -1285,7 +1290,8 @@ h4.experiments_list_hed-recs {
   list-style: none;
   padding-left: 1.5em;
   text-decoration: dotted underline #888;
-  background: url(/assets/images/src/icon_info_circle_white.svg) left 50% no-repeat;
+  background: url(/assets/images/src/icon_info_circle_white.svg) left 50%
+    no-repeat;
   background-size: 1.2em auto;
 }
 
@@ -2177,7 +2183,8 @@ footer ul {
 }
 
 .opportunities_summary_recs {
-  background: url(/assets/images/src/icon_code_rec.svg) left 0 bottom 50% no-repeat;
+  background: url(/assets/images/src/icon_code_rec.svg) left 0 bottom 50%
+    no-repeat;
   background-size: auto 2rem;
   padding-left: 2.2em;
   height: 1em;
@@ -2418,7 +2425,8 @@ footer ul {
 .testinfo_forms summary strong {
   font-weight: bold;
   color: #e33535;
-  background: url(/assets/images/src/icon_grading_warn.svg) left center no-repeat;
+  background: url(/assets/images/src/icon_grading_warn.svg) left center
+    no-repeat;
   background-size: 1em 1em;
   padding-left: 1.6em;
 }
@@ -2585,7 +2593,8 @@ details.details_custommetrics summary {
 
 .compare-experiment.compare-loading .results_header {
   padding: 1.2rem 6rem 0;
-  background: url(/assets/images/src/icon_science_bubbling.svg) left top no-repeat;
+  background: url(/assets/images/src/icon_science_bubbling.svg) left top
+    no-repeat;
   background-size: 6rem auto;
   margin: 3rem 0 0;
 }
@@ -5396,8 +5405,8 @@ label.test_preset_profile {
 #visual_comparison .addBtn {
   border: 1px solid rgba(255, 255, 255, 0.1);
   font-size: 0.9em;
-  background: rgba(0, 0, 0, 0.33) url("/assets/images/icon-add.svg") top 50% left
-    0.8rem no-repeat;
+  background: rgba(0, 0, 0, 0.33) url("/assets/images/icon-add.svg") top 50%
+    left 0.8rem no-repeat;
   background-size: 0.9rem 0.9rem;
   color: #fff;
   padding: 0.8em 0.8em 0.8em 2.5em;

--- a/www/assets/css/wpt-header.css
+++ b/www/assets/css/wpt-header.css
@@ -71,7 +71,8 @@ wpt-header .wptheader_menubtn {
   box-sizing: border-box;
   color: #fff;
   border: 0;
-  background: #141e33 url(/assets/images/wpt-header-menubtn.svg) 50% 50% no-repeat;
+  background: #141e33 url(/assets/images/wpt-header-menubtn.svg) 50% 50%
+    no-repeat;
   text-indent: -9999px;
   background-size: 16px auto;
   cursor: pointer;

--- a/www/assets/js/site.js
+++ b/www/assets/js/site.js
@@ -1028,7 +1028,9 @@ var getScrollbarWidth = function() {
         !document.getElementById("injectscript-container")
       ) {
         // load Flask
-        const { default: CodeFlask } = await import("/assets/js/codeflask.module.js");
+        const { default: CodeFlask } = await import(
+          "/assets/js/codeflask.module.js"
+        );
         var injectScript = document.getElementById("injectScript");
         // editor container
         var codeEl = document.createElement("div");

--- a/www/common.inc
+++ b/www/common.inc
@@ -24,6 +24,12 @@ if (Util::getSetting('cp_auth')) {
     unset($_SESSION['client_error']);
 
     set_exception_handler(function ($e) {
+        if(Util::getSetting('environment') == "dev") {
+            echo "<pre>";
+            var_dump($e);
+            echo "</pre>";
+            exit();
+        }
         if (is_a($e, ForbiddenException::class)) {
             http_response_code(404);
             die();

--- a/www/common.inc
+++ b/www/common.inc
@@ -24,7 +24,7 @@ if (Util::getSetting('cp_auth')) {
     unset($_SESSION['client_error']);
 
     set_exception_handler(function ($e) {
-        if(Util::getSetting('environment') == "dev") {
+        if (Util::getSetting('environment') == "dev") {
             echo "<pre>";
             var_dump($e);
             echo "</pre>";

--- a/www/common/AttachUser.php
+++ b/www/common/AttachUser.php
@@ -92,14 +92,6 @@ use WebPageTest\Exception\UnauthorizedException;
         }
     }
 
-    // In a dev environment, default to showing paid content, use a flag for unpaid
-    if (Util::getSetting('environment') == 'dev') {
-        $user->setPaid(true);
-        if (isset($_REQUEST['unpaid'])) {
-            $user->setPaid(false);
-        }
-    }
-
     $isPaid = $user->isPaid();
     if ($isPaid) {
         //calculate based on paid priority

--- a/www/cpauth/account.php
+++ b/www/cpauth/account.php
@@ -88,42 +88,42 @@ if ($request_method === 'POST') {
         throw new ClientException("Incorrect post type", "/account");
         exit();
     }
-} elseif ($request_method == 'GET') {
-    $error_message = $_SESSION['client-error'] ?? null;
+}
 
-    $is_paid = $request_context->getUser()->isPaid();
-    $is_verified = $request_context->getUser()->isVerified();
-    $is_wpt_enterprise = $request_context->getUser()->isWptEnterpriseClient();
-    $user_id = $request_context->getUser()->getUserId();
-    $remainingRuns = $request_context->getUser()->getRemainingRuns();
-    $user_contact_info = $request_context->getClient()->getUserContactInfo($user_id);
-    $user_email = $request_context->getUser()->getEmail();
-    $first_name = $user_contact_info['firstName'] ?? "";
-    $last_name = $user_contact_info['lastName'] ?? "";
-    $company_name = $user_contact_info['companyName'] ?? "";
+$error_message = $_SESSION['client-error'] ?? null;
 
-    $contact_info = array(
-        'layout_theme' => 'b',
-        'is_paid' => $is_paid,
-        'is_verified' => $is_verified,
-        'first_name' => htmlspecialchars($first_name),
-        'last_name' => htmlspecialchars($last_name),
-        'email' => $user_email,
-        'company_name' => htmlspecialchars($company_name),
-        'id' => $user_id
-    );
+$is_paid = $request_context->getUser()->isPaid();
+$is_verified = $request_context->getUser()->isVerified();
+$is_wpt_enterprise = $request_context->getUser()->isWptEnterpriseClient();
+$user_id = $request_context->getUser()->getUserId();
+$remainingRuns = $request_context->getUser()->getRemainingRuns();
+$user_contact_info = $request_context->getClient()->getUserContactInfo($user_id);
+$user_email = $request_context->getUser()->getEmail();
+$first_name = $user_contact_info['firstName'] ?? "";
+$last_name = $user_contact_info['lastName'] ?? "";
+$company_name = $user_contact_info['companyName'] ?? "";
 
-    $billing_info = array();
-    $client_token = "";
-    $country_list = Util::getCountryList();
-    $state_list = Util::getStateList();
+$contact_info = array(
+    'layout_theme' => 'b',
+    'is_paid' => $is_paid,
+    'is_verified' => $is_verified,
+    'first_name' => htmlspecialchars($first_name),
+    'last_name' => htmlspecialchars($last_name),
+    'email' => $user_email,
+    'company_name' => htmlspecialchars($company_name),
+    'id' => $user_id
+);
 
-    if ($is_paid) {
-        if ($is_wpt_enterprise) {
-            $billing_info = $request_context->getClient()->getPaidEnterpriseAccountPageInfo();
-        } else {
-            $billing_info = $request_context->getClient()->getPaidAccountPageInfo();
-        }
+$billing_info = array();
+$client_token = "";
+$country_list = Util::getCountryList();
+$state_list = Util::getStateList();
+
+if ($is_paid) {
+    if ($is_wpt_enterprise) {
+        $billing_info = $request_context->getClient()->getPaidEnterpriseAccountPageInfo();
+    } else {
+        $billing_info = $request_context->getClient()->getPaidAccountPageInfo();
         $customer_details = $billing_info['braintreeCustomerDetails'];
         $billing_frequency = $customer_details['billingFrequency'] == 12 ? "Annually" : "Monthly";
 
@@ -136,59 +136,56 @@ if ($request_method === 'POST') {
             $plan_renewal_date = new DateTime($customer_details['nextBillingDate']);
             $billing_info['plan_renewal'] = $plan_renewal_date->format('m/d/Y');
         }
-
-        $billing_info['is_wpt_enterprise'] = $is_wpt_enterprise;
         $billing_info['is_canceled'] = str_contains($customer_details['status'], 'CANCEL');
         $billing_info['billing_frequency'] = $billing_frequency;
         $client_token = $billing_info['braintreeClientToken'];
-    } else {
-        $info = $request_context->getClient()->getUnpaidAccountpageInfo();
-        $client_token = $info['braintreeClientToken'];
-        $plans = $info['wptPlans'];
-        $annual_plans = array();
-        $monthly_plans = array();
-        usort($plans, function ($a, $b) {
-            if ($a['price'] == $b['price']) {
-                return 0;
-            }
-            return ($a['price'] < $b['price']) ? -1 : 1;
-        });
-        foreach ($plans as $plan) {
-            if ($plan['billingFrequency'] == 1) {
-                $plan['price'] = number_format(($plan['price']), 2, ".", ",");
-                $plan['annual_price'] = number_format(($plan['price'] * 12.00), 2, ".", ",");
-                $monthly_plans[] = $plan;
-            } else {
-                $plan['annual_price'] = number_format(($plan['price']), 2, ".", ",");
-                $plan['monthly_price'] = number_format(($plan['price'] / 12.00), 2, ".", ",");
-                $annual_plans[] = $plan;
-            }
-        }
-        $billing_info = array(
-            'annual_plans' => $annual_plans,
-            'monthly_plans' => $monthly_plans
-        );
     }
 
-    $results = array_merge($contact_info, $billing_info);
-    $results['csrf_token'] = $_SESSION['csrf_token'];
-    $results['validation_pattern'] = ValidatorPatterns::getContactInfo();
-    $results['validation_pattern_password'] = ValidatorPatterns::getPassword();
-    $results['bt_client_token'] = $client_token;
-    $results['country_list'] = $country_list;
-    $results['state_list'] = $state_list;
-    $results['remainingRuns'] = $remainingRuns;
-
-    if (!is_null($error_message)) {
-        $results['error_message'] = $error_message;
-        unset($_SESSION['client-error']);
-    }
-
-    $tpl = new Template('account');
-    $tpl->setLayout('account');
-    echo $tpl->render('my-account', $results);
-    exit();
+    $billing_info['is_wpt_enterprise'] = $is_wpt_enterprise;
 } else {
-    throw new ClientException("HTTP Method not supported for this endpoint", "/");
-    exit();
+    $info = $request_context->getClient()->getUnpaidAccountpageInfo();
+    $client_token = $info['braintreeClientToken'];
+    $plans = $info['wptPlans'];
+    $annual_plans = array();
+    $monthly_plans = array();
+    usort($plans, function ($a, $b) {
+        if ($a['price'] == $b['price']) {
+            return 0;
+        }
+        return ($a['price'] < $b['price']) ? -1 : 1;
+    });
+    foreach ($plans as $plan) {
+        if ($plan['billingFrequency'] == 1) {
+            $plan['price'] = number_format(($plan['price']), 2, ".", ",");
+            $plan['annual_price'] = number_format(($plan['price'] * 12.00), 2, ".", ",");
+            $monthly_plans[] = $plan;
+        } else {
+            $plan['annual_price'] = number_format(($plan['price']), 2, ".", ",");
+            $plan['monthly_price'] = number_format(($plan['price'] / 12.00), 2, ".", ",");
+            $annual_plans[] = $plan;
+        }
+    }
+    $billing_info = array(
+        'annual_plans' => $annual_plans,
+        'monthly_plans' => $monthly_plans
+    );
 }
+
+$results = array_merge($contact_info, $billing_info);
+$results['csrf_token'] = $_SESSION['csrf_token'];
+$results['validation_pattern'] = ValidatorPatterns::getContactInfo();
+$results['validation_pattern_password'] = ValidatorPatterns::getPassword();
+$results['bt_client_token'] = $client_token;
+$results['country_list'] = $country_list;
+$results['state_list'] = $state_list;
+$results['remainingRuns'] = $remainingRuns;
+
+if (!is_null($error_message)) {
+    $results['error_message'] = $error_message;
+    unset($_SESSION['client-error']);
+}
+
+$tpl = new Template('account');
+$tpl->setLayout('account');
+echo $tpl->render('my-account', $results);
+exit();

--- a/www/cpauth/logout.php
+++ b/www/cpauth/logout.php
@@ -35,6 +35,19 @@ use WebPageTest\RequestContext;
 
         setcookie($cp_access_token_cookie_name, "", time() - 3600, "/", $host);
         setcookie($cp_refresh_token_cookie_name, "", time() - 3600, "/", $host);
+
+        // Destroy the session
+        $_SESSION = array();
+
+        if (ini_get("session.use_cookies")) {
+            $params = session_get_cookie_params();
+            setcookie(session_name(), '', time() - 42000,
+                $params["path"], $params["domain"],
+                $params["secure"], $params["httponly"]
+            );
+        }
+
+        session_destroy();
     }
 
     header("Location: {$redirect_uri}");

--- a/www/cpauth/logout.php
+++ b/www/cpauth/logout.php
@@ -41,9 +41,14 @@ use WebPageTest\RequestContext;
 
         if (ini_get("session.use_cookies")) {
             $params = session_get_cookie_params();
-            setcookie(session_name(), '', time() - 42000,
-                $params["path"], $params["domain"],
-                $params["secure"], $params["httponly"]
+            setcookie(
+                session_name(),
+                '',
+                time() - 42000,
+                $params["path"],
+                $params["domain"],
+                $params["secure"],
+                $params["httponly"]
             );
         }
 

--- a/www/running.inc
+++ b/www/running.inc
@@ -22,7 +22,7 @@
             if (!isset($test)) {
                 echo "<h3>Test Not Found</h3>\n";
                 echo "<p>Sorry, the test you requested could not be found.</p>";
-            } else if (TestArchiveExpired($id)) {
+            } elseif (TestArchiveExpired($id)) {
                 echo "<h3>Test Result Expired</h3>\n";
                 $retain_months = GetSetting('archive_retention_months', null);
                 if ($retain_months) {

--- a/www/src/CPClient.php
+++ b/www/src/CPClient.php
@@ -315,7 +315,6 @@ class CPClient
     {
         $gql = (new Query())
             ->setSelectionSet([
-                'braintreeClientToken',
                 (new Query('wptApiKey'))
                     ->setSelectionSet([
                         'id',
@@ -323,32 +322,6 @@ class CPClient
                         'apiKey',
                         'createDate',
                         'changeDate'
-                    ]),
-                (new Query('braintreeCustomerDetails'))
-                    ->setSelectionSet([
-                        'customerId',
-                        'wptPlanId',
-                        'subscriptionId',
-                        'ccLastFour',
-                        'daysPastDue',
-                        'subscriptionPrice',
-                        'maskedCreditCard',
-                        'nextBillingDate',
-                        'billingPeriodEndDate',
-                        'numberOfBillingCycles',
-                        'ccExpirationDate',
-                        'ccImageUrl',
-                        'status',
-                        (new Query('discount'))
-                            ->setSelectionSet([
-                                'amount',
-                                'numberOfBillingCycles'
-                            ]),
-                        'remainingRuns',
-                        'monthlyRuns',
-                        'planRenewalDate',
-                        'billingFrequency',
-                        'wptPlanName'
                     ])
             ]);
         try {

--- a/www/templates/account/includes/api-keys.php
+++ b/www/templates/account/includes/api-keys.php
@@ -1,0 +1,79 @@
+<div class="card api-consumers">
+    <h3>API Consumers</h3>
+    <div class="create-key-container">
+        <div class="create-delete-button-container">
+            <button type="button" class="new-api-key" data-toggle="open" data-targetid="create-api-key-toggle-area">New Api Key</button>
+            <label for="delete-api-key-submit-input" class="delete-key disabled" data-apikeybox="delete-button" disabled>Delete</label>
+        </div>
+        <div class="toggleable" id="create-api-key-toggle-area">
+            <form method="POST" action="/account">
+                <label for="api-key-name" class="sr-only">API Key Name</label>
+                <input type="text" name="api-key-name" placeholder="Enter Application Name" required />
+                <button type="submit">Save</button>
+                <button type="button" class="cancel" data-toggle="close" data-targetid="create-api-key-toggle-area">Cancel</button>
+                <input type="hidden" name="type" value="create-api-key" />
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
+            </form>
+        </div>
+    </div>
+    <div class="info">
+        <form method='POST' action='/account'>
+            <table class="sortable">
+                <caption>
+                    <span class="sr-only">API Consumers table, column headers with buttons are sortable.</span>
+                </caption>
+                <thead>
+                    <tr>
+                        <th class="no-sort select-all-box"><label class="sr-only" for="select-all-api-keys">Select all api keys</label><input type="checkbox" name="select-all-api-keys" data-apikeybox="select-all" /></th>
+                        <th aria-sort="ascending">
+                            <button>
+                                Name
+                                <span aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th>
+                            <button>
+                                API Key
+                                <span aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th>
+                            <button>
+                                Create Date
+                                <span aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th>
+                            <button>
+                                Last Updated
+                                <span aria-hidden="true"></span>
+                            </button>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($wptApiKey as $row) : ?>
+                        <tr>
+                            <td>
+                                <input type='checkbox' data-apikeybox="individual" name='api-key-id[]' value='<?= $row['id'] ?>' />
+                            </td>
+                            <td><?= $row['name'] ?></td>
+                            <td class="hidden-content">
+                                <button type="button" class="view-button">View</button>
+                                <span class="hidden-area closed">
+                                    <span class="api-key"><?= $row['apiKey'] ?></span>
+                                    <button type="button" class="hide-button"><span class="sr-only">Close</span></button>
+                            </td>
+                            </span>
+                            <td><?= date_format(date_create($row['createDate']), 'M d Y H:i:s e') ?></td>
+                            <td><?= date_format(date_create($row['changeDate']), 'M d Y H:i:s e') ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+            <input type='hidden' name='type' value='delete-api-key' />
+            <input type='hidden' name='csrf_token' value='<?= $csrf_token ?>' />
+            <input type="submit" id="delete-api-key-submit-input" class="sr-only" />
+        </form>
+    </div>
+</div>

--- a/www/templates/account/includes/billing-data.php
+++ b/www/templates/account/includes/billing-data.php
@@ -46,134 +46,50 @@
     </div>
 </div>
 
-<?php if (!$is_wpt_enterprise) : ?>
-    <div class="card billing-history">
-        <div class="info">
-            <table class="sortable responsive-vertical-table">
-                <caption>
-                    <h3>Billing History</h3>
-                    <span class="sr-only">, column headers with buttons are sortable.</span>
-                </caption>
-                <thead>
-                    <tr>
-                        <th aria-sort="ascending">
-                            <button>
-                                Date Time Stamp
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
-                        <th>
-                            <button>
-                                Credit Card
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
-                        <th>
-                            <button>
-                                Card Number
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
-                        <th>
-                            <button>
-                                Amount
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($braintreeTransactionHistory as $row) : ?>
-                        <tr>
-                            <td data-th="DateTime"><?= date_format(date_create($row['transactionDate']), 'M d Y H:i:s e') ?></td>
-                            <td data-th="Credit Card"><?= $row['cardType'] ?></td>
-                            <td data-th="Card No."><?= $row['maskedCreditCard'] ?></td>
-                            <td data-th="Amount">$<?= $row['amount'] ?></td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        </div>
-    </div>
-<?php endif; // (!$is_wpt_enterprise):
-?>
-
-<div class="card api-consumers">
-    <h3>API Consumers</h3>
-    <div class="create-key-container">
-        <div class="create-delete-button-container">
-            <button type="button" class="new-api-key" data-toggle="open" data-targetid="create-api-key-toggle-area">New Api Key</button>
-            <label for="delete-api-key-submit-input" class="delete-key disabled" data-apikeybox="delete-button" disabled>Delete</label>
-        </div>
-        <div class="toggleable" id="create-api-key-toggle-area">
-            <form method="POST" action="/account">
-                <label for="api-key-name" class="sr-only">API Key Name</label>
-                <input type="text" name="api-key-name" placeholder="Enter Application Name" required />
-                <button type="submit">Save</button>
-                <button type="button" class="cancel" data-toggle="close" data-targetid="create-api-key-toggle-area">Cancel</button>
-                <input type="hidden" name="type" value="create-api-key" />
-                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
-            </form>
-        </div>
-    </div>
+<div class="card billing-history">
     <div class="info">
-        <form method='POST' action='/account'>
-            <table class="sortable">
-                <caption>
-                    <span class="sr-only">API Consumers table, column headers with buttons are sortable.</span>
-                </caption>
-                <thead>
+        <table class="sortable responsive-vertical-table">
+            <caption>
+                <h3>Billing History</h3>
+                <span class="sr-only">, column headers with buttons are sortable.</span>
+            </caption>
+            <thead>
+                <tr>
+                    <th aria-sort="ascending">
+                        <button>
+                            Date Time Stamp
+                            <span aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th>
+                        <button>
+                            Credit Card
+                            <span aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th>
+                        <button>
+                            Card Number
+                            <span aria-hidden="true"></span> </button>
+                    </th>
+                    <th>
+                        <button>
+                            Amount
+                            <span aria-hidden="true"></span>
+                        </button>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($braintreeTransactionHistory as $row) : ?>
                     <tr>
-                        <th class="no-sort select-all-box"><label class="sr-only" for="select-all-api-keys">Select all api keys</label><input type="checkbox" name="select-all-api-keys" data-apikeybox="select-all" /></th>
-                        <th aria-sort="ascending">
-                            <button>
-                                Name
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
-                        <th>
-                            <button>
-                                API Key
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
-                        <th>
-                            <button>
-                                Create Date
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
-                        <th>
-                            <button>
-                                Last Updated
-                                <span aria-hidden="true"></span>
-                            </button>
-                        </th>
+                        <td data-th="DateTime"><?= date_format(date_create($row['transactionDate']), 'M d Y H:i:s e') ?></td>
+                        <td data-th="Credit Card"><?= $row['cardType'] ?></td>
+                        <td data-th="Card No."><?= $row['maskedCreditCard'] ?></td>
+                        <td data-th="Amount">$<?= $row['amount'] ?></td>
                     </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($wptApiKey as $row) : ?>
-                        <tr>
-                            <td>
-                                <input type='checkbox' data-apikeybox="individual" name='api-key-id[]' value='<?= $row['id'] ?>' />
-                            </td>
-                            <td><?= $row['name'] ?></td>
-                            <td class="hidden-content">
-                                <button type="button" class="view-button">View</button>
-                                <span class="hidden-area closed">
-                                    <span class="api-key"><?= $row['apiKey'] ?></span>
-                                    <button type="button" class="hide-button"><span class="sr-only">Close</span></button>
-                            </td>
-                            </span>
-                            <td><?= date_format(date_create($row['createDate']), 'M d Y H:i:s e') ?></td>
-                            <td><?= date_format(date_create($row['changeDate']), 'M d Y H:i:s e') ?></td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-            <input type='hidden' name='type' value='delete-api-key' />
-            <input type='hidden' name='csrf_token' value='<?= $csrf_token ?>' />
-            <input type="submit" id="delete-api-key-submit-input" class="sr-only" />
-        </form>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
     </div>
 </div>

--- a/www/templates/account/my-account.php
+++ b/www/templates/account/my-account.php
@@ -72,13 +72,18 @@
         </div>
     <?php endif; ?>
 
-    <?php if ($is_paid) {
-        include_once __DIR__ . '/includes/billing-data.php';
-        include_once __DIR__ . '/includes/modals/subscription-plan.php';
-        include_once __DIR__ . '/includes/modals/payment-info.php';
+    <?php
+    if ($is_paid) {
+        if (!$is_wpt_enterprise) {
+            include_once __DIR__ . '/includes/billing-data.php';
+            include_once __DIR__ . '/includes/modals/subscription-plan.php';
+            include_once __DIR__ . '/includes/modals/payment-info.php';
+        }
+        include_once __DIR__ . '/includes/api-keys.php';
     } else {
         include_once __DIR__ . '/includes/signup.php';
-    } ?>
+    }
+    ?>
 </div>
 
 


### PR DESCRIPTION
This PR does a few things (sorry).

- Destroys sessions on logout. I don't need to keep around php sessions for users who are logging out. We have no need for that information
- Remove billing information for enterprise user account pages. We're having issues with getting any data that isn't api keys and personal info right now and will work on making the other data come back
- Format and clean up some code
- Add a little debug thing for when a user is in dev mode