### PR TITLE
Webvitals page: prevent double js loading

### DIFF
--- a/www/webvitals.php
+++ b/www/webvitals.php
@@ -146,14 +146,6 @@ $profiles = parse_ini_file($profile_file, true);
           </div><!--home_content_contain-->
         </div><!--home_content-->
         </div>
-        <?php
-        if (!isset($site_js_loaded) || !$site_js_loaded) {
-            echo "<script src=\"{$GLOBALS['cdnPath']}/assets/js/jquery.js\"></script>\n";
-            echo "<script src=\"{$GLOBALS['cdnPath']}/assets/js/site.js?v=" . VER_JS . "\"></script>\n";
-            $hasJquery = true;
-        }
-        ?>
-
         <script>
         <?php
           echo "var profiles = " . json_encode($profiles) . ";\n";


### PR DESCRIPTION
As far as I can tell `$site_js_loaded` is not set anywhere in the codebase.

Since we're including the footer in this page, it loads the JS, no need to load it again.

Fixes #2307