### PR TITLE
Ability to pass current %TEST_ID% into custom scripts

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -3459,7 +3459,7 @@ function ProcessTestScript($url, &$test)
                     $origin .= ':' . $parts['port'];
                 }
                 $script = str_ireplace('%ORIGIN%', $origin, $script);
-
+                $script = str_ireplace('%TEST_ID%', $test['id'], $script);
                 $script = str_ireplace('%HOST_REGEX%', str_replace('.', '\\.', $host), $script);
                 if (stripos($script, '%HOSTR%') !== false) {
                     if (GetRedirect($url, $rhost, $rurl)) {


### PR DESCRIPTION
 
#2373 

Added %TEST_ID% to custom scripts
- I picked %TEST_ID over %TESTID% just to follow other variable substitutions like "%HOST_REGEX%"
- I can also add this to the WebPageTest-docs if you would like.

![cbefore](https://user-images.githubusercontent.com/33207323/192610169-d0bbd805-86bd-40be-a3db-40d841739c48.png)
![cafter](https://user-images.githubusercontent.com/33207323/192610181-729ce133-1e52-4344-aa94-1a3f41469cdc.png)
