### PR TITLE
Offer ability to remove TTFB variance from experiment comparison

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -281,6 +281,15 @@ details.metrics_shown summary::-webkit-details-marker {
   margin-bottom: 1.5rem;
 }
 
+p.ttfb_experiment_warning {
+  font-size: .9rem;
+  padding: 1em;
+  border: 1px solid #e6b57e;
+  background: #fff6df;
+  max-width: none;
+  border-radius: 0.5em;
+}
+
 .opportunities_summary .extended {
   white-space: break-spaces;
 }

--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -281,13 +281,13 @@ details.metrics_shown summary::-webkit-details-marker {
   margin-bottom: 1.5rem;
 }
 
-p.ttfb_experiment_warning {
-  font-size: .9rem;
-  padding: 1em;
-  border: 1px solid #e6b57e;
-  background: #fff6df;
-  max-width: none;
-  border-radius: 0.5em;
+.compare-experiment p.ttfb_experiment_warning {
+    font-size: .9rem;
+    padding: 1em;
+    border: 1px solid #e6b57e;
+    background: #fff6df;
+    max-width: none;
+    border-radius: 0.5em;
 }
 
 .opportunities_summary .extended {

--- a/www/experiments/findings.inc
+++ b/www/experiments/findings.inc
@@ -85,7 +85,7 @@ if ($experiment) {
                             $controlMetric = $controlMetric - $controlTTFB;
                         }
                         $thisDiff = $controlMetric - $experimentMetric;
-                        $units = "<span class=\"units\">" . $metric[2] . "</span>";
+                        $units = '<span class="units">' . $metric[2] . '</span>';
                         $changeTerms = array("Faster", "Slower");
                         if ($metric[3]) {
                             $changeTerms = $metric[3];
@@ -133,7 +133,7 @@ if ($ttfbDiffNotable) {
     if ($removeTTFBfromDiffs) {
         echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> This comparison view is omitting TTFB to adjust for network variance. <a href="' . $experimentResultsHref . '">View this comparison with TTFB differences visible.</a>';
     } else {
-        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> We noticed a ' . $ttfbDiffClean . 's difference in response time between the experiment and control runs, which can make other metric changes seem more significant than they really are. <a href="' . $experimentResultsHref . '&ignoreTTFB">View this comparison with TTFB differences removed</a>';
+        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> This experiment had a ' . $ttfbDiffClean . 's difference in response time between the median experiment and control runs, which can make other metric changes seem more significant than they really are. To examine the variability of response times in all test runs, you can <a href="/graph_page_data.php?tests='.$tests[0]["id"]. ',' .$tests[1]['id'].'&medianMetric=ttfb&control=1">plot full results</a>. Or, you can <a href="' . $experimentResultsHref . '&ignoreTTFB">view this comparison with TTFB removed from later metric comparisons</a>.';
     }
 }
 

--- a/www/experiments/findings.inc
+++ b/www/experiments/findings.inc
@@ -1,6 +1,7 @@
 <?php
 
 if ($experiment) {
+
     // compare render-blocking scripts
     $experimentBlockingReqs = array();
     $experimentRequests = $tests[0]['stepResult']->getRequests();
@@ -23,86 +24,137 @@ if ($experiment) {
 
 
     $diffMetrics = array(
-        //array( "TTFB", "Time to First Byte", "s"),
-        array( "StartRender", "Start Render", "s"),
-        array( "firstContentfulPaint", "First Contentful Paint", "s"),
-        array( "SpeedIndex", "Speed Index", "s"),
-        array( "chromeUserTiming.LargestContentfulPaint", "Largest Contentful Paint", "s"),
-        array( "chromeUserTiming.CumulativeLayoutShift", "Cumulative Layout Shift", "", array("Better","Worse")),
-        array( "TotalBlockingTime", "Total Blocking Time", "s"),
-        array( "visualComplete", "Visual Complete", "s"),
-        array( "FullyLoaded", "Fully Loaded", "s"),
-        array( "BytesIn", "Total Bytes", "kb", array("Lighter","Heavier"))
+        //array( "TTFB", "Time to First Byte", "s"), 
+        array("render", "Start Render", "s"),
+        array("firstContentfulPaint", "First Contentful Paint", "s"),
+        array("SpeedIndex", "Speed Index", "s"),
+        array("chromeUserTiming.LargestContentfulPaint", "Largest Contentful Paint", "s"),
+        array("chromeUserTiming.CumulativeLayoutShift", "Cumulative Layout Shift", "", array("Better", "Worse")),
+        array("TotalBlockingTime", "Total Blocking Time", "s"),
+        array("visualComplete", "Visual Complete", "s"),
+        array("fullyLoaded", "Fully Loaded", "s"),
+        array("BytesIn", "Total Bytes", "kb", array("Lighter", "Heavier"))
     );
 
-    ?>
-<div class="scrollableTable">
-    <table id="tableResults" class="pretty">
-        <tbody>
-            <tr class="metric_labels">
-                <?php
-                foreach ($diffMetrics as $metric) {
-                    $experimentMetric = $tests[0]['stepResult']->getMetric($metric[0]);
-                    $thisDiff = $tests[1]['stepResult']->getMetric($metric[0]) - $experimentMetric;
-                    $thisDiff = floatval(removeLeadingZero(round($thisDiff, 3)));
-                    if (abs($thisDiff) > 0) {
-                        echo '<th align="center" valign="middle">' . $metric[1] . '</th>';
-                    }
-                }
 
-                    // additional non-metric comparisons
-                if ($blockingReqsDiff !== 0) {
-                    echo '<th align="center" valign="middle">Render-Blocking Requests</th>';
-                }
-
-                ?>
-            </tr>
-            <tr>
-                <?php
-                foreach ($diffMetrics as $metric) {
-                    $experimentMetric = $tests[0]['stepResult']->getMetric($metric[0]);
-                    $controlMetric = $tests[1]['stepResult']->getMetric($metric[0]);
-                    $thisDiff = $controlMetric - $experimentMetric;
-                    $units = "<span class=\"units\">" . $metric[2] . "</span>";
-                    $changeTerms = array("Faster","Slower");
-                    if ($metric[3]) {
-                        $changeTerms = $metric[3];
-                    }
-                    $thisDiff = floatval(removeLeadingZero(round($thisDiff, 3)));
-                    $experimentMetric = floatval(removeLeadingZero(round($experimentMetric, 3)));
-                    $controlMetric = floatval(removeLeadingZero(round($controlMetric, 3)));
-
-                    $change = '<span class="metric_change"><em>' . ( $thisDiff >= 0 ? $changeTerms[0] : $changeTerms[1] ) . '</em></span>';
+    // see if there's a notable diff in TTFB first, which is usually unrelated to the experiment
+    // offer a link and query string to ignore ttfb in some metrics
+    $experimentTTFB = $tests[0]['stepResult']->getMetric("TTFB");
+    $controlTTFB = $tests[1]['stepResult']->getMetric("TTFB");
+    $ttfbDiff = $tests[1]['stepResult']->getMetric("TTFB") - $tests[0]['stepResult']->getMetric("TTFB");
+    $ttfbDiffClean = floatval(removeLeadingZero(round($ttfbDiff, 3)));
+    $ttfbDiffClean = abs(round($ttfbDiffClean / 1000, 2));
+    $ttfbDiffNotable = abs($ttfbDiff) > 100;
+    $removeTTFBfromDiffs = isset($_GET['ignoreTTFB']);
 
 
+    // check if metric might benefit from TTFB removal
+    function ignoreTTFBforMetric($metric)
+    {
+        global $removeTTFBfromDiffs;
+        if (
+            $removeTTFBfromDiffs
+            && ($metric === "render"
+                || $metric === "firstContentfulPaint"
+                || $metric === "SpeedIndex"
+                || $metric === "chromeUserTiming.LargestContentfulPaint"
+                || $metric === "visualComplete"
+                || $metric === "fullyLoaded")
+        ) {
+            return true;
+        }
+        return false;
+    }
 
-                    if (abs($thisDiff) > 0) {
-                        if ($metric[2] === "s") {
-                            $thisDiff = round($thisDiff / 1000, 2);
-                            $experimentMetric = round($experimentMetric / 1000, 2);
-                            $controlMetric = round($controlMetric / 1000, 2);
+
+?>
+    <div class="scrollableTable">
+        <table id="tableResults" class="pretty">
+            <tbody>
+                <tr class="metric_labels">
+                    <?php
+                    foreach ($diffMetrics as $metric) {
+                        $experimentMetric = $tests[0]['stepResult']->getMetric($metric[0]);
+                        $controlMetric = $tests[1]['stepResult']->getMetric($metric[0]);
+                        if (ignoreTTFBforMetric($metric[0])) {
+                            $experimentMetric = $experimentMetric - $experimentTTFB;
+                            $controlMetric = $controlMetric - $controlTTFB;
                         }
-                        $compare = '<span class="metric_experiment"><span>Experiment:</span><span>' . $experimentMetric .  $units . '</span></span>';
-                        $compare .= '<span class="metric_control"><span>Control:</span><span>' . $controlMetric .  $units . '</span></span>';
-                        echo '<td id="TTFB" valign="middle" class="' . ( $thisDiff >= 0 ? "good" : "poor" ) . '">' . abs($thisDiff) . $units . $change . $compare . '</td>';
+                        $thisDiff = $controlMetric - $experimentMetric;
+
+                        $thisDiff = floatval(removeLeadingZero(round($thisDiff, 3)));
+                        if (abs($thisDiff) > 0) {
+                            echo '<th align="center" valign="middle">' . $metric[1] . '</th>';
+                        }
                     }
-                }
 
                     // additional non-metric comparisons
-                if ($blockingReqsDiff !== 0) {
-                    $changeTerms = array("Fewer","More");
-                    $units = "";
-                    $change = '<span class="metric_change"><em>' . ( $blockingReqsDiff >= 0 ? $changeTerms[0] : $changeTerms[1] ) . '</em></span>';
-                    $compare = '<span class="metric_experiment"><span>Experiment:</span><span>' . count($experimentBlockingReqs) .  $units . '</span></span>';
-                    $compare .= '<span class="metric_control"><span>Control:</span><span>' . count($controlBlockingReqs) .  $units . '</span></span>';
+                    if ($blockingReqsDiff !== 0) {
+                        echo '<th align="center" valign="middle">Render-Blocking Requests</th>';
+                    }
 
-                    echo '<td id="TTFB" valign="middle" class="' . ( $blockingReqsDiff >= 0 ? "good" : "poor" ) . '">' . abs($blockingReqsDiff) . $units . $change . $compare . '</td>';
-                }
-                ?>
-            </tr>
-        </tbody>
-    </table>
-</div>
+                    ?>
+                </tr>
+                <tr>
+                    <?php
+                    foreach ($diffMetrics as $metric) {
+                        $experimentMetric = $tests[0]['stepResult']->getMetric($metric[0]);
+                        $controlMetric = $tests[1]['stepResult']->getMetric($metric[0]);
+                        if (ignoreTTFBforMetric($metric[0])) {
+                            $experimentMetric = $experimentMetric - $experimentTTFB;
+                            $controlMetric = $controlMetric - $controlTTFB;
+                        }
+                        $thisDiff = $controlMetric - $experimentMetric;
+                        $units = "<span class=\"units\">" . $metric[2] . "</span>";
+                        $changeTerms = array("Faster", "Slower");
+                        if ($metric[3]) {
+                            $changeTerms = $metric[3];
+                        }
+                        $thisDiff = floatval(removeLeadingZero(round($thisDiff, 3)));
+                        $experimentMetric = floatval(removeLeadingZero(round($experimentMetric, 3)));
+                        $controlMetric = floatval(removeLeadingZero(round($controlMetric, 3)));
+
+                        $change = '<span class="metric_change"><em>' . ($thisDiff >= 0 ? $changeTerms[0] : $changeTerms[1]) . '</em></span>';
 
 
-<?php } ?>
+
+                        if (abs($thisDiff) > 0) {
+                            if ($metric[2] === "s") {
+                                $thisDiff = round($thisDiff / 1000, 2);
+                                $experimentMetric = round($experimentMetric / 1000, 2);
+                                $controlMetric = round($controlMetric / 1000, 2);
+                            }
+                            $compare = '<span class="metric_experiment"><span>Experiment:</span><span>' . $experimentMetric .  $units . '</span></span>';
+                            $compare .= '<span class="metric_control"><span>Control:</span><span>' . $controlMetric .  $units . '</span></span>';
+                            echo '<td id="TTFB" valign="middle" class="' . ($thisDiff >= 0 ? "good" : "poor") . '">' . abs($thisDiff) . $units . $change . $compare . '</td>';
+                        }
+                    }
+
+                    // additional non-metric comparisons
+                    if ($blockingReqsDiff !== 0) {
+                        $changeTerms = array("Fewer", "More");
+                        $units = "";
+                        $change = '<span class="metric_change"><em>' . ($blockingReqsDiff >= 0 ? $changeTerms[0] : $changeTerms[1]) . '</em></span>';
+                        $compare = '<span class="metric_experiment"><span>Experiment:</span><span>' . count($experimentBlockingReqs) .  $units . '</span></span>';
+                        $compare .= '<span class="metric_control"><span>Control:</span><span>' . count($controlBlockingReqs) .  $units . '</span></span>';
+
+                        echo '<td id="TTFB" valign="middle" class="' . ($blockingReqsDiff >= 0 ? "good" : "poor") . '">' . abs($blockingReqsDiff) . $units . $change . $compare . '</td>';
+                    }
+                    ?>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+
+<?php }
+
+if ($ttfbDiffNotable) {
+    if ($removeTTFBfromDiffs) {
+        echo "<p class=\"ttfb_experiment_warning\"><strong>Note:</strong> This comparison view is omitting TTFB to adjust for network variance. <a href=\"" . $experimentResultsHref . "\">View this comparison with TTFB differences visible.</a>";
+    } else {
+        echo "<p class=\"ttfb_experiment_warning\"><strong>Note:</strong> We noticed a " . $ttfbDiffClean . "s difference in response time between the experiment and control runs, which are usually unrelated to the experiment and can might make other metric changes seem more significant than they really are. <a href=\"" . $experimentResultsHref . "&ignoreTTFB\">View this comparison with TTFB differences removed</a>";
+    }
+}
+
+?>

--- a/www/experiments/findings.inc
+++ b/www/experiments/findings.inc
@@ -131,9 +131,9 @@ if ($experiment) {
 
 if ($ttfbDiffNotable) {
     if ($removeTTFBfromDiffs) {
-        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> This comparison view is omitting TTFB to adjust for network variance. <a href="' . $experimentResultsHref . '">View this comparison with TTFB differences visible.</a>';
+        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> The metric comparisons above exclude differences in response time that exist between the median experiment and control runs of this experiment. <a href="' . $experimentResultsHref . '">View this comparison with TTFB differences included</a>.';
     } else {
-        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> This experiment had a ' . $ttfbDiffClean . 's difference in response time between the median experiment and control runs, which can make other metric changes seem more significant than they really are. To examine the variability of response times in all test runs, you can <a href="/graph_page_data.php?tests='.$tests[0]["id"]. ',' .$tests[1]['id'].'&medianMetric=ttfb&control=1">plot full results</a>. Or, you can <a href="' . $experimentResultsHref . '&ignoreTTFB">view this comparison with TTFB removed from later metric comparisons</a>.';
+        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> This experiment had a ' . $ttfbDiffClean . 's difference in response time between the median experiment and control runs, which can make other metric changes seem more significant than they really are. To examine the variability of response times in all test runs, you can <a href="/graph_page_data.php?tests='.$tests[0]["id"]. ',' .$tests[1]['id'].'&medianMetric=ttfb&control=1">plot full results</a>. Or, you can <a href="' . $experimentResultsHref . '&ignoreTTFB">view this comparison with TTFB removed from relevant metric comparisons</a>.';
     }
 }
 

--- a/www/experiments/findings.inc
+++ b/www/experiments/findings.inc
@@ -22,18 +22,17 @@ if ($experiment) {
     $blockingReqsDiff = count($controlBlockingReqs) - count($experimentBlockingReqs);
 
 
-
+    // item args: metric key name, readable name, units, optional comparative terms if not faster/slower, available for optional ttfb removal
     $diffMetrics = array(
-        //array( "TTFB", "Time to First Byte", "s"), 
-        array("render", "Start Render", "s"),
-        array("firstContentfulPaint", "First Contentful Paint", "s"),
-        array("SpeedIndex", "Speed Index", "s"),
-        array("chromeUserTiming.LargestContentfulPaint", "Largest Contentful Paint", "s"),
-        array("chromeUserTiming.CumulativeLayoutShift", "Cumulative Layout Shift", "", array("Better", "Worse")),
-        array("TotalBlockingTime", "Total Blocking Time", "s"),
-        array("visualComplete", "Visual Complete", "s"),
-        array("fullyLoaded", "Fully Loaded", "s"),
-        array("BytesIn", "Total Bytes", "kb", array("Lighter", "Heavier"))
+        array("render", "Start Render", "s", null, true),
+        array("firstContentfulPaint", "First Contentful Paint", "s", null, true),
+        array("SpeedIndex", "Speed Index", "s", null, true),
+        array("chromeUserTiming.LargestContentfulPaint", "Largest Contentful Paint", "s", null, true),
+        array("chromeUserTiming.CumulativeLayoutShift", "Cumulative Layout Shift", "", array("Better", "Worse"), false),
+        array("TotalBlockingTime", "Total Blocking Time", "s", null, false),
+        array("visualComplete", "Visual Complete", "s", null, true),
+        array("fullyLoaded", "Fully Loaded", "s", null, true),
+        array("BytesIn", "Total Bytes", "kb", array("Lighter", "Heavier"), false)
     );
 
 
@@ -48,25 +47,6 @@ if ($experiment) {
     $removeTTFBfromDiffs = isset($_GET['ignoreTTFB']);
 
 
-    // check if metric might benefit from TTFB removal
-    function ignoreTTFBforMetric($metric)
-    {
-        global $removeTTFBfromDiffs;
-        if (
-            $removeTTFBfromDiffs
-            && ($metric === "render"
-                || $metric === "firstContentfulPaint"
-                || $metric === "SpeedIndex"
-                || $metric === "chromeUserTiming.LargestContentfulPaint"
-                || $metric === "visualComplete"
-                || $metric === "fullyLoaded")
-        ) {
-            return true;
-        }
-        return false;
-    }
-
-
 ?>
     <div class="scrollableTable">
         <table id="tableResults" class="pretty">
@@ -76,7 +56,7 @@ if ($experiment) {
                     foreach ($diffMetrics as $metric) {
                         $experimentMetric = $tests[0]['stepResult']->getMetric($metric[0]);
                         $controlMetric = $tests[1]['stepResult']->getMetric($metric[0]);
-                        if (ignoreTTFBforMetric($metric[0])) {
+                        if ($ttfbDiffNotable && $removeTTFBfromDiffs && $metric[4]) {
                             $experimentMetric = $experimentMetric - $experimentTTFB;
                             $controlMetric = $controlMetric - $controlTTFB;
                         }
@@ -100,7 +80,7 @@ if ($experiment) {
                     foreach ($diffMetrics as $metric) {
                         $experimentMetric = $tests[0]['stepResult']->getMetric($metric[0]);
                         $controlMetric = $tests[1]['stepResult']->getMetric($metric[0]);
-                        if (ignoreTTFBforMetric($metric[0])) {
+                        if ($ttfbDiffNotable && $removeTTFBfromDiffs && $metric[4]) {
                             $experimentMetric = $experimentMetric - $experimentTTFB;
                             $controlMetric = $controlMetric - $controlTTFB;
                         }

--- a/www/experiments/findings.inc
+++ b/www/experiments/findings.inc
@@ -131,9 +131,9 @@ if ($experiment) {
 
 if ($ttfbDiffNotable) {
     if ($removeTTFBfromDiffs) {
-        echo "<p class=\"ttfb_experiment_warning\"><strong>Note:</strong> This comparison view is omitting TTFB to adjust for network variance. <a href=\"" . $experimentResultsHref . "\">View this comparison with TTFB differences visible.</a>";
+        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> This comparison view is omitting TTFB to adjust for network variance. <a href="' . $experimentResultsHref . '">View this comparison with TTFB differences visible.</a>';
     } else {
-        echo "<p class=\"ttfb_experiment_warning\"><strong>Note:</strong> We noticed a " . $ttfbDiffClean . "s difference in response time between the experiment and control runs, which are usually unrelated to the experiment and can might make other metric changes seem more significant than they really are. <a href=\"" . $experimentResultsHref . "&ignoreTTFB\">View this comparison with TTFB differences removed</a>";
+        echo '<p class="ttfb_experiment_warning"><strong>Note:</strong> We noticed a ' . $ttfbDiffClean . 's difference in response time between the experiment and control runs, which can make other metric changes seem more significant than they really are. <a href="' . $experimentResultsHref . '&ignoreTTFB">View this comparison with TTFB differences removed</a>';
     }
 }
 


### PR DESCRIPTION
This implements a check for TTFB differences and when they are greater than 100ms, offers a link to view the comparison with TTFB ignored from all additive metrics. fixes #2329