### PR TITLE
Fix summary opps counts

### DIFF
--- a/www/experiments.php
+++ b/www/experiments.php
@@ -128,18 +128,7 @@ $page_description = "Website performance test result$testLabel.";
                 <?php
                     $testStepResult = TestStepResult::fromFiles($testInfo, $run, $cached, $step);
                     $requests = $testStepResult->getRequests();
-                    // initial host is used by a few opps, so we'll calculate it here
-                    $initialHost = null;
-                    $rootURL = null;
-                    $initialOrigin = null;
-                foreach ($requests as $request) {
-                    if ($request['is_base_page'] == "true") {
-                        $initialHost = $request['host'];
-                        $rootURL = trim($request['full_url']);
-                        $initialOrigin = "http" . (strpos($rootURL, "https") === 0 ? "s" : "" ) . "://" . $initialHost;
-                        break;
-                    }
-                }
+                    
 
                     include __DIR__ . '/experiments/common.inc';
 

--- a/www/experiments/common.inc
+++ b/www/experiments/common.inc
@@ -2,6 +2,20 @@
 
 // container for assessment including opportunities, experiments to recommend
 
+// initial host is used by a few opps, so we'll calculate it here
+$initialHost = null;
+$rootURL = null; 
+$initialOrigin = null;
+foreach ($requests as $request) {
+	if ($request['is_base_page'] == "true") {
+		$initialHost = $request['host'];
+		$rootURL = trim($request['full_url']);
+		$initialOrigin = "http" . (strpos( $rootURL, "https") === 0 ? "s" : "" ) . "://" . $initialHost;
+		break;
+	}
+}
+
+
 function documentRelativePath($url, $path)
 {
     $basePath = explode('/', $path);


### PR DESCRIPTION
Placing this here instead of at the top of result inc will allow the numbers to look the same on exps and result summary (commit 1 of 2).