### PR TITLE
feat(user): add first/last/company name

### DIFF
--- a/tests/CPClientTest.php
+++ b/tests/CPClientTest.php
@@ -261,17 +261,23 @@ final class CPClientTest extends TestCase
         $client->revokeToken($token);
     }
 
-    public function testGetUserDetails(): void
+    public function testGetUser(): void
     {
         $handler = $this->createMockResponse(200, '{
     "data": {
       "userIdentity": {
         "activeContact": {
           "id": 263425,
-          "name": "Alice Bob",
+          "firstName": "Alice",
+          "lastName": "Bob",
           "email": "alicebob@catchpoint.com",
           "isWptPaidUser": true,
-          "isWptAccountVerified": true
+          "isWptAccountVerified": true,
+          "companyName": null
+        },
+        "levelSummary": {
+          "levelId": 3,
+          "isWptEnterpriseClient": false
         }
       },
       "braintreeCustomerDetails": {
@@ -290,11 +296,18 @@ final class CPClientTest extends TestCase
             ]
         ));
 
-        $data = $client->getUserDetails();
-        $this->assertEquals('263425', $data['userIdentity']['activeContact']['id']);
+        $user = $client->getUser();
+        $this->assertEquals('263425', $user->getUserId());
+        $this->assertEquals('Alice', $user->getFirstName());
+        $this->assertEquals('Bob', $user->getLastName());
+        $this->assertEquals('', $user->getCompanyName());
+        $this->assertEquals('alicebob@catchpoint.com', $user->getEmail());
+        $this->assertTrue($user->isPaid());
+        $this->assertTrue($user->isVerified());
+        $this->assertFalse($user->isWptEnterpriseClient());
     }
 
-    public function testGetUserDetailsWithError(): void
+    public function testGetUserWithError(): void
     {
         $handler = $this->createMockResponse(200, '{
       "errors":[
@@ -328,7 +341,7 @@ final class CPClientTest extends TestCase
         ));
 
         $this->expectException(ClientException::class);
-        $client->getUserDetails();
+        $client->getUser();
     }
 
     public function testGetUserContactInfo(): void

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -43,4 +43,24 @@ final class UserTest extends TestCase
         $user->setUserPriority(0);
         $this->assertEquals($user->getUserPriority(), 0);
     }
+
+    public function testGetSetFirstName(): void
+    {
+        $user = new User();
+        $this->assertEquals("", $user->getFirstName());
+        $user->setFirstName();
+        $this->assertEquals("", $user->getFirstName());
+        $user->setFirstName("Gooby");
+        $this->assertEquals("Gooby", $user->getFirstName());
+    }
+
+    public function testGetSetLastName(): void
+    {
+        $user = new User();
+        $this->assertEquals("", $user->getLastName());
+        $user->setLastName();
+        $this->assertEquals("", $user->getLastName());
+        $user->setLastName("Pls");
+        $this->assertEquals("Pls", $user->getLastName());
+    }
 }

--- a/www/common/AttachUser.php
+++ b/www/common/AttachUser.php
@@ -18,28 +18,17 @@ use WebPageTest\Exception\UnauthorizedException;
 
     $user = new User();
 
-    if ($request->getClient()->isAuthenticated()) {
-        $user->setAccessToken($request->getClient()->getAccessToken());
-    }
-    if (isset($_COOKIE[$cp_refresh_token_cookie_name])) {
-        $user->setRefreshToken($_COOKIE[$cp_refresh_token_cookie_name]);
-    }
-
-    $access_token = $user->getAccessToken();
-
     // Signed in, grab info on user
-    if (!is_null($access_token)) {
+    if ($request->getClient()->isAuthenticated()) {
         try {
-            $data = $request->getClient()->getUserDetails();
-            $user->setRemainingRuns($data['braintreeCustomerDetails']['remainingRuns']);
-            $user->setMonthlyRuns($data['braintreeCustomerDetails']['monthlyRuns']);
-            $user->setUserId($data['userIdentity']['activeContact']['id']);
-            $user->setEmail($data['userIdentity']['activeContact']['email']);
-            $user->setPaid($data['userIdentity']['activeContact']['isWptPaidUser']);
-            $user->setVerified($data['userIdentity']['activeContact']['isWptAccountVerified']);
-            $user->setOwnerId($data['userIdentity']['levelSummary']['levelId']);
-            $user->setEnterpriseClient(!!$data['userIdentity']['levelSummary']['isWptEnterpriseClient']);
+            $user = $request->getClient()->getUser();
             $owner = $user->getOwnerId();
+            if ($request->getClient()->isAuthenticated()) {
+                $user->setAccessToken($request->getClient()->getAccessToken());
+            }
+            if (isset($_COOKIE[$cp_refresh_token_cookie_name])) {
+                $user->setRefreshToken($_COOKIE[$cp_refresh_token_cookie_name]);
+            }
         } catch (UnauthorizedException $e) {
             error_log($e->getMessage());
             // if this fails, Refresh and retry
@@ -65,16 +54,14 @@ use WebPageTest\Exception\UnauthorizedException;
                         "/",
                         $host
                     );
-                    $data = $request->getClient()->getUserDetails();
-                    $user->setUserId($data['userIdentity']['activeContact']['id']);
-                    $user->setRemainingRuns($data['braintreeCustomerDetails']['remainingRuns']);
-                    $user->setMonthlyRuns($data['braintreeCustomerDetails']['monthlyRuns']);
-                    $user->setEmail($data['userIdentity']['activeContact']['email']);
-                    $user->setPaid($data['userIdentity']['activeContact']['isWptPaidUser']);
-                    $user->setVerified($data['userIdentity']['activeContact']['isWptAccountVerified']);
-                    $user->setOwnerId($data['userIdentity']['levelSummary']['levelId']);
-                    $user->setEnterpriseClient(!!$data['userIdentity']['levelSummary']['isWptEnterpriseClient']);
+                    $user = $request->getClient()->getUser();
                     $owner = $user->getOwnerId();
+                    if ($request->getClient()->isAuthenticated()) {
+                        $user->setAccessToken($request->getClient()->getAccessToken());
+                    }
+                    if (isset($_COOKIE[$cp_refresh_token_cookie_name])) {
+                        $user->setRefreshToken($_COOKIE[$cp_refresh_token_cookie_name]);
+                    }
                 } catch (Exception $e) {
                     error_log($e->getMessage());
                     // if this fails, delete all the cookies

--- a/www/cpauth/account.php
+++ b/www/cpauth/account.php
@@ -97,11 +97,10 @@ $is_verified = $request_context->getUser()->isVerified();
 $is_wpt_enterprise = $request_context->getUser()->isWptEnterpriseClient();
 $user_id = $request_context->getUser()->getUserId();
 $remainingRuns = $request_context->getUser()->getRemainingRuns();
-$user_contact_info = $request_context->getClient()->getUserContactInfo($user_id);
 $user_email = $request_context->getUser()->getEmail();
-$first_name = $user_contact_info['firstName'] ?? "";
-$last_name = $user_contact_info['lastName'] ?? "";
-$company_name = $user_contact_info['companyName'] ?? "";
+$first_name = $request_context->getUser()->getFirstName();
+$last_name = $request_context->getUser()->getLastName();
+$company_name = $request_context->getUser()->getCompanyName();
 
 $contact_info = array(
     'layout_theme' => 'b',

--- a/www/src/User.php
+++ b/www/src/User.php
@@ -16,10 +16,16 @@ class User
     private bool $is_wpt_enterprise_client;
     private int $remaining_runs;
     private int $monthly_runs;
+    private string $first_name;
+    private string $last_name;
+    private string $company_name;
 
     public function __construct()
     {
         $this->email = null;
+        $this->first_name = "";
+        $this->last_name = "";
+        $this->company_name = "";
         $this->is_admin = false;
         $this->owner_id = "2445"; // owner id of 2445 was for unpaid users
         $this->access_token = null;
@@ -172,5 +178,35 @@ class User
     public function getUserPriority(): ?int
     {
         return $this->user_priority;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->first_name;
+    }
+
+    public function setFirstName(?string $first_name = ""): void
+    {
+        $this->first_name = $first_name ?? "";
+    }
+
+    public function getLastName(): string
+    {
+        return $this->last_name;
+    }
+
+    public function setLastName(?string $last_name = ""): void
+    {
+        $this->last_name = $last_name ?? "";
+    }
+
+    public function getCompanyName(): string
+    {
+        return $this->company_name;
+    }
+
+    public function setCompanyName(?string $company_name = ""): void
+    {
+        $this->company_name = $company_name ?? "";
     }
 }


### PR DESCRIPTION
you can have a little $user->getFirstName() and $user->getLastName(),
and $user->getCompanyName() [as well as all of their sets] as a treat.

This is a multi-piece job.

- we add first, last, and company name all to the User object.
- we query for those things on the activeContact on every page load
    - This allows us to take out the getUserContactInfo query,
      making the account page faster
- we move all of that setting of things out of the middleware and into
  the client itself and have the client return a user object. This is so
  we have better tooling and we stop doing _so_ many things in two
  places.
- add some tests to make sure this all works