### PR TITLE
Fix the height of webvitals content iframe

### DIFF
--- a/www/webvitals.php
+++ b/www/webvitals.php
@@ -134,7 +134,7 @@ $profiles = parse_ini_file($profile_file, true);
         </div><!--home_content-->
 
         <div class="home_content_contain">
-          <iframe id="vitals-content" frameBorder="0" scrolling="no" height="3250" src="https://www.product.webpagetest.org/second"></iframe>
+          <iframe id="vitals-content" frameBorder="0" scrolling="no" height="3370" src="https://www.product.webpagetest.org/second"></iframe>
             </div><!--home_content_contain-->
 
             <div class="home_content_contain">


### PR DESCRIPTION
This is just a quick patch, a better iframe resizing is necessary based on the content height, because of user fonts, etc.

Before:

<img width="1639" alt="Screen Shot 2022-09-07 at 11 30 11 AM" src="https://user-images.githubusercontent.com/51308/188918491-1242dec6-9222-4ff7-8ef4-abba854b32b1.png">

After:

<img width="1570" alt="Screen Shot 2022-09-07 at 11 30 22 AM" src="https://user-images.githubusercontent.com/51308/188918507-6d2a6cb3-0fdf-45b1-b26f-ee3c96057d78.png">
