### PR TITLE
Fix misaligned "Oops" message

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -5579,8 +5579,8 @@ label.test_preset_profile {
 
 .testerror h1 {
   color: #dc9739;
-  text-align: left;
   margin: 1em 0;
+  border-bottom: 1px solid #ddd;
 }
 
 .testerror h1 em {
@@ -5589,8 +5589,7 @@ label.test_preset_profile {
   font-weight: 500;
   font-size: 0.8em;
   color: #333;
-  margin: 0.3em 0 0.5em;
-  border-bottom: 1px solid #ddd;
+  margin: 0.1em 0.3em;
   padding-bottom: 1em;
 }
 


### PR DESCRIPTION
before:

<img width="697" alt="Screen Shot 2022-09-26 at 3 04 46 PM" src="https://user-images.githubusercontent.com/51308/192359371-0c4c3a9d-b04a-4ec8-ad39-8b5b33393beb.png">

after:

<img width="695" alt="Screen Shot 2022-09-26 at 3 03 46 PM" src="https://user-images.githubusercontent.com/51308/192359369-ea50449b-2577-4dee-a6af-c3c6a8c0c8b8.png">
