### PR TITLE
Move `/results/` urls to `/result/` for #2339

### DIFF
--- a/www/include/JsonResultGenerator.php
+++ b/www/include/JsonResultGenerator.php
@@ -278,11 +278,13 @@ class JsonResultGenerator
         $cached = $testStepResult->isCachedRun();
         $step = $testStepResult->getStepNumber();
 
+        $url_friendly_dir = str_replace('./results/', '/result/', $this->testInfo->getRootDirectory());
+
         $localPaths = new TestPaths($this->testInfo->getRootDirectory(), $run, $cached, $step);
+        $remotePaths = new TestPaths($this->urlStart . $url_friendly_dir, $run, $cached, $step);
         $nameOnlyPaths = new TestPaths("", $run, $cached, $step);
         $urlGenerator = UrlGenerator::create($this->friendlyUrls, $this->urlStart, $this->testInfo->getId(), $run, $cached, $step);
         $friendlyUrlGenerator = UrlGenerator::create(true, $this->urlStart, $this->testInfo->getId(), $run, $cached, $step);
-        $urlPaths = new TestPaths($this->urlStart . substr($this->testInfo->getRootDirectory(), 1), $run, $cached, $step);
 
         $basic_results = $this->hasInfoFlag(self::BASIC_INFO_ONLY);
 
@@ -320,12 +322,12 @@ class JsonResultGenerator
         if ($this->fileHandler->gzFileExists($localPaths->devtoolsScriptTimingFile())) {
             $ret['rawData']['scriptTiming'] = $urlGenerator->getGZip($nameOnlyPaths->devtoolsScriptTimingFile());
         }
-        $ret['rawData']['headers'] = $urlPaths->headersFile();
-        $ret['rawData']['pageData'] = $urlPaths->pageDataFile();
-        $ret['rawData']['requestsData'] = $urlPaths->requestDataFile();
-        $ret['rawData']['utilization'] = $urlPaths->utilizationFile();
+        $ret['rawData']['headers'] = $remotePaths->headersFile();
+        $ret['rawData']['pageData'] = $remotePaths->pageDataFile();
+        $ret['rawData']['requestsData'] = $remotePaths->requestDataFile();
+        $ret['rawData']['utilization'] = $remotePaths->utilizationFile();
         if ($this->fileHandler->fileExists($localPaths->bodiesFile())) {
-            $ret['rawData']['bodies'] = $urlPaths->bodiesFile();
+            $ret['rawData']['bodies'] = $remotePaths->bodiesFile();
         }
         if ($this->fileHandler->gzFileExists($localPaths->devtoolsTraceFile())) {
             $ret['rawData']['trace'] = $urlGenerator->getGZip($nameOnlyPaths->devtoolsTraceFile() . ".gz");

--- a/www/include/UrlGenerator.php
+++ b/www/include/UrlGenerator.php
@@ -245,7 +245,7 @@ class FriendlyUrlGenerator extends UrlGenerator
         if (sizeof($parts) > 2) {
             $testPath .= "/" . $parts[2];
         }
-        return $this->baseUrl . "/results/" . $testPath . "/" . $this->underscorePrefix() . $image . ".png";
+        return $this->baseUrl . "/result/" . $testPath . "/" . $this->underscorePrefix() . $image . ".png";
     }
 
     public function resultSummary($extraParams = null)

--- a/www/include/XmlResultGenerator.php
+++ b/www/include/XmlResultGenerator.php
@@ -267,7 +267,8 @@ class XmlResultGenerator
 
         $localPaths = new TestPaths($testRoot, $run, $cached, $step);
         $nameOnlyPaths = new TestPaths("", $run, $cached, $step);
-        $urlPaths = new TestPaths($this->baseUrl . substr($testRoot, 1), $run, $cached, $step);
+        $url_friendly_dir = str_replace('./results/', '/result/', $this->testInfo->getRootDirectory());
+        $remotePaths = new TestPaths($this->baseUrl . $url_friendly_dir, $run, $cached, $step);
 
 
         echo "<results>\n";
@@ -318,19 +319,19 @@ class XmlResultGenerator
             echo "<scriptTiming>" . htmlspecialchars($urlGenerator->getGZip($nameOnlyPaths->devtoolsScriptTimingFile())) . "</scriptTiming>\n";
         }
         if ($this->fileHandler->gzFileExists($localPaths->headersFile())) {
-            echo "<headers>" . $urlPaths->headersFile() . "</headers>\n";
+            echo "<headers>" . $remotePaths->headersFile() . "</headers>\n";
         }
         if ($this->fileHandler->gzFileExists($localPaths->bodiesFile())) {
-            echo "<bodies>" . $urlPaths->bodiesFile() . "</bodies>\n";
+            echo "<bodies>" . $remotePaths->bodiesFile() . "</bodies>\n";
         }
         if ($this->fileHandler->gzFileExists($localPaths->pageDataFile())) {
-            echo "<pageData>" . $urlPaths->pageDataFile() . "</pageData>\n";
+            echo "<pageData>" . $remotePaths->pageDataFile() . "</pageData>\n";
         }
         if ($this->fileHandler->gzFileExists($localPaths->requestDataFile())) {
-            echo "<requestsData>" . $urlPaths->requestDataFile() . "</requestsData>\n";
+            echo "<requestsData>" . $remotePaths->requestDataFile() . "</requestsData>\n";
         }
         if ($this->fileHandler->gzFileExists($localPaths->utilizationFile())) {
-            echo "<utilization>" . $urlPaths->utilizationFile() . "</utilization>\n";
+            echo "<utilization>" . $remotePaths->utilizationFile() . "</utilization>\n";
         }
         echo "</rawData>\n";
 

--- a/www/nginx.conf
+++ b/www/nginx.conf
@@ -139,6 +139,38 @@ rewrite ^/result/([a-zA-Z0-9_]+)/([a-zA-Z0-9]+)/consolelog/cached/$ /consolelog.
 rewrite ^/result/([a-zA-Z0-9_]+)/.*page_data.csv$ /csv.php?test=$1 last;
 rewrite ^/result/([a-zA-Z0-9_]+)/.*requests.csv$ /csv.php?test=$1&requests=1 last;
 
+#gzip compressed text result files
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+).(txt|csv)$ /gettext.php?test=$1$2$3_$4&file=$5.$6 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+).(txt|csv)$ /gettext.php?test=$1$2$3_$4_$5&file=$6.$7 last;
+
+# waterfalls, connections, optimizations
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&cached=1 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&cached=1 last;
+
+# waterfalls, connections, optimizations with multistep support
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5&step=$6 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&step=$7 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&step=$6 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_waterfall.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&step=$6&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&step=$7&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4&run=$5&cached=1&step=$6&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_connection.png$ /waterfall.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7&type=connection last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&step=$6 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&step=$7 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4&run=$5&cached=1&step=$6 last;
+rewrite ^/result/([0-9][0-9])/([0-9][0-9])/([0-9][0-9])/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/([0-9]+)_Cached_([0-9]+)_optimization.png$ /optimizationChecklist.php?test=$1$2$3_$4_$5&run=$6&cached=1&step=$7 last;
+
 #thumbnails
 rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&file=$2_screen.jpg last;
 rewrite ^/result/([a-zA-Z0-9_]+)/([0-9]+)_Cached_screen_thumb.jpg$ /thumbnail.php?test=$1&run=$2&cached=1&file=$2_Cached_screen.jpg last;


### PR DESCRIPTION
PR #2339 is about removing support for all (mostly legacy) `/results/` URLs.

"Mostly" because there are a few places where `/results/` are still used. This PR migrates them to `/result`

The `nginx.conf` changes are a copy of the relevant `/results/` config.  Once this is in, #2339 will remove anything `/results` form the `.conf`