### PR TITLE
fix(account/signup): support legacy plan upgrades

### DIFF
--- a/tests/Handlers/AccountTest.php
+++ b/tests/Handlers/AccountTest.php
@@ -616,7 +616,7 @@ final class AccountTest extends TestCase
 
         $client = $this->createMock(CPClient::class);
         $client->expects($this->once())
-            ->method('getWptPlans');
+            ->method('getFullWptPlanSet');
         $client->expects($this->once())
             ->method('getUserContactInfo')
             ->with(12345)

--- a/www/assets/js/estimate-taxes.js
+++ b/www/assets/js/estimate-taxes.js
@@ -3,7 +3,7 @@
 
   class EstimateTaxes {
     constructor(addressForm, summaryNode) {
-      if(!addressForm || !summaryNode) {
+      if (!addressForm || !summaryNode) {
         return;
       }
       this.form = addressForm;

--- a/www/src/CPClient.php
+++ b/www/src/CPClient.php
@@ -33,6 +33,8 @@ use WebPageTest\CPGraphQlTypes\ChargifySubscriptionInputType;
 use WebPageTest\CPGraphQlTypes\ContactUpdateInput;
 use WebPageTest\CPGraphQlTypes\SubscriptionCancellationInputType;
 use WebPageTest\PaidPageInfo;
+use WebPageTest\PlanList;
+use WebPageTest\PlanListSet;
 
 class CPClient
 {
@@ -270,6 +272,49 @@ class CPClient
         }
     }
 
+    public function getFullWptPlanSet(): PlanListSet
+    {
+        $gql = (new Query('wptPlan'))
+            ->setSelectionSet([
+                'name',
+                'priceInCents',
+                'description',
+                'interval',
+                'monthlyTestRuns'
+            ]);
+
+        $results = $this->graphql_client->runQuery($gql, true);
+        $all_plans = array_map(function ($data): Plan {
+            $options = [
+                'id' => $data['name'],
+                'name' => $data['description'],
+                'priceInCents' => $data['priceInCents'],
+                'billingFrequency' => $data['interval'],
+                'runs' => $data['monthlyTestRuns']
+            ];
+
+            return new Plan($options);
+        }, $results->getData()['wptPlan'] ?? []);
+
+          $current_plans = array_filter($all_plans, function (Plan $plan) {
+              /** This is a bit of a hack for now. These are our approved plans for new
+               * customers to be able to use. We will better handle this from the backend
+               * */
+                return strtolower($plan->getId()) == 'ap5' ||
+                     strtolower($plan->getId()) == 'ap6' ||
+                     strtolower($plan->getId()) == 'ap7' ||
+                     strtolower($plan->getId()) == 'ap8' ||
+                     strtolower($plan->getId()) == 'mp5' ||
+                     strtolower($plan->getId()) == 'mp6' ||
+                     strtolower($plan->getId()) == 'mp7' ||
+                     strtolower($plan->getId()) == 'mp8';
+          });
+        $set = new PlanListSet();
+        $set->setAllPlans(new PlanList(...$all_plans));
+        $set->setCurrentPlans(new PlanList(...$current_plans));
+        return $set;
+    }
+
     public function getWptPlans(): PlanList
     {
         $gql = (new Query('wptPlan'))
@@ -293,18 +338,16 @@ class CPClient
 
             return new Plan($options);
         }, $results->getData()['wptPlan'] ?? []), function (Plan $plan) {
-          /** This is a bit of a hack for now. These are our approved plans for new
-           * customers to be able to use. We will better handle this from the backend
-           * */
-            return strtolower($plan->getId()) == 'ap5' ||
-                   strtolower($plan->getId()) == 'ap6' ||
-                   strtolower($plan->getId()) == 'ap7' ||
-                   strtolower($plan->getId()) == 'ap8' ||
-                   strtolower($plan->getId()) == 'mp5' ||
-                   strtolower($plan->getId()) == 'mp6' ||
-                   strtolower($plan->getId()) == 'mp7' ||
-                   strtolower($plan->getId()) == 'mp8';
+                return strtolower($plan->getId()) == 'ap5' ||
+                     strtolower($plan->getId()) == 'ap6' ||
+                     strtolower($plan->getId()) == 'ap7' ||
+                     strtolower($plan->getId()) == 'ap8' ||
+                     strtolower($plan->getId()) == 'mp5' ||
+                     strtolower($plan->getId()) == 'mp6' ||
+                     strtolower($plan->getId()) == 'mp7' ||
+                     strtolower($plan->getId()) == 'mp8';
         });
+
         return new PlanList(...$plans);
     }
 

--- a/www/src/CPSignupClient.php
+++ b/www/src/CPSignupClient.php
@@ -166,7 +166,7 @@ class CPSignupClient
             ]);
 
         $results = $this->graphql_client->runQuery($gql, true);
-        $plans = array_filter(array_map(function ($data): Plan {
+        $plans = array_map(function ($data): Plan {
             $options = [
                 'id' => $data['name'],
                 'name' => $data['description'],
@@ -176,19 +176,22 @@ class CPSignupClient
             ];
 
             return new Plan($options);
-        }, $results->getData()['wptPlan'] ?? []), function (Plan $plan) {
+        }, $results->getData()['wptPlan'] ?? []);
+
+        $plans = array_filter($plans, function (Plan $plan) {
           /** This is a bit of a hack for now. These are our approved plans for new
            * customers to be able to use. We will better handle this from the backend
            * */
             return strtolower($plan->getId()) == 'ap5' ||
-                   strtolower($plan->getId()) == 'ap6' ||
-                   strtolower($plan->getId()) == 'ap7' ||
-                   strtolower($plan->getId()) == 'ap8' ||
-                   strtolower($plan->getId()) == 'mp5' ||
-                   strtolower($plan->getId()) == 'mp6' ||
-                   strtolower($plan->getId()) == 'mp7' ||
-                   strtolower($plan->getId()) == 'mp8';
+                 strtolower($plan->getId()) == 'ap6' ||
+                 strtolower($plan->getId()) == 'ap7' ||
+                 strtolower($plan->getId()) == 'ap8' ||
+                 strtolower($plan->getId()) == 'mp5' ||
+                 strtolower($plan->getId()) == 'mp6' ||
+                 strtolower($plan->getId()) == 'mp7' ||
+                 strtolower($plan->getId()) == 'mp8';
         });
+
         return new PlanList(...$plans);
     }
 

--- a/www/src/PlanListSet.php
+++ b/www/src/PlanListSet.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebPageTest;
+
+use WebPageTest\PlanList;
+
+class PlanListSet
+{
+    private PlanList $all_plans;
+    private PlanList $current_plans;
+
+    public function __construct()
+    {
+        $this->all_plans = new PlanList();
+        $this->current_plans = new PlanList();
+    }
+
+    public function setAllPlans(PlanList $all_plans)
+    {
+        $this->all_plans = $all_plans;
+    }
+
+    public function setCurrentPlans(PlanList $current_plans)
+    {
+        $this->current_plans = $current_plans;
+    }
+
+    public function getAllPlans(): PlanList
+    {
+        return $this->all_plans;
+    }
+
+    public function getCurrentPlans(): PlanList
+    {
+        return $this->current_plans;
+    }
+}

--- a/www/src/Util.php
+++ b/www/src/Util.php
@@ -773,7 +773,6 @@ class Util
             $planId = $plan->getId();
             if (strtolower($planId) == strtolower($id)) {
                 return $plan;
-                exit();
             }
         }
     }


### PR DESCRIPTION
We have an issue where we are filtering out plans people might be on still, but that we no longer sell, as they are legacy plans in the system.

This should fix that.