### PR TITLE
pagestyle2.css: dead code is dead

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -33,91 +33,122 @@
   color: #fff;
 }
 
-/*
-header {
-    grid-column-gap: 1.25em;
-    border-bottom: 5px solid #1E2B47;
-    background-color: #121D35;
-    padding-top: 1px;
-    padding: 0.5em 0 0;
-}
-
-.home header {
-    border-bottom: 5px solid #6c0977;
-}
-
-@media screen and (min-width: 50em) {
-    header {
-        display: grid;
-        grid-template-columns: 1vw repeat(4, 1fr) 1vw;
-        align-items: center;
-    }
-} */
-
 @media screen and (min-width: 75em) {
   body {
     display: grid;
   }
-
-  /* header {
-        grid-column: gutter-start / gutter-end;
-        grid-template-columns: 1vw repeat( 10, 1fr) 1vw;
-    } */
 }
 
-/*
-@media (min-width: 87.5em) {
-    header {
-        grid-template-columns: calc(50vw - 45em) repeat( 10, 1fr) calc(50vw - 45em);
-    }
- }
+h1 {
+  font-size: 1.7em;
+  font-family: "Open Sans", sans-serif;
+  line-height: 1em;
+  font-weight: 700;
+  margin-bottom: 1em;
+  margin-top: 1.5em;
+  padding: 0;
+  text-align: left;
+}
 
-header .logo {
-    line-height: 0;
-    margin: 1em 0;
+h2,
+h3,
+h4,
+h5,
+h6 {
+  padding: 0.5em 0;
+  margin: 0 0 0.5em;
+}
+
+h2 {
+  font-size: 1.6em;
+  line-height: 1.4em;
+  font-weight: 700;
+}
+
+h3,
+.h3 {
+  font-size: 1.3em;
+  line-height: 1.4em;
+}
+
+h3.hed_sub {
+  font-size: 1.8em;
+  font-weight: 900;
+  margin: 1em 0 0;
+  font-style: normal;
+  line-height: 1.4;
+  text-transform: none;
+  color: #2a3d64;
+}
+
+.hed_sub em,
+.results_header .hed_sub + p {
+  font-size: 0.5em;
+  font-style: normal;
+  text-transform: none;
+  color: #555;
+  font-weight: 500;
+}
+
+.hed_sub em details {
+  display: inline-block;
+  position: relative;
+  z-index: 20;
+  margin: 0 0 0 1.2em;
+}
+
+.hed_sub em details summary {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  list-style-position: outside;
+}
+
+.hed_sub em details ul {
+  position: absolute;
+  background: #fff;
+  border-radius: 0.6em;
+  border: 1px solid #eee;
+  padding: 0.2em 0.6em;
+  top: 2em;
+  min-width: 100%;
+  width: 15em;
+  left: 0;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
+}
+
+.hed_sub em details li {
+  padding: 0.4em;
+}
+
+@media (max-width: 50em) {
+  .hed_sub {
+    font-size: 1em;
+    margin: 0.5em 0 0;
+  }
+
+  .hed_sub em details ul {
+    left: auto;
+    right: 0;
+  }
+
+  h2 {
+    font-size: 1.2em;
+  }
+  h3,
+  .h3 {
+    font-size: 1.1em;
+  }
+  h3.hed_sub {
+    font-size: 1.6em;
+  }
+  .hed_sub em,
+  .results_header .hed_sub + p {
     display: block;
-    text-align: center;
+    font-size: 0.6em;
+    margin: 0.5em 0;
+  }
 }
-
-header .logo img {
-    width: 12em;
-    max-width: 50vw;
-}
-
-@media screen and (min-width:40em) {
-    header .logo {
-        grid-column: 1 / 7;
-        border-bottom: 1px solid rgba(255, 255, 255, .3);
-        padding-bottom: 1.5rem;
-        margin-bottom: 0;
-        margin-top: 1.3em;
-    }
-}
-
-@media screen and (min-width:75em) {
-    header .logo {
-        grid-column: 2/4;
-        align-self: center;
-        justify-self: left;
-        padding-bottom: 0;
-        margin: 1em 0 1.3em;
-        border: 0;
-    }
-    header .logo img {
-        width: 12rem;
-    }
-}
-
-header a {
-    color: #fff;
-}
-
-a[aria-current=page] {
-    text-decoration: none;
-    color: inherit;
-    font-weight: 700;
-    cursor: default;
-} */
 
 .results_header .hed_sub {
   font-size: 1.3rem;
@@ -246,12 +277,8 @@ h6 {
 
 .test_results-content h4,
 .test_results-content details.values summary {
-  /* background: #fff; */
-  /* padding: 1.5em 0 0 0; */
-  font-weight: 300;
   color: #2a3b64;
   font-weight: 500;
-  /* text-transform: uppercase; */
   font-size: 1.4em;
 }
 
@@ -305,7 +332,6 @@ h1 .pro-flag {
   display: flex;
   gap: 3rem;
   margin: 0.5rem 0;
-  /* border-bottom: 1px solid #eee; */
   padding: 0 0 0.5rem;
   justify-content: space-between;
   align-items: flex-start;
@@ -314,27 +340,20 @@ h1 .pro-flag {
 .experiment_opportunities {
   border-top: 1px solid #eee;
   padding: 0.5rem 0 0;
-  /* margin-bottom: 1rem; */
 }
 
 .experiment_opportunities-resolved {
   flex: 1 1 25%;
-  /* justify-content: flex-start; */
 }
 
 .experiment_opportunities p {
   margin: 0.3em 0 1rem;
 }
 
-.experiment_opportunities p strong {
-}
-
 .experiment_opportunities-resolved ol {
   padding: 0;
   list-style: none;
-  display: flex;
   gap: 1rem;
-  flex-flow: row wrap;
   justify-content: flex-start;
   display: flex;
   overflow: auto;
@@ -429,9 +448,6 @@ a.experiment_meta-more {
   text-decoration: none;
   background-image: none;
   padding-right: 0.7em;
-  /* background: #1071ba; */
-  /* border-color: #1071ba; */
-  /* color: #fff; */
 }
 
 .experiment_meta details a,
@@ -575,9 +591,7 @@ span.lh-flag.poor {
   margin: 1em -3rem !important;
   background-clip: padding-box;
   position: relative;
-  /* overflow-y: visible; */
   overflow: hidden;
-  /* height: 100%; */
 }
 
 @media (max-width: 87.5em) {
@@ -611,7 +625,6 @@ span.lh-flag.poor {
   padding: 0 0 1.5rem;
   border-bottom: 1px solid #ddd;
   margin: 0 2rem 2.5rem;
-  /* font-size: 1.2em; */
 }
 
 .compare-loading #statusTable th {
@@ -624,7 +637,6 @@ span.lh-flag.poor {
   align-items: center;
   justify-content: flex-start;
   border-bottom: 1px solid #ddd;
-  padding-bottom: 0.6rem;
   margin-top: 0;
   margin-left: -3em;
   margin-right: -3em;
@@ -674,7 +686,6 @@ p.grade_summary {
   font-weight: 500;
   min-height: none;
   padding-left: 2.5rem;
-  /* vertical-align: middle; */
 }
 
 .grade_heading span {
@@ -730,19 +741,13 @@ p.grade_summary {
   list-style: none;
   margin: 0;
   padding: 0;
-  /* counter-reset: bottlenecks; */
 }
 
 .experiments_bottlenecks > ol > li > details > summary {
   font-size: 1.1875rem;
   font-weight: 900;
   cursor: pointer;
-  /* border-bottom: 1px solid #ddd; */
-  /* border-top: 1px solid #ddd; */
-  /* padding: .6em 0; */
   margin: 0;
-  /* user-select: all; */
-  /* display: flex; */
 }
 
 .experiments_bottlenecks > ol > li > details > summary:focus {
@@ -775,7 +780,6 @@ p.grade_summary {
 
 .experiments_details_desc p {
   flex: 1 1 40%;
-  /* font-size: 1.1em; */
 }
 
 .experiments_details_body ol {
@@ -784,10 +788,7 @@ p.grade_summary {
 }
 
 .experiments_bottlenecks > ol > li {
-  /* counter-increment: bottlenecks; */
-  margin-bottom: 1em;
   border-bottom: 1px solid #eee;
-  /* border-top: 1px solid #ddd; */
   padding: 1em 0;
   margin: 0;
 }
@@ -849,8 +850,6 @@ h4.experiments_list_hed {
   margin: 1.3em 0 0;
   color: #4e8f37;
   font-size: 1.3em;
-  padding-bottom: 0;
-  padding-left: 2.5em;
   background: url(/assets/images/src/icon_science_bubbling.svg) left bottom
     no-repeat;
   background-size: 1.6em;
@@ -873,7 +872,6 @@ h4.experiments_list_hed-recs {
 .experiments_list > li {
   border: 1px solid #eee;
   padding: 1rem 1.5rem;
-  background: #fff;
   margin: 0.8rem 0;
   border-radius: 0.3em;
   display: flex;
@@ -884,16 +882,13 @@ h4.experiments_list_hed-recs {
 .experiment_description code {
   font-size: 1.2em;
   word-break: break-word;
-  /* background: #eee; */
   padding: 0.2em 0.4em;
-  /* color: #1e1e1e; */
   font-weight: 500;
 }
 
 .experiment_description_text h5 {
   font-size: 1rem;
   color: #2a3c64;
-  margin-bottom: 0;
   padding: 0;
   font-weight: 900;
   margin: 0 0 1em;
@@ -959,7 +954,6 @@ h4.experiments_list_hed-recs {
 
 .experiment_description_text li {
   list-style: disc;
-  margin-left: 2em;
   margin: 0.5em 0 0 2em;
 }
 
@@ -1007,7 +1001,6 @@ h4.experiments_list_hed-recs {
   cursor: pointer;
   border-radius: 2rem;
   vertical-align: middle;
-  /* display: flex; */
   text-decoration: none;
 }
 
@@ -1079,12 +1072,10 @@ h4.experiments_list_hed-recs {
   border-radius: 2rem;
   overflow: hidden;
   box-shadow: 0 0 3px rgb(0 0 0 / 10%);
-  /* overflow: auto; */
   background: #fff;
 }
 
 .experiment_description_go.experiment_description_go-multi > label {
-  /* margin: 1em !important; */
   display: block;
   border-radius: 0;
   text-align: left;
@@ -1169,7 +1160,6 @@ h4.experiments_list_hed-recs {
 }
 
 .experiments_foot {
-  /* border-top: 1px solid #ddd; */
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -1182,7 +1172,6 @@ h4.experiments_list_hed-recs {
   background: #2a3c64;
   border-right: 0;
   border-left: 0;
-  /* scroll-margin-bottom: 3rem; */
 }
 
 .experiments_foot-stick {
@@ -1196,7 +1185,6 @@ h4.experiments_list_hed-recs {
 }
 
 .experiments_foot details summary {
-  background: none;
   cursor: pointer;
   list-style: none;
   padding-left: 1.5em;
@@ -1246,7 +1234,6 @@ h4.experiments_list_hed-recs {
 }
 
 .experiments_foot details ol:after {
-  content: "";
   border-top: 0.6em solid rgb(250 250 250);
   border-right: 0.6em solid transparent;
   border-left: 0.6em solid transparent;
@@ -1375,10 +1362,6 @@ h4.experiments_list_hed-recs {
 p {
   margin: 0 0 1em 0;
 }
-
-/* body.compact p {
-    margin: 0 0 0.25em;
-} */
 
 ul {
   list-style: none;
@@ -1512,7 +1495,6 @@ h2 .medium {
   .tri-col > div {
     width: 33%;
     flex-grow: 1;
-    /* justify-self: space-between; */
     margin-right: 1.5em;
     align-self: stretch;
   }
@@ -1540,7 +1522,6 @@ body.compare footer {
 
 footer {
   display: block;
-  /* border-top: 1px solid #eee; */
   grid-column: 2 / 12;
   margin-top: 4rem;
   padding: 2rem 0;
@@ -1568,8 +1549,6 @@ footer .logo {
   margin: 0;
   padding: 0;
   width: 200px;
-  /* background: #111e35; */
-  /* border-radius: .5em; */
 }
 
 footer .footer_social {
@@ -1578,7 +1557,6 @@ footer .footer_social {
   font-weight: 500;
   color: #666;
   gap: 0.5em;
-  /* margin-right: 2em; */
   text-align: right;
   justify-content: flex-end;
 }
@@ -1627,13 +1605,7 @@ footer {
   display: flex;
   justify-content: space-between;
   border-top: 1px solid #fff;
-  padding-top: 3rem;
-  align-items: flex-start;
-  /* background: #111e35; */
-  /* margin: 2rem 0 0; */
-  /* color: #fff; */
   padding: 3rem 3em;
-  /* box-sizing: border-box; */
   width: auto;
   align-items: flex-start;
 }
@@ -1647,7 +1619,6 @@ footer ul li {
 }
 
 footer ul {
-  /* margin: auto; */
   justify-content: center;
   text-align: right;
   font-size: 0.9em;
@@ -1784,77 +1755,7 @@ footer ul {
 .heading_details {
   font-size: 0.875em;
   display: none;
-  /* TODO TODO */
 }
-
-/* Header */
-
-/*
-#wptAuthBar {
-    list-style-type: none;
-}
-
-@media (max-width:60em) {
-    #wptAuthBar {
-        margin: 1em 0;
-        padding: .6em 1.5rem 0;
-        justify-content: center;
-    }
-}
-
-#wptAuthBar li {
-    color: #fff;
-}
-
-#wptAuthBar a {
-    text-decoration: none;
-    margin: 1.5em 1.3em;
-    display: inline-block;
-    white-space: nowrap;
-}
-
-#wptAuthBar li {
-    display: flex;
-    margin-bottom: 0;
-    font-size: .9em;
-}
-
-#wptAuthBar {
-    grid-column: 5/6;
-    align-self: center;
-    justify-self: end;
-    display: flex;
-    align-items: center;
-    grid-row: 2;
-    margin-top: 0;
-}
-
-#wptAuthBar a {
-    margin: auto;
-}
-
-#wptAuthBar .pill {
-    margin-left: 1.75em;
-    margin-top: 0;
-}
-
-@media screen and (min-width:75em) {
-    #wptAuthBar {
-        grid-column: 10/12;
-        grid-row: auto;
-    }
-    #wptAuthBar li {
-        font-size: 1em;
-    }
-}
-
-#wptAuthBar a:hover {
-    text-decoration: underline;
-}
-
-#wptAuthBar svg {
-    padding-left: .5em;
-} */
 
 .results_nav_contain {
   border-bottom: 1px solid #ddd;
@@ -1875,7 +1776,6 @@ footer ul {
   grid-template-columns: 1fr 1fr;
   margin: 0 0 1em;
   padding: 0;
-  text-align: left;
   grid-column-gap: 1em;
   gap: 1em;
   margin-top: 6.3125em;
@@ -1890,15 +1790,11 @@ footer ul {
 
 .opportunities_summary {
   display: flex;
-  gap: 1rem;
-  padding: 1em 1em;
   border: 1px solid #eee;
   border: 0;
-  padding: 0 !important;
   padding: 0 0 1rem;
   gap: 1rem;
   margin-bottom: 1rem;
-  /* align-items: flex-start; */
 }
 
 .results_body .opportunities_summary {
@@ -1918,13 +1814,6 @@ footer ul {
 
 .opportunities_summary a {
   border-right: 0;
-}
-
-.opportunities_summary a:hover,
-.opportunities_summary a:focus {
-  /* box-shadow: 0 0 5px rgba(0,0,0,.2); */
-  /* border-radius: .5em; */
-  /* background: #fff; */
 }
 
 .opportunities_summary a:last-child {
@@ -1954,8 +1843,6 @@ footer ul {
 .opportunities_summary .grade_heading {
   background: none !important;
   font-size: 1.1rem;
-  /* border-bottom: 1px solid #ddd; */
-  /* padding-bottom: .7em; */
   margin: 0;
   display: flex;
   gap: 0.8rem;
@@ -1969,14 +1856,9 @@ footer ul {
 }
 
 .opportunities_summary p > strong {
-  /* border-bottom: 1px solid #eee; */
   display: inline-block;
-  /* padding-bottom: .5rem; */
   margin-bottom: 1rem;
   color: #2a3c64;
-  /* margin: -1em -1em 1em; */
-  /* padding: .5em 1em; */
-  /* background: #fafafa; */
   font-weight: 900;
 }
 
@@ -2023,20 +1905,8 @@ footer ul {
   flex-flow: column;
   justify-content: space-between;
   flex: 1 1 33%;
-  /* border-radius: .5em; */
-  /* padding-left: 2rem; */
   text-decoration: none;
-  /* color: inherit; */
-  /* background-clip: border-box; */
-  /* overflow: hidden; */
   margin: 0;
-}
-
-.opportunities_summary a:hover ul,
-.opportunities_summary a:focus ul {
-  /* box-shadow: 0 0 5px #eee; */
-  /* border-color: #1071ba; */
-  /* background: #fff; */
 }
 
 .opportunities_summary .grade_heading > span {
@@ -2050,8 +1920,6 @@ footer ul {
   color: #222;
   font-size: 0.9em;
   justify-self: flex-start;
-  /* border-bottom: 1px solid #ddd; */
-  /* padding-bottom: 1rem; */
   margin: 0em 0.5em 1rem 0;
 }
 
@@ -2064,11 +1932,8 @@ footer ul {
   display: flex;
   gap: 0.8em;
   align-items: center;
-  padding-top: 0.7em;
   margin: 0;
-  /* justify-self: auto; */
   padding: 0.1rem 0 0;
-  background: #fff;
   justify-content: flex-start;
   border-color: #efefef;
   background: #fff;
@@ -2079,7 +1944,6 @@ footer ul {
 .opportunities_summary_exps {
   font-size: 0.85em !important;
   font-weight: 500;
-  /* margin: 0 -1rem -1rem; */
   padding: 0 1.8em 0 0;
   color: #111;
   display: flex;
@@ -2088,7 +1952,6 @@ footer ul {
   margin: 0;
   min-height: 2em;
   position: relative;
-  /* text-transform: uppercase; */
 }
 
 .experiment_summary_label {
@@ -2123,18 +1986,12 @@ footer ul {
   border: 1px solid #aaa;
   display: inline-block;
   border-radius: 100%;
-  color: #fff;
   width: 1.3em;
   height: 1.3em;
   text-align: center;
   font-weight: 900;
-  /* font-size: .9em; */
-  /* margin-right: .5em; */
   line-height: 1.3;
-  /* position: absolute; */
   text-indent: 0;
-  /* top: -.5em; */
-  /* right: 0; */
   background: #fff;
   color: #333;
 }
@@ -2142,80 +1999,16 @@ footer ul {
 .experiment_summary_count {
   border: 1px solid #ddd;
   color: #333;
-  /* border: 1px solid #1071ba; */
   width: 1.7em;
   height: 1.7em;
   line-height: 1.7;
-  /* padding: .2em; */
-  /* position: relative; */
-  /* top: -0.5em; */
-  /* left: -4em; */
   text-align: center;
   font-weight: 900;
   font-size: 0.8em;
-  /* margin-right: 2.5em; */
-  /* border: 0; */
   position: absolute;
   right: 0;
-  /* top: 0; */
   margin: 0;
-  /* padding: .1em; */
 }
-
-.opportunities_summary_opps .experiment_summary_count {
-  /* margin-right: .5em; */
-}
-
-/*
-.result-summary .opportunities_summary {
-    display: block;
-    max-width: auto;
-    margin: 0;
-}
-
-.result-summary .opportunities_summary a.grade_anchor {
-    display: flex;
-    gap: 1rem;
-    flex-flow: row wrap;
-    border-bottom: 1px solid #eee;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    margin-bottom: 1rem;
-    justify-items: space-between;
-}
-
-.result-summary .opportunities_summary a.grade_anchor:last-of-type {
-    border: 0;
-    padding-bottom: 0;
-    margin-bottom: 0;
-}
-
-.result-summary .opportunities_summary a.grade_anchor>p {
-    flex: 1 1 50%;
-    display: flex;
-    align-items: flex-start;
-    margin: 0;
-}
-
-.result-summary .opportunities_summary a.grade_anchor>p strong {
-    flex: 1 1 25%;
-    border: 0;
-}
-
-.result-summary .opportunities_summary a.grade_anchor>p>span {
-    flex: 1 1 70%;
-}
-
-.result-summary .opportunities_summary a.grade_anchor>div {
-    flex: 1 1 35%;
-    display: flex;
-    gap: .5rem;
-    align-items: flex-start;
-}
-
-.result-summary .opportunities_summary .extended {
-    display: none;
-} */
 
 .experiments_bottlenecks > ol > li > details > summary {
   padding-left: 2.7em;
@@ -2234,7 +2027,6 @@ footer ul {
 .experiments_bottlenecks > ol > li > details > summary:before {
   position: absolute;
   left: 0;
-  /* opacity: 0; */
 }
 
 @media (max-width: 60em) {
@@ -2381,7 +2173,6 @@ footer ul {
 }
 
 .testinfo_forms details > div {
-  padding: 0.4em 1.3em 0;
   color: #222;
   position: absolute;
   background: #fff;
@@ -2434,7 +2225,6 @@ details.details_custommetrics summary {
 
 .testinfo_artifacts h3 {
   font-weight: normal;
-  border-radius: 2px;
   border: 1px solid #999;
   font-size: 1rem;
   padding: 0.5em 1em;
@@ -2482,10 +2272,8 @@ details.details_custommetrics summary {
   }
 
   .testinfo_command-bar {
-    /* margin-top: 0; */
     padding: 0;
     justify-content: flex-start;
-    /* text-align: left; */
     flex: 0 1 auto;
   }
 }
@@ -2494,7 +2282,6 @@ details.details_custommetrics summary {
   .results_and_command {
     gap: 0;
     flex-flow: column;
-    /* padding: 0; */
   }
 
   .testinfo_command-bar {
@@ -2531,7 +2318,6 @@ details.details_custommetrics summary {
   padding-bottom: 0.5rem;
   flex: 1 1 60%;
   max-width: 100%;
-  /* padding: ; */
 }
 
 .compare-experiment.compare-loading .results_header {
@@ -2628,7 +2414,6 @@ details.details_custommetrics summary {
 
 .compare-experiment .header_screenshots {
   flex: 1 1 45%;
-  /* align-self: flex-start; */
 }
 
 .compare-experiment #header_data {
@@ -2650,7 +2435,6 @@ details.details_custommetrics summary {
   background-size: 100%;
   border: 2px solid #2d3c60;
   margin-left: -1.5em;
-  /* opacity: 0; */
 }
 
 .header_screenshots.playing .play,
@@ -2846,16 +2630,15 @@ nav a:hover {
     }
 } */
 
+#main {
+  padding: 1.5em 0;
+}
+
 .home #main {
-  /* max-width: 1083px; */
   margin: auto;
   width: 100%;
   padding: 0;
 }
-
-/* body.compact #main {
-    padding: 0.5em 0;
-} */
 
 @media screen and (min-width: 75em) {
   body.result #main {
@@ -3012,7 +2795,6 @@ body.result #main {
 }
 
 .home_feature_hed_contain {
-  /* transition: all 1s ease-out; */
   overflow: hidden;
 }
 
@@ -3032,36 +2814,17 @@ body.result #main {
   box-shadow: 0px 0px 5px 3px #85e0ff45;
 }
 
-/*
-header {
-    transition: border-color 1s ease-out;
-}
-
-.home.feature-pro header {
-    border-bottom-color: #2fbded;
-} */
-
 .pro-flag {
-  font-size: 0.5em;
-  padding: 0.5em;
-  border-radius: 0.4em;
-  margin: 0 1em 0 0.4em;
-  font-size: 0.3em;
   font-weight: 900;
-  text-transform: uppercase;
   background: linear-gradient(302deg, #6ca71a, #3c7b00);
   color: #fff;
   padding: 0.5em;
-  border-radius: 0.4em;
   line-height: 0.8;
-  /* align-self: flex-start; */
   font-style: normal;
-  margin: 0 1em;
   text-shadow: none;
   -webkit-text-stroke: 0;
   text-transform: capitalize;
   font-size: 0.5em;
-  /* padding: 0.3em 0.4em; */
   border-radius: 0.5em;
   margin: 0 1em 0 0.4em;
   border: 3px solid #fff;
@@ -3078,11 +2841,9 @@ header .pro-flag {
 .result .results_header_contain .pro-flag {
   border-width: 2px;
   margin-right: 1em;
-  /* padding: .5em; */
 }
 
 .result .opportunities_summary .pro-flag {
-  /* padding: .4em !important; */
   font-size: 0.7em;
   font-weight: 900;
   border-width: 0;
@@ -3094,7 +2855,6 @@ header .pro-flag {
 .home_feature_hed_text_leadin {
   font-weight: 300;
   margin-right: 0.2em;
-  /* font-size: 3rem; */
 }
 
 .home_feature_hed_text_line {
@@ -3104,16 +2864,13 @@ header .pro-flag {
 .home_feature_hed_contain .pill {
   background: #1151bb;
   border-radius: 6.25em;
-  padding: 0.6875em 1.4375em;
   line-height: 1em;
   text-decoration: none;
   color: #fff;
   margin: 1.5rem 0 3em 0em;
   display: inline-block;
-  padding: 1.2em 2em;
   background-color: #00000026;
   font-weight: 700;
-  color: #ffffff;
   border: 1px solid #fff;
   padding: 0.9em 1.5em;
 }
@@ -3137,7 +2894,6 @@ header .pro-flag {
   display: flex;
   margin: 0 auto;
   max-width: 1400px;
-
   padding: 3rem 0 5rem;
   justify-content: space-between;
   align-items: flex-start;
@@ -3152,7 +2908,6 @@ header .pro-flag {
 }
 
 .home_feature_hed {
-  /* display: block; */
   width: 100%;
 }
 
@@ -3245,7 +3000,6 @@ header .pro-flag {
 
 .results_nav_hed {
   padding: 0.6em 0.5em 0.6em 0;
-  margin-right: 3em;
   font-size: 0.9rem;
   margin: 0 0;
   font-weight: 900;
@@ -3264,16 +3018,9 @@ header .pro-flag {
   }
 }
 
-.results_nav {
-  /* display: flex; */
-  /* justify-items: flex-start; */
-}
-
 .results_nav_pair {
   display: flex;
   align-items: center;
-  /* flex: 1 0 30em; */
-  /* justify-self: flex-start; */
 }
 
 .results_nav .test_meta_commands {
@@ -3368,9 +3115,7 @@ header .pro-flag {
   flex: 0 1 45%;
   border: 6px solid #fff;
   box-shadow: 0px 0px 5px 3px #fe89ff7a;
-  /* margin-left: 2em; */
   background: #fff;
-  /* max-height: 200px; */
   overflow: hidden;
   position: relative;
   object-fit: contain;
@@ -3384,20 +3129,6 @@ header .pro-flag {
   height: auto;
   display: block;
 }
-
-/* .home_feature_hed_visual {
-    transition: .2s linear;
-    position: relative;
-    z-index: 9999999;
-    transform-origin: right 60%;
-    overflow: visible;
-}
-
-@media (min-width: 50.0625em) {
-    .home.playing .home_feature_hed_visual {
-        transform: scale(1.4);
-    }
-} */
 
 @media (min-width: 65em) {
   .home_feature_hed .attention {
@@ -3417,7 +3148,6 @@ header .pro-flag {
 
 @media (max-width: 90em) {
   .home_content_contain {
-    /* width: auto; */
     padding: 0;
     box-sizing: border-box;
   }
@@ -3481,18 +3211,11 @@ header .pro-flag {
     margin: 2rem 0 -30px;
     display: block;
     max-width: 90vw;
-    /* width: 100%; */
   }
 }
 
 .home_feature_hed-lfwp .attention {
   display: block;
-}
-
-@media (max-width: 70em) {
-  .home_feature_hed-lfwp .home_feature_hed_visual {
-    /* padding-top: 62.62% !important; */
-  }
 }
 
 @media (max-width: 30em) {
@@ -3684,10 +3407,6 @@ header .pro-flag {
   margin-right: 0.2em;
 }
 
-.home_feature_hed-lfwp .home_feature_hed_visual {
-  /* padding-top: 24%; */
-}
-
 .home_feature_hed-lfwp b.flag {
   background: #ffffff;
   padding: 0.1em 0.5em;
@@ -3698,12 +3417,6 @@ header .pro-flag {
   margin-right: 0.5em;
   vertical-align: middle;
   font-weight: 700;
-}
-
-@media (min-width: 80em) {
-  .home_feature_hed-lfwp .home_feature_hed_visual {
-    /* padding-top: 27%; */
-  }
 }
 
 @media (min-width: 85em) {
@@ -3738,11 +3451,9 @@ header .pro-flag {
 nav.link_select {
   color: #1a2a4a;
   font-weight: 700;
-  max-width: 100%;
   display: inline-block;
   position: relative;
   width: 13em;
-  /* line-height: 2; */
   font-size: 0.8em;
   max-width: 100%;
   box-sizing: border-box;
@@ -3788,7 +3499,6 @@ nav.link_select {
     min-width: 20em;
     max-width: 70%;
     font-size: 0.9em;
-    /* width: 100%; */
   }
 }
 
@@ -3952,12 +3662,10 @@ nav.link_select:hover ul {
 
 .test_presets_easy .fieldrow:first-child {
   flex: 1 1 30em;
-  /* max-width: 40%; */
 }
 
 label small {
   display: block;
-  /* max-width: 80%; */
 }
 
 .test_presets_easy .profiles {
@@ -4150,7 +3858,6 @@ ul.meta_exp_applied_list {
 
 .test_preset_profile strong {
   min-width: 5em;
-  /* flex: 1 1 10em; */
 }
 
 #injectscript-container {
@@ -4181,12 +3888,6 @@ ul.meta_exp_applied_list {
 
   .test_preset_profile strong {
     min-width: 4em;
-    /* flex: 1 1 10em; */
-  }
-
-  .test_preset_profile strong {
-    /* width: 90%; */
-    /* display: block; */
   }
 }
 
@@ -4234,7 +3935,6 @@ span.test_presets_tag-experiment {
 
 .test_presets .test_preset_profile {
   gap: 0;
-  /* align-items: flex-end; */
   padding: 1em;
   border-bottom: 1px solid #2a3d64;
 }
@@ -4264,7 +3964,6 @@ span.test_presets_tag-experiment {
   position: absolute;
   background: rgb(255 255 255 / 93%);
   bottom: 110%;
-  display: block;
   color: #1a2a4a;
   width: auto;
   min-width: 20em;
@@ -4342,18 +4041,10 @@ span.test_preset_profile_tt:after {
   display: none;
 }
 
-.compare {
-  /* background: #000; */
-  /* color: #fff; */
-}
-
 .compare #main {
-  /* grid-column: 2 / 12;
-    /* background: #000; */
   padding: 2em 0;
   max-width: none;
   width: auto;
-  /* min-width: 1083px; */
 }
 
 .compare .test_results_header {
@@ -4413,13 +4104,6 @@ span.test_preset_profile_tt:after {
   font-style: normal;
 }
 
-.waterfall-sliders div {
-  /* display: flex;
-    display: flex;
-    flex-flow: row;
-    justify-content: space-between; */
-}
-
 .waterfall-sliders label {
   font-weight: 500;
   display: flex;
@@ -4456,7 +4140,6 @@ span.test_preset_profile_tt:after {
     padding: 1em 0;
     display: flex;
     justify-content: space-between;
-    /* align-items: flex-start; */
   }
 
   .compare_settings {
@@ -4470,7 +4153,6 @@ span.test_preset_profile_tt:after {
   }
 
   .compare_key {
-    /* border-left: 1px solid #ddd; */
     padding-left: 0;
     display: flex;
     align-items: flex-start;
@@ -4490,7 +4172,6 @@ span.test_preset_profile_tt:after {
 }
 
 h1.attention {
-  text-align: center;
   font-weight: 700;
   font-size: 2.125em;
   text-align: center;
@@ -4498,11 +4179,6 @@ h1.attention {
   line-height: 1.4;
   padding: 0 1rem;
 }
-
-/* body.compact h1.attention {
-    font-size: 2.5em;
-    margin: .4em auto 1em;
-} */
 
 @media (min-width: 40em) {
   h1.attention {
@@ -4544,7 +4220,6 @@ table.history {
   border-collapse: collapse;
   font-size: 0.875em;
   margin: 0;
-  /* border: none !important; */
 }
 
 table.history.pretty {
@@ -4553,7 +4228,6 @@ table.history.pretty {
 }
 
 table.history tbody tr th {
-  /* max-width: 4rem !important; */
   width: 1%;
 }
 
@@ -4580,7 +4254,6 @@ table.history tbody th {
 .history th,
 .history td {
   white-space: nowrap;
-  /* text-decoration: underline; */
   text-align: left;
   padding: 1rem;
   border: 1px solid #ddd;
@@ -4695,7 +4368,7 @@ form[name="filterLog"] .history_filter input[type="text"] {
 .chart_node {
   text-align: center;
   vertical-align: middle;
-  font-family: arial, helvetica;
+  font-family: arial, helvetica, sans-serif;
   cursor: default;
   border: 2px solid #b5d9ea;
   background-color: #edf7ff;
@@ -4717,10 +4390,6 @@ form[name="filterLog"] .history_filter input[type="text"] {
 
 #test_box-container {
   grid-column: 3 / 10;
-  /* border: 1px solid #2F80ED;
-    border-right-width: 0;
-    border-left-width: 0;
-    box-shadow: 0 0 30px rgba(47, 128, 237, .5); */
   margin-bottom: 4em;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
@@ -4728,27 +4397,6 @@ form[name="filterLog"] .history_filter input[type="text"] {
 .home #test_box-container {
   border-bottom: 0;
   margin-bottom: 0;
-}
-
-/* body.compact #test_box-container {
-    box-shadow: none;
-} */
-
-@media (min-width: 35em) {
-  /* #test_box-container {
-        border-radius: 10px;
-        border-right-width: 1px;
-        border-left-width: 1px;
-        margin-right: 1rem;
-        margin-left: 1rem;
-    } */
-}
-
-@media (min-width: 75em) {
-  /* #test_box-container {
-        margin-right: 0;
-        margin-left: 0;
-    } */
 }
 
 #test_box-container .test_subbox {
@@ -4762,7 +4410,6 @@ form[name="filterLog"] .history_filter input[type="text"] {
 
 #test_box-container .notification-container {
   background: #f9d856;
-  padding: 1em;
   color: #111;
   border-radius: 10px;
   padding: 1.875em;
@@ -4973,18 +4620,12 @@ form[name="filterLog"] .history_filter input[type="text"] {
 .input_fields li input[type="radio"],
 .input_fields .fieldrow input[type="radio"],
 .input_fields .fieldrow input[type="checkbox"] {
-  /* align-self: flex-start; */
   margin-top: 0.2em;
 }
 
 .input_fields li input[type="radio"],
 .input_fields .fieldrow input[type="radio"] {
-  /* margin-right: .3em; */
   margin-left: 0;
-}
-
-.input_fields li input[type="radio"]:nth-of-type(2n) {
-  /* margin-left: 2em; */
 }
 
 .input_fields label input[type="radio"],
@@ -5097,10 +4738,6 @@ form[name="filterLog"] .history_filter input[type="text"] {
   margin-top: 0;
 }
 
-/* body.compact #url {
-    margin-bottom: 0em;
-} */
-
 @media screen and (min-width: 60em) {
   #url {
     font-size: 1.25em;
@@ -5151,7 +4788,6 @@ a.btn-primary-compact {
   display: inline-block;
   margin: 0;
   border-radius: 1em;
-  /* font-weight: 700; */
 }
 
 @media screen and (min-width: 50em) {
@@ -5201,16 +4837,6 @@ label.test_preset_profile {
   padding: 0.5rem 0;
 }
 
-/* label.test_preset_profile.test_preset_profile-Mobile span:after {
-    background: url(/assets/images/test_icons/chrome.svg) left center no-repeat;
-    width: 100%;
-    display: inline-block;
-    background-size: contain, contain, contain;
-    content: "";
-    width: 35rem;
-    height: 100%;
-} */
-
 #change-location-btn {
   border: 1px solid #fff;
   color: #fff;
@@ -5221,7 +4847,6 @@ label.test_preset_profile {
   cursor: pointer;
   transition: background 0.1s ease-in-out;
   background: url("/assets/images/icon-map.svg") 50% 50% no-repeat transparent;
-  text-indent: 0.5em;
   width: 1em;
   text-indent: -999px;
   overflow: hidden;
@@ -5235,9 +4860,6 @@ label.test_preset_profile {
   #change-location-btn {
     margin-left: 0.25em;
     margin-top: 0;
-    /* width: 1em; */
-    /* text-indent: -999px; */
-    /* overflow: hidden; */
   }
 }
 
@@ -5247,7 +4869,6 @@ label.test_preset_profile {
 
 #simplemodal-container {
   background-color: #fff !important;
-  /* border: 2px solid #444; */
   padding: 5vh 5vw;
   position: fixed;
   z-index: 9999999 !important;
@@ -5316,7 +4937,6 @@ label.test_preset_profile {
 }
 
 #map {
-  /* width: 100%; */
   height: 100%;
   margin: 0px 0px 10px;
   border: 1px solid black;
@@ -5358,7 +4978,6 @@ label.test_preset_profile {
 
 #visual_comparison .urldiv a {
   color: #fff;
-  margin-bottom: 1em;
   display: block;
   margin: 1.2em 0 2.5em;
 }
@@ -5459,6 +5078,40 @@ label.test_preset_profile {
   background-color: rgba(0, 0, 0, 0.63);
 }
 
+.box {
+  background: #fff;
+  box-shadow: 1px 1px 8px rgba(0, 0, 0, 0.2);
+  padding: 1em 1em;
+  margin: 1em 0;
+  padding-bottom: 2em;
+}
+
+.about h1,
+.common h1 {
+  margin-left: 3rem;
+}
+
+#custom-waterfall .box:not(.details_panel),
+.about .box,
+.common .box,
+.video .box {
+  padding: 3rem;
+}
+
+@media (max-width: 60em) {
+  .about h1,
+  .common h1 {
+    margin-left: 1.5rem;
+  }
+  #custom-waterfall .box:not(.details_panel),
+  .about .box,
+  .common .box,
+  .video .box,
+  #page-images .box {
+    padding: 1em 1.5em;
+  }
+}
+
 /* error page styles */
 
 .testerror {
@@ -5541,10 +5194,6 @@ label.test_preset_profile {
 .video_runlabel a {
   font-weight: 500;
   font-size: 0.9em;
-  border: 1px solid transparent;
-  padding: 0.2em 0.7em;
-  font-weight: 500;
-  font-size: 0.9em;
   border: 1px solid #ddd;
   background: #fff;
   padding: 0.2em 1em;
@@ -5577,10 +5226,6 @@ label.test_preset_profile {
   background: #074677;
 }
 
-/* body.compact #header_container {
-    padding: 0 1.5em;
-} */
-
 #header_container {
   display: flex;
   flex-flow: column;
@@ -5588,7 +5233,6 @@ label.test_preset_profile {
   max-width: 1400px;
   margin: 0 auto;
   position: relative;
-  /* gap: 1em; */
 }
 
 @media (max-width: 60em) {
@@ -5601,11 +5245,8 @@ label.test_preset_profile {
 
 .cta-banner {
   text-align: center;
-  /* transform-origin: top center; */
   font-size: 0.9em;
   padding: 0.3em 0 0.8em;
-  /* border-bottom: 1px solid rgba(0, 0, 0, 0.11); */
-  margin: 0;
   position: relative;
   background: #1f2c47;
   color: #fff;
@@ -5622,7 +5263,6 @@ label.test_preset_profile {
 }
 
 .cta-banner a {
-  /* display: block; */
   margin: 0 0 0 0.3em;
 }
 
@@ -5668,7 +5308,6 @@ label.test_preset_profile {
   line-height: 1;
   overflow-x: auto;
   vertical-align: top;
-  /* min-width: 100%; */
 }
 
 .test_results-content {
@@ -5803,19 +5442,16 @@ li.even {
 /* results table rows */
 
 .scrollableTable table tr.runview {
-  /* border-top: 1px solid #eee; */
   margin-top: 1em;
 }
 
 .scrollableTable table.pretty#tableResults tr.runview th {
   background: #fff;
   padding: 1.5em 0 0 0;
-  font-weight: 300;
   color: #2a3b64;
   font-weight: 500;
   text-transform: uppercase;
   font-size: 1em;
-  /* border-top: 1px solid; */
   position: sticky;
   left: 0;
 }
@@ -5843,7 +5479,6 @@ table.pretty td {
   text-align: left;
   vertical-align: top;
   width: 1%;
-  /* equal cols default */
 }
 
 img.autohide:hover {
@@ -5920,10 +5555,6 @@ table.details td.reqMime {
   margin-top: 1em;
 }
 
-.vitals-diagnostics {
-  /* text-align: center; */
-}
-
 .summary-container {
   display: flex;
   flex-wrap: wrap;
@@ -5938,12 +5569,9 @@ table.details td.reqMime {
 .summary-container p {
   margin-bottom: 0;
   line-height: 1;
-  /* font-size: .7em; */
 }
 
 .summary-metric {
-  /* min-width: 300px; */
-  /* border: 1px solid black; */
   font-size: 1em;
   overflow: hidden;
   margin-bottom: 1rem;
@@ -6018,20 +5646,12 @@ table.details td.reqMime {
 
 .summary-metric h4 {
   margin: 0;
-  padding: 0;
   background: none;
   border: 0px solid #fff;
   font-weight: 500;
   color: #686868;
   padding: 0;
-  /* display: block; */
-  /* padding-top: 24px; */
   font-size: 1.1em;
-  /* text-align: center; */
-}
-
-.summary-metric h3 {
-  /* display: none; */
 }
 
 .crux .cruxlabel {
@@ -6114,8 +5734,6 @@ table.details td.reqMime {
 }
 
 .cruxembed .crux h3 {
-  /* padding-top: 1.5em;
-    font-size: 1em; */
   margin-top: 2rem;
 }
 
@@ -6133,7 +5751,6 @@ table.details td.reqMime {
   border: 0px solid #fff;
   font-weight: 700;
   color: #686868;
-  /* display: block; */
   font-size: 0.9em;
   min-height: 2em;
 }
@@ -6146,7 +5763,6 @@ table.details td.reqMime {
 
 .cruxembed .crux .legend {
   font-size: smaller;
-  font-weight: normal;
   font-weight: normal;
   margin: 0 0 1em;
   display: block;
@@ -6443,23 +6059,16 @@ th.header {
 /* Test Results Pages */
 
 .grades {
-  /* float: right; */
   line-height: 1.2em;
-  display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
   gap: 2rem;
   padding: 0 0 1rem;
-  /* max-width: 55%; */
   font-size: 0.625em;
-  /* 10px */
   text-align: center;
   display: grid;
-  /* flex-flow: row wrap; */
 }
 
 .grades li {
-  /* align-items: flex-start; */
-  /* gap: 4rem; */
   text-align: left;
   justify-content: space-between;
 }
@@ -6492,7 +6101,6 @@ th.header {
   border-radius: 0.5rem;
   text-align: center !important;
   display: inline-block;
-  /* width: 1em; */
 }
 
 @media (max-width: 60em) {
@@ -6561,7 +6169,6 @@ th.header {
   background: #0d1424;
   background: #111a2a;
   border-bottom: 1px solid #010102;
-  /* border-bottom: 1px solid ; */
 }
 
 .alert-banner img,
@@ -6681,7 +6288,6 @@ div.overflow-container > *,
 
 .scrollableTable th,
 .scrollableTable td {
-  /* scroll-snap-align: start; */
   min-width: 3.5rem;
   position: relative;
   z-index: 10;
@@ -6705,7 +6311,6 @@ div.overflow-container > *,
 .scrollableTable thead tr {
   position: sticky;
   top: 0;
-  /* border-bottom: 1px solid #ddd; */
 }
 
 .scrollableTable tbody th {
@@ -6752,7 +6357,6 @@ table.pretty {
   background-color: #fff;
   border-collapse: collapse;
   border: 0;
-  /* border-radius: 10px; */
 }
 
 table#tableResults.pretty th,
@@ -6809,9 +6413,6 @@ table.pretty .metric_groups th span {
   border-top: 1px solid #ddd;
 }
 
-table.pretty .metric_groups th:last-child span {
-}
-
 table.pretty .metric_groups th a {
   color: inherit;
 }
@@ -6827,7 +6428,6 @@ table.pretty .metric_groups th {
   font-weight: 700;
   color: #686868;
   padding: 0 2rem 4px 0;
-  /* display: block; */
   padding-top: 24px;
   font-size: 0.9em;
   vertical-align: top;
@@ -6855,11 +6455,8 @@ table.pretty .metric_groups th {
   font-size: 0.4em;
   font-weight: 900;
   -webkit-text-stroke: 0;
-  display: inline-block;
   font-style: normal;
   text-transform: uppercase;
-  margin: 0;
-  /* color: #222; */
   padding: 0rem 0.5rem;
   display: inline;
   width: auto;
@@ -6908,7 +6505,6 @@ table#tableResults.pretty td {
   border-top-width: 0;
   vertical-align: baseline;
   color: #2a3c64;
-  /* display: block; */
   -webkit-text-stroke: 0.04em currentColor;
 }
 
@@ -6943,10 +6539,6 @@ table#tableResults td.good {
 .results_header table#tableResults td.good em {
   background: #6ca71a;
   color: #fff;
-  /* padding: .1rem .5rem; */
-  /* display: inline-block; */
-  /* width: auto; */
-  /* margin: 0; */
 }
 
 .results_header table#tableResults td.poor em {
@@ -6965,10 +6557,7 @@ table#tableResults td.poor {
 }
 
 a.result_plot {
-  display: block;
   margin: 1em 0 1em;
-  /* text-align: right; */
-  /* width: 100%; */
   display: inline-block;
   font-size: 0.8em;
   border-radius: 1.5em;
@@ -7029,12 +6618,6 @@ div.tableBytes td {
   text-align: left;
 }
 
-td {
-  /* text-align: center;
-    vertical-align: middle; */
-  /* padding: 1em; */
-}
-
 div.bar {
   height: 20px;
   margin-top: auto;
@@ -7093,8 +6676,7 @@ table.legend td {
   position: fixed;
   bottom: 1em;
   left: 50%;
-  margin-left: 510px;
-  /* 980px/2+20 */
+  margin-left: 510px; /* 980px/2+20 */
   padding: 1em;
   display: none;
 }
@@ -7110,26 +6692,13 @@ table.legend td {
   padding: 0 1em;
 }
 
-.accordion_block {
-  /* border: 1px solid #aaa; */
-  /* border-radius: 5px; */
-  /* width: 930px; */
-}
-
 h4.accordion_opener {
-  /* text-align: center; */
   cursor: pointer;
   display: block;
   padding: 0.2em 0 0em 0;
   background: no-repeat 10px 50% transparent;
-  /* font-size: 1.5em; */
-  /* line-height: 1em; */
   margin: 0 0 1em;
   background-size: 0.6rem 0.6rem;
-}
-
-.accordion_opener.jkActive {
-  /* background-color: whitesmoke; */
 }
 
 h4.accordion_opener:before {
@@ -7145,9 +6714,6 @@ h4.accordion_opener:before {
 h4.accordion_closed:before {
   transform-origin: 50% 50%;
   transform: rotate(-90deg);
-}
-
-h4.accordion_opened:before {
 }
 
 h4.accordion_loading:before {
@@ -7312,7 +6878,6 @@ table.details td.error {
   padding-bottom: 0.875em;
   max-width: 30rem;
   margin: auto 0 5em;
-  /* word-break: break-all; */
 }
 
 .resource-block img {
@@ -7335,10 +6900,6 @@ table.details td.error {
 .resource-block p {
   color: #a9c8f1;
   line-height: 1.5em;
-}
-
-.resource-block:last-of-type {
-  /* margin-bottom: 7.125em; */
 }
 
 .resource-block a {
@@ -7366,7 +6927,6 @@ div.tableBytes table {
 td {
   text-align: center;
   vertical-align: middle;
-  /* padding: 1em; */
 }
 
 div.tableRequests td {
@@ -7398,23 +6958,15 @@ td.legend {
 
 .testimonial {
   display: block;
-  /* border: 1px solid #ffffff; */
-  /* background: #35044e; */
   text-align: center;
-  /* box-shadow: 1px 1px 70px rgb(0 0 0 / 50%); */
   border-radius: 1rem;
-  /* margin-bottom: 0em; */
   max-width: 50em;
-  margin-left: auto;
-  margin-right: auto;
-  /* margin-top: 6rem; */
   margin: 0 auto;
 }
 
 .testimonial blockquote {
   font-size: 1.375em;
   line-height: 1.454545455em;
-  /* margin-top: 3rem; */
   padding-bottom: 3rem;
   font-weight: 300;
   background: url(/assets/images/test_icons/comment.svg) bottom center no-repeat;
@@ -7483,13 +7035,10 @@ td.legend {
 .feed {
   overflow: hidden;
   padding-bottom: 0.875em;
-  /* width: 100%; */
   flex: 1 1 auto;
 }
 
 .feed ul {
-  /* border: 1px solid #2F80ED;
-    box-shadow: 0 0 15px rgb(47 128 237 / 50%); */
   background: #fff;
   border-radius: 0.5em;
   margin: 1em 0;
@@ -7506,9 +7055,6 @@ td.legend {
 .feed li {
   border-radius: 3px;
   padding: 0.5em;
-}
-
-.feed li:nth-child(odd) {
 }
 
 .feed a {
@@ -7577,7 +7123,6 @@ td.legend {
 }
 
 .test_results-content .google-visualization-table .gradient {
-  background-image: none;
   background: gainsboro;
 }
 
@@ -7601,7 +7146,6 @@ td.legend {
   font-size: 1em;
   font-weight: 700;
   padding: 0 0 1.4em 2.4em;
-  display: inline-block;
   cursor: pointer;
   display: block;
   margin-bottom: 1em;
@@ -7623,7 +7167,6 @@ td.legend {
   margin: 0 0.7em 0 0;
   background-color: #980e99;
   border-radius: 100%;
-  padding: 0;
   float: left;
   border: 1px solid #fff;
   padding: 0;
@@ -7675,12 +7218,6 @@ td.legend {
   outline: 1px solid #6078a7;
 }
 
-.simpleadvancedfields_contain > input {
-}
-
-.simpleadvancedfields_contain > input + label {
-}
-
 .simpleadvancedfields {
   flex: 1;
   display: flex;
@@ -7714,7 +7251,6 @@ td.legend {
 }
 
 .vitals-diagnostics .frames {
-  margin-bottom: 2em;
   margin: 2em 0;
   display: flex;
   justify-content: center;
@@ -7725,8 +7261,6 @@ td.legend {
 .vitals-diagnostics .vitals-waterfall {
   margin-top: 4em;
   position: relative;
-  /* margin: 4em auto 0;
-    max-width: 1012px; */
   text-align: center !important;
 }
 
@@ -7735,23 +7269,7 @@ td.legend {
   text-align: center;
 }
 
-/* .vitals-diagnostics .vitals-waterfall .waterfall-container :after {
-    content: "";
-    position: absolute;
-    right: 3px;
-    top: 0;
-    bottom: 0;
-    border-right: 2px dashed #008000;
-} */
-
 .vitals-diagnostics .waterfall-label {
-  /* padding: .3em;
-    text-align: right;
-    top: 0;
-    float: right;
-    margin-bottom: 0;
-    position: relative;
-    margin-bottom: 2em; */
   display: none;
 }
 
@@ -7774,11 +7292,6 @@ td.legend {
   padding-left: 2em;
 }
 
-#result.vitals-diagnostics .pretty {
-  /* font-size: .9em; */
-  /* margin-bottom: 2em; */
-}
-
 .vitals-diagnostics .pretty caption {
   font-size: 1.4em;
   font-weight: bold;
@@ -7789,9 +7302,6 @@ td.legend {
 .vitals-diagnostics .pretty th,
 .vitals-diagnostics .pretty td,
 .vitals-diagnostics .values li {
-  /* text-align: left; */
-  /* word-break: keep-all; */
-  /* white-space: nowrap; */
   border: 1px solid #ddd;
   padding: 0.8em;
 }
@@ -7879,12 +7389,6 @@ td.legend {
   .waterfall-legend tbody tr {
     display: flex;
     flex-flow: row wrap;
-    /* grid-template-columns: 1fr 1fr 1fr; */
-  }
-
-  .waterfall-legend tbody td {
-    /* padding: .5rem .5rem .5rem 0;
-        border: 0; */
   }
 
   div.waterfall-container,
@@ -7933,7 +7437,6 @@ div.request-overlay {
   background-color: #fff;
   overflow: hidden;
   opacity: 0.9;
-  filter: alpha(opacity=90);
 }
 
 div.request-overlay.selected {
@@ -7950,7 +7453,6 @@ div.request-overlay.lcp-request {
 
 div.transparent {
   opacity: 0;
-  filter: alpha(opacity=0);
 }
 
 div.dialog-title {
@@ -8031,7 +7533,7 @@ div.jqmDialog {
   font-size: smaller;
   line-height: 1.5em;
   overflow: hidden;
-  font-family: verdana, tahoma, helvetica;
+  font-family: verdana, tahoma, helvetica, sans-serif;
   color: #000;
   background: #fff;
   border: 1px solid #aaa;
@@ -8057,7 +7559,7 @@ div.jqmdTC {
   background: #303030;
   color: #000;
   padding: 0.5rem 1rem;
-  font-family: "sans serif", verdana, tahoma, helvetica;
+  font-family: verdana, tahoma, helvetica, sans-serif;
   font-weight: bold;
   zoom: 1;
   cursor: move;
@@ -8103,17 +7605,6 @@ div.jqmdBC button {
   clip: rect(1px, 1px, 1px, 1px);
 }
 
-.ui-helper-reset {
-  /* margin: 0; */
-  /* padding: 0; */
-  /* border: 0; */
-  /* outline: 0; */
-  /* line-height: 1.3; */
-  /* text-decoration: none; */
-  /* font-size: 100%; */
-  /* list-style: none; */
-}
-
 .ui-helper-clearfix:before,
 .ui-helper-clearfix:after {
   content: "";
@@ -8124,10 +7615,6 @@ div.jqmdBC button {
   clear: both;
 }
 
-.ui-helper-clearfix {
-  /* zoom: 1; */
-}
-
 .ui-helper-zfix {
   width: 100%;
   height: 100%;
@@ -8135,7 +7622,6 @@ div.jqmdBC button {
   left: 0;
   position: absolute;
   opacity: 0;
-  filter: Alpha(Opacity=0);
 }
 
 .ui-state-disabled {
@@ -8155,45 +7641,6 @@ div.jqmdBC button {
   left: 0;
   width: 100%;
   height: 100%;
-}
-
-.ui-widget {
-  /* font-family: Trebuchet MS, Tahoma, Verdana, Arial, sans-serif; */
-  /* font-size: 1.1em; */
-}
-
-.ui-widget .ui-widget {
-  /* font-size: 1em; */
-}
-
-.ui-widget input,
-.ui-widget select,
-.ui-widget textarea,
-.ui-widget button {
-  /* font-family: Trebuchet MS, Tahoma, Verdana, Arial, sans-serif;
-    font-size: 1em; */
-}
-
-.ui-widget-content {
-  /* border: 1px solid #dddddd; */
-  /* background-color: #eeeeee; */
-  /* color: #333333; */
-}
-
-.ui-widget-content a {
-  /* color: #333333; */
-}
-
-.ui-widget-header {
-  /* border: 1px solid #e78f08; */
-  /* background-color: #f6a828; */
-  /* color: #ffffff; */
-  /* font-weight: bold; */
-  /* padding: .5em 10vw; */
-}
-
-.ui-widget-header a {
-  /* color: #ffffff; */
 }
 
 .ui-state-default,
@@ -8218,7 +7665,6 @@ div.request-dialog-radio .ui-state-default {
 .ui-widget-content .ui-state-hover,
 .ui-widget-header .ui-state-hovers {
   border: none;
-  /* background-color: #777; */
 }
 
 div.request-dialog-radio .ui-state-hover {
@@ -8248,20 +7694,6 @@ div.request-dialog-radio .ui-widget-header .ui-state-active {
 
 .ui-widget :active {
   outline: none;
-}
-
-.ui-state-highlight,
-.ui-widget-content .ui-state-highlight,
-.ui-widget-header .ui-state-highlight {
-  /* border: none;
-    background: #ffe45c url(images/ui-bg_highlight-soft_75_ffe45c_1x100.png) 50% top repeat-x;
-    color: #363636; */
-}
-
-.ui-state-highlight a,
-.ui-widget-content .ui-state-highlight a,
-.ui-widget-header .ui-state-highlight a {
-  /* color: #363636; */
 }
 
 .ui-state-error,
@@ -8295,7 +7727,6 @@ div.request-dialog-radio .ui-widget-header .ui-state-active {
 .ui-widget-content .ui-priority-secondary,
 .ui-widget-header .ui-priority-secondary {
   opacity: 0.7;
-  filter: Alpha(Opacity=70);
   font-weight: normal;
 }
 
@@ -8303,7 +7734,6 @@ div.request-dialog-radio .ui-widget-header .ui-state-active {
 .ui-widget-content .ui-state-disabled,
 .ui-widget-header .ui-state-disabled {
   opacity: 0.35;
-  filter: Alpha(Opacity=35);
   background-image: none;
 }
 
@@ -8653,7 +8083,6 @@ div.bar {
 .details_panel[open] .details_panel_hed {
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
   margin: 0;
-  /* padding: 0 0 .8em; */
 }
 
 .details_panel_hed::-webkit-details-marker {
@@ -8669,7 +8098,6 @@ div.bar {
 .details_panel:not([open]):focus-within .details_panel_hed {
   border: 1px solid #aaa;
   outline: none;
-  /* box-shadow: 0 0 30px rgb(47 128 237 / 50%); */
 }
 
 .details_panel:focus-within summary:focus {
@@ -8986,9 +8414,6 @@ body.screenshot .experiment_meta_included summary {
   border: 0;
 }
 
-body.screenshot .experiment_meta_included summary {
-}
-
 body.screenshot .experiment_meta_included * {
   display: inline-block;
 }
@@ -9092,15 +8517,10 @@ wpt-header .wptheader_nav_menu_section a.banner_lfwp:hover {
 .banner_lfwp_pill {
   background: #efd36e;
   border-radius: 6.25em;
-  padding: 0.6875em 1.4375em;
   line-height: 1em;
   text-decoration: none;
-  color: #fff;
   margin: 1rem 0 0 0em;
-  display: inline-block;
-  padding: 1.2em 2em;
   font-weight: 700;
-  color: #ffffff;
   border: 1px solid #fff;
   padding: 1em 1.3em;
   display: block;


### PR DESCRIPTION
15% fewer LOC (8415 down from 9924)

Removed:
 * commented out code
 * empty selectors
 * properties overwritten by shorthands, e.g. `padding-left` followed by `padding`
 * duplicate properties
 * `alpha()` opacity
 
Added:
 * generic font families where missing (mostly in jQuery stuff)