### PR TITLE
Remove unused paths from nginx conf

### DIFF
--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -209,11 +209,6 @@ rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&cached=1&step=$6 last;
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7 last;
 
-
-#location cookie dropping
-rewrite ^/loc/([a-zA-Z0-9_]+)$ /util/setloc.php?location=$1 last;
-rewrite ^/loc/([a-zA-Z0-9_]+)$/ /util/setloc.php?location=$1 last;
-
 #gzip compressed text result files
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+).(txt|csv)$ /gettext.php?test=$1$2$3_$4&file=$5.$6 last;
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+).(txt|csv)$ /gettext.php?test=$1$2$3_$4_$5&file=$6.$7 last;

--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -62,17 +62,13 @@ location ~* /results/.*\.(php|gz|json) {
 rewrite ^/about$ /about.php last;
 rewrite ^/traceroute$ /traceroute.php last;
 rewrite ^/tips$ /tips.php last;
-rewrite ^/compare-cf$ /compare-cf.php last;
-rewrite ^/advanced$ /advanced.php last;
 rewrite ^/easy$ /index.php last;
 rewrite ^/webvitals$ /webvitals.php last;
 rewrite ^/vitals$ /webvitals.php last;
 rewrite ^/ez$ /index.php last;
 rewrite ^/comprehensive$ /index.php last;
 rewrite ^/simple$ /index.php last;
-rewrite ^/gce$ /gce.php last;
 rewrite ^/lighthouse$ /lighthouse_test.php last;
-rewrite ^/mobiletest$ /advanced.php?cfg=Dulles:Chrome&connection=3G&mobile=1&mdev=Nexus5&fvonly=1&runs=3&video=1&force=1 last;
 rewrite ^/tv$ /tv.php permanent;
 rewrite ^/terms$ /terms.php permanent;
 
@@ -252,25 +248,7 @@ rewrite ^/timeline/[0-9]+/(.*)$ /chrome/$1 last;
 location ^~ /events {
         proxy_ssl_server_name on;
         proxy_ssl_name $proxy_host;
-        proxy_pass https://pages.webpagetest.org;
-        proxy_pass_header Server;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-}
-location ^~ /hs {
-        proxy_ssl_server_name on;
-        proxy_ssl_name $proxy_host;
-        proxy_pass https://pages.webpagetest.org;
-        proxy_pass_header Server;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-}
-location ^~ /_hcms {
-        proxy_ssl_server_name on;
-        proxy_ssl_name $proxy_host;
-        proxy_pass https://pages.webpagetest.org;
+        proxy_pass https://product.webpagetest.org;
         proxy_pass_header Server;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -23,13 +23,11 @@ location ~ ^/cli/ {
         return 403;
 }
 
-
 location / {
         index  index.php;
 }
 
 error_page 404 /404.php;
-
 
 # disable chunked encoding for mp4 files because it breaks flash video on firefox
 location ~* \.mp4 {
@@ -58,31 +56,44 @@ location ~* /results/.*\.(php|gz|json) {
         deny all;
 }
 
-#webpagetest rewrite rules
-rewrite ^/about$ /about.php last;
-rewrite ^/traceroute$ /traceroute.php last;
-rewrite ^/tips$ /tips.php last;
+# index.php pseudonyms
 rewrite ^/easy$ /index.php last;
-rewrite ^/webvitals$ /webvitals.php last;
-rewrite ^/vitals$ /webvitals.php last;
+rewrite ^/simple$ /index.php last;
 rewrite ^/ez$ /index.php last;
 rewrite ^/comprehensive$ /index.php last;
-rewrite ^/simple$ /index.php last;
-rewrite ^/lighthouse$ /lighthouse_test.php last;
-rewrite ^/tv$ /tv.php permanent;
-rewrite ^/terms$ /terms.php permanent;
+rewrite ^/test$ / permanent; #old pages that were eliminated in the UI rewrite
 
+# webpagetest rewrite rules, alphabetized
+rewrite ^/about$ /about.php last;
+rewrite ^/lighthouse$ /lighthouse_test.php last;
+rewrite ^/terms$ /terms.php permanent;
+rewrite ^/testlog$ /testlog/7/ permanent;
+rewrite ^/testlog.csv /testlog.php?f=csv last;
+rewrite ^/testlog/([0-9]+)$ /testlog/$1/ permanent;
+rewrite ^/testlog/([0-9]+)/$ /testlog.php?days=$1 last;
+rewrite ^/timeline/[0-9]+/(.*)$ /chrome/$1 last; #versioned timeline path
+rewrite ^/tips$ /tips.php last;
+rewrite ^/traceroute$ /traceroute.php last;
+rewrite ^/tv$ /tv.php permanent;
+rewrite ^/video/embed/([a-zA-Z0-9_]+)$ /video/view.php?embed=1&id=$1 last;
+rewrite ^/vitals$ /webvitals.php last;
+rewrite ^/waterfall.png /waterfall.php last;
+rewrite ^/webvitals$ /webvitals.php last;
+rewrite ^/xmlResult/([a-zA-Z0-9_]+)/$ /xmlResult.php?test=$1 last;
+
+# login and auth
+rewrite ^/account /cpauth/account.php last;
+rewrite ^/cpauth /cpauth/oauth.php last;
+rewrite ^/forgot-password /cpauth/forgot_password.php last;
 rewrite ^/login /cpauth/login.php last;
 rewrite ^/logout /cpauth/logout.php last;
-rewrite ^/forgot-password /cpauth/forgot_password.php last;
 rewrite ^/signup$ /cpauth/signup.php last;
 rewrite ^/signup/$ /cpauth/signup.php last;
 rewrite ^/signup/([a-zA-Z0-9_]+)$ /cpauth/signup.php?step=$1 last;
 
-rewrite ^/cpauth /cpauth/oauth.php last;
-rewrite ^/account /cpauth/account.php last;
-
-#result paths
+#
+# result paths section
+#
 rewrite ^/result/([a-zA-Z0-9_]+)$ /result/$1/ permanent;
 rewrite ^/result/([a-zA-Z0-9_]+)/$ /results.php?test=$1 last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/waterfall$ /result/$1/$2/details/ permanent;
@@ -124,18 +135,6 @@ rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog/$ /consolelog.php?tes
 rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog/cached$ /consolelog.php?test=$1&run=$2&cached=1 last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog/cached/$ /consolelog.php?test=$1&run=$2&cached=1 last;
 
-rewrite ^/testlog$ /testlog/7/ permanent;
-rewrite ^/testlog/([0-9]+)$ /testlog/$1/ permanent;
-rewrite ^/testlog/([0-9]+)/$ /testlog.php?days=$1 last;
-rewrite ^/xmlResult/([a-zA-Z0-9_]+)/$ /xmlResult.php?test=$1 last;
-rewrite ^/testlog.csv /testlog.php?f=csv last;
-rewrite ^/waterfall.png /waterfall.php last;
-
-#old direct path to images
-rewrite ^/results/([a-zA-Z0-9])([a-zA-Z0-9]+)/([a-zA-Z0-9_]+).png$ /results/old/_$1/$1$2/$3.png last;
-rewrite ^/results/([a-zA-Z0-9])([a-zA-Z0-9]+)/([a-zA-Z0-9_]+).jpg$ /results/old/_$1/$1$2/$3.jpg last;
-rewrite ^/results/old/_([a-zA-Z0-9])/([a-zA-Z0-9]+)/([a-zA-Z0-9_]+).png$ /results/old/$2/$3.png last;
-
 #csv combined results
 rewrite ^/result/([a-zA-Z0-9_]+)/.*page_data.csv$ /csv.php?test=$1 last;
 rewrite ^/result/([a-zA-Z0-9_]+)/.*requests.csv$ /csv.php?test=$1&requests=1 last;
@@ -155,6 +154,18 @@ rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall_thumb.png$ /thumbna
 rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_waterfall.png last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&step=$3&file=$2_$3_optimization.png last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization_thumb.png$ /thumbnail.php?test=$1&run=$2&cached=1&step=$3&file=$2_Cached_$3_optimization.png last;
+
+#tcpdump capture files
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+).cap$ /getgzip.php?test=$1&file=$2.cap last;
+rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached.cap$ /getgzip.php?test=$1&file=$2_Cached.cap last;
+
+#
+# older results section, note the plural "results"
+#
+#old direct path to images
+rewrite ^/results/([a-zA-Z0-9])([a-zA-Z0-9]+)/([a-zA-Z0-9_]+).png$ /results/old/_$1/$1$2/$3.png last;
+rewrite ^/results/([a-zA-Z0-9])([a-zA-Z0-9]+)/([a-zA-Z0-9_]+).jpg$ /results/old/_$1/$1$2/$3.jpg last;
+rewrite ^/results/old/_([a-zA-Z0-9])/([a-zA-Z0-9]+)/([a-zA-Z0-9_]+).png$ /results/old/$2/$3.png last;
 
 #old direct thumbnail paths
 rewrite ^/results/old/([a-zA-Z0-9_]+)/([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&file=$2_screen.jpg last;
@@ -192,7 +203,6 @@ rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&step=$6&type=connection last;
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7&type=connection last;
 
-
 # optimization checklists
 rewrite ^/results/old/([a-zA-Z0-9_]+)/([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1&run=$2 last;
 rewrite ^/results/old/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1&run=$2&cached=1 last;
@@ -213,17 +223,6 @@ rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+).(txt|csv)$ /gettext.php?test=$1$2$3_$4&file=$5.$6 last;
 rewrite ^/results/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+).(txt|csv)$ /gettext.php?test=$1$2$3_$4_$5&file=$6.$7 last;
 
-#tcpdump capture files
-rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+).cap$ /getgzip.php?test=$1&file=$2.cap last;
-rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached.cap$ /getgzip.php?test=$1&file=$2_Cached.cap last;
-
-#embeddable video widget
-rewrite ^/video/embed/([a-zA-Z0-9_]+)$ /video/view.php?embed=1&id=$1 last;
-
-#old pages that were eliminated in the UI rewrite
-rewrite ^/test$ / permanent;
-
-
 # static files
 location ~* \.(js|css|png|jpg|jpeg|gif|ico|swf|exe|msi|zip)$ {
     expires max;
@@ -235,10 +234,6 @@ location ~* \.(js|css|png|jpg|jpeg|gif|ico|swf|exe|msi|zip)$ {
 location ~* /work/update/.*$ {
     expires -1;
 }
-
-#versioned timeline path
-rewrite ^/timeline/[0-9]+/(.*)$ /chrome/$1 last;
-
 
 location ^~ /events {
         proxy_ssl_server_name on;


### PR DESCRIPTION
These are currently 404s. Removed them all except https://webpagetest.org/events which is fixed. Although it should probably be just a redirect, but keeping it for now.