### PR TITLE
Surface extensions in the UI

### DIFF
--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1202,6 +1202,9 @@ function GetTestInfoHtml($includeScript = true)
     if (isset($test['testinfo']['addCmdLine']) && strlen($test['testinfo']['addCmdLine'])) {
         $html .= '<li>Command Line: ' . htmlspecialchars($test['testinfo']['addCmdLine']) . '</li>';
     }
+    if (isset($test['testinfo']['extensions']) && strlen($test['testinfo']['extensions'])) {
+        $html .= '<li>Enable extension: ' . htmlspecialchars($test['testinfo']['extensions']) . '</li>';
+    }
 
     if (isset($test['testinfo']['connectivity']) && strcasecmp($test['testinfo']['connectivity'], 'custom') != 0) {
         $html .= "<li>Connectivity: {$test['testinfo']['bwIn']}/{$test['testinfo']['bwOut']} Kbps, {$test['testinfo']['latency']}ms Latency";
@@ -3318,11 +3321,39 @@ function PopulateTestInfo(&$test)
             $ret[$key] = $test[$key];
         }
     };
-    $keys = array('url', 'runs', 'fvonly', 'web10', 'ignoreSSL', 'video', 'label',
-      'priority', 'block', 'location', 'browser', 'connectivity', 'bwIn', 'bwOut',
-      'latency', 'plr', 'tcpdump', 'timeline', 'trace', 'bodies', 'netlog',
-      'standards', 'noscript', 'pngss', 'iq', 'bodies', 'keepua', 'benchmark',
-      'mobile', 'tsview_id', 'addCmdLine');
+    $keys = array(
+        'addCmdLine',
+        'benchmark',
+        'block',
+        'bodies',
+        'browser',
+        'bwIn',
+        'bwOut',
+        'connectivity',
+        'extensions',
+        'fvonly',
+        'ignoreSSL',
+        'iq',
+        'keepua',
+        'label',
+        'latency',
+        'location',
+        'mobile',
+        'netlog',
+        'noscript',
+        'plr',
+        'pngss',
+        'priority',
+        'runs',
+        'standards',
+        'tcpdump',
+        'timeline',
+        'trace',
+        'tsview_id',
+        'url',
+        'video',
+        'web10',
+    );
     foreach ($keys as $key) {
         $copy($key);
     }

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -1202,8 +1202,8 @@ function GetTestInfoHtml($includeScript = true)
     if (isset($test['testinfo']['addCmdLine']) && strlen($test['testinfo']['addCmdLine'])) {
         $html .= '<li>Command Line: ' . htmlspecialchars($test['testinfo']['addCmdLine']) . '</li>';
     }
-    if (isset($test['testinfo']['extensions']) && strlen($test['testinfo']['extensions'])) {
-        $html .= '<li>Enable extension: ' . htmlspecialchars($test['testinfo']['extensions']) . '</li>';
+    if (isset($test['testinfo']['extensionName']) && strlen($test['testinfo']['extensionName'])) {
+        $html .= '<li>Enable extension: ' . htmlspecialchars($test['testinfo']['extensionName']) . '</li>';
     }
 
     if (isset($test['testinfo']['connectivity']) && strcasecmp($test['testinfo']['connectivity'], 'custom') != 0) {
@@ -3331,6 +3331,7 @@ function PopulateTestInfo(&$test)
         'bwOut',
         'connectivity',
         'extensions',
+        'extensionName',
         'fvonly',
         'ignoreSSL',
         'iq',

--- a/www/home.php
+++ b/www/home.php
@@ -786,6 +786,28 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
                                                     </label>
                                                     <input type="text" name="cmdline" id="cmdline" class="text" style="width: 400px;" autocomplete="off">
                                                 </li>
+                                                <?php
+                                                $rawextensions = Util::getSetting('extensions');
+                                                if ($rawextensions) {
+                                                    $extensions = explode(',', $rawextensions);
+                                                ?>
+                                                <li>
+                                                    <label for="extensions">
+                                                        Enable extension<br>
+                                                    </label>
+                                                    <select name="extensions" id="extensions">
+                                                        <option>Pick an extension...</option>
+                                                        <?php
+                                                        foreach($extensions as $ext) {
+                                                            [$id, $name] = explode('/', $ext);
+                                                            echo '<option value="'.$id.'">' . htmlspecialchars($name) . '</option>';
+                                                        }
+                                                        ?>
+                                                    <select>
+                                                </li>
+                                                <?php
+                                                }
+                                                ?>
                                             </ul>
                                         </div>
                                         <?php if (!GetSetting('no_basic_auth_ui') || isset($_GET['auth'])) { ?>

--- a/www/home.php
+++ b/www/home.php
@@ -7,6 +7,8 @@
 include 'common.inc';
 
 use WebPageTest\Util;
+use WebPageTest\Util\IniReader;
+
 // see if we are overriding the max runs
 $max_runs = GetSetting('maxruns', 9);
 if (isset($_COOKIE['maxruns']) && (int)$_GET['maxruns'] > 0) {
@@ -787,9 +789,8 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
                                                     <input type="text" name="cmdline" id="cmdline" class="text" style="width: 400px;" autocomplete="off">
                                                 </li>
                                                 <?php
-                                                $rawextensions = Util::getSetting('extensions');
-                                                if ($rawextensions) {
-                                                    $extensions = explode(',', $rawextensions);
+                                                $extensions = IniReader::getExtensions();
+                                                if ($extensions) {
                                                 ?>
                                                 <li>
                                                     <label for="extensions">
@@ -798,8 +799,7 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
                                                     <select name="extensions" id="extensions">
                                                         <option>Pick an extension...</option>
                                                         <?php
-                                                        foreach($extensions as $ext) {
-                                                            [$id, $name] = explode('/', $ext);
+                                                        foreach($extensions as $id => $name) {
                                                             echo '<option value="'.$id.'">' . htmlspecialchars($name) . '</option>';
                                                         }
                                                         ?>

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -49,6 +49,7 @@ use WebPageTest\Util;
 use WebPageTest\Util\Cache;
 use WebPageTest\Template;
 use WebPageTest\RateLimiter;
+use WebPageTest\Util\IniReader;
 
 require_once('./ec2/ec2.inc.php');
 require_once(__DIR__ . '/include/CrUX.php');
@@ -520,7 +521,12 @@ if (@strlen($req_rkey)) {
         }
 
         if (isset($_REQUEST['extensions']) && is_string($_REQUEST['extensions']) && strlen($_REQUEST['extensions']) == 32) {
-            $test['extensions'] = $_REQUEST['extensions'];
+            $extensions = IniReader::getExtensions();
+            $requested = $_REQUEST['extensions'];
+            if (array_key_exists($requested, $extensions)) {
+                $test['extensions'] = $_REQUEST['extensions'];
+                $test['extensionName'] = $extensions[$requested];
+            }
         }
 
         // Store an opaque metadata string/JSON object if one was provided (up to 10KB)
@@ -3050,6 +3056,9 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
             }
             if (array_key_exists('extensions', $test) && strlen($test['extensions'])) {
                 $job['extensions'] = $test['extensions'];
+            }
+            if (array_key_exists('extensionName', $test) && strlen($test['extensionName'])) {
+                $job['extensionName'] = $test['extensionName'];
             }
             if (array_key_exists('customBrowserUrl', $test) && strlen($test['customBrowserUrl'])) {
                 $job['customBrowserUrl'] = $test['customBrowserUrl'];

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -519,6 +519,10 @@ if (@strlen($req_rkey)) {
             $test['addCmdLine'] .= "--host-resolver-rules=\"$req_hostResolverRules,EXCLUDE localhost,EXCLUDE 127.0.0.1\"";
         }
 
+        if (isset($_REQUEST['extensions']) && is_string($_REQUEST['extensions']) && strlen($_REQUEST['extensions']) == 32) {
+            $test['extensions'] = $_REQUEST['extensions'];
+        }
+
         // Store an opaque metadata string/JSON object if one was provided (up to 10KB)
         if (isset($_REQUEST['metadata']) && is_string($_REQUEST['metadata']) && strlen($_REQUEST['metadata'] <= 10240)) {
             $metadata = $_REQUEST['metadata'];
@@ -3043,6 +3047,9 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
             }
             if (array_key_exists('addCmdLine', $test) && strlen($test['addCmdLine'])) {
                 $job['addCmdLine'] = $test['addCmdLine'];
+            }
+            if (array_key_exists('extensions', $test) && strlen($test['extensions'])) {
+                $job['extensions'] = $test['extensions'];
             }
             if (array_key_exists('customBrowserUrl', $test) && strlen($test['customBrowserUrl'])) {
                 $job['customBrowserUrl'] = $test['customBrowserUrl'];

--- a/www/settings/extensions.ini.sample
+++ b/www/settings/extensions.ini.sample
@@ -1,0 +1,14 @@
+[extensions]
+; sorted alphabetically by name
+eiimnmioipafcokbfikbljfdeojpcgbh = "BlockSite: Block Websites & Stay Focused"
+hgenngnjgfkdggambccohomebieocekm = "Bulk URL Opener Extension"
+bhlhnicpbhignbdhedgjhgdocnmhomnp = "ColorZilla"
+bmjmipppabdlpjccanalncobmbacckjn = "Cursor style - custom cursor for your browser"
+ogdlpmhglpejoiomcodnpjnfgcpmgale = "Custom Cursor for Chrome"
+aapbdbdomjkkjkaonfhkkikfgjllcleb = "Google Translate"
+gcbommkclmclpchllfjekcdonpmejbdp = "HTTPS Everywhere"
+bmnlcjabgnpnenekpadlanbbkooimhnj = "PayPal Honey: Automatic Coupons & Cash Back"
+jfbnmfgkohlfclfnplnlenbalpppohkm = "Roblox+"
+jghecgabfgfdldnmbfkhmffcabddioke = "Volume Master"
+cjpalhdlnbpafiamejdnhcphjbkeiagm = "uBlock Origin"
+kgjfgplpablkjnlkjmjdecgdpfankdle = "Zoom Scheduler"

--- a/www/src/Util/IniReader.php
+++ b/www/src/Util/IniReader.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebPageTest\Util;
+
+class IniReader
+{
+    public static function getExtensions(): array
+    {
+        $file = __DIR__ . '/../../settings/extensions.ini';
+        if (is_file($file)) {
+            return parse_ini_file($file);
+        }
+        return [];
+    }
+}


### PR DESCRIPTION
The agent work was done by @pmeenan a while ago: https://github.com/WPO-Foundation/wptagent/pull/499/commits/5e0b90031ab5e580d40e2b987e76322a78f8104f

This implementation lists the top X extensions. Where X is 12, as seen in the chrome web store homepage as "recommended for you" loaded in incognito. Looking at https://chrome.google.com/webstore/category/recommended_extensions now (as opposed to last week) seems things change pretty rapidly, so we might need a better way to get the top X

This is the new UI in the Chrome tab:

<img width="1178" alt="Screen Shot 2022-09-06 at 12 58 33 PM" src="https://user-images.githubusercontent.com/51308/188696871-58013c55-d8d2-4a16-9d7e-ab94dd820995.png">

Test results:

<img width="856" alt="Screen Shot 2022-09-06 at 1 05 06 PM" src="https://user-images.githubusercontent.com/51308/188697268-d9a7778c-d1bc-46be-aebb-2c9060f057fb.png">



