### PR TITLE
Webvitals: unbreak the profile selection

### DIFF
--- a/www/webvitals.php
+++ b/www/webvitals.php
@@ -161,7 +161,7 @@ $profiles = parse_ini_file($profile_file, true);
         var wptStorage = window.localStorage || {};
 
         var profileChanged = function() {
-          var sel = document.getElementById("profile");
+          var sel = document.getElementById("webvital_profile");
           var txt = document.getElementById("description");
           var profile = sel.options[sel.selectedIndex].value;
           var description = "";


### PR DESCRIPTION
s/profile/webvital_profile/

Results!
 * the JS error (`sel` is null so cannot read `sel.options`) is gone
 * the cookie `wvProfile` is written
 * the description of the profile shows up:
<img width="859" alt="Screen Shot 2022-09-07 at 12 04 45 PM" src="https://user-images.githubusercontent.com/51308/188927301-8a6e4c50-4a57-4d98-8493-c361e8de39c7.png">
