### PR TITLE
improve renderedHTML collection for sites that use dynamic css frameworks

### DIFF
--- a/www/settings/custom_metrics/rendered-html.js
+++ b/www/settings/custom_metrics/rendered-html.js
@@ -1,1 +1,10 @@
+// fix up that output in case there are style elements with cssom rules not in the source
+// this often happens with dynamic stylesheet frameworks
+let styles = document.querySelectorAll('style').forEach(style => {
+    let thisText = "";
+    for (let i in style.sheet.cssRules) {
+        thisText += style.sheet.cssRules[i].cssText;
+    }
+    style.innerText = "/* inner styles set by WPT to match CSSOM */" + thisText;
+});
 return document.documentElement.outerHTML;


### PR DESCRIPTION
This change will help a lot of sites to be able to see better results for the "mimic server-generated html experiment" 

The issue was that some sites that use frameworks like Styled Components will dynamically set a style element's css rules without setting the textnodes of that style element, and because of that the styles weren't captured in the html. 

This change fixes that. 