### PR TITLE
Reusable code flask

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -3860,13 +3860,13 @@ ul.meta_exp_applied_list {
   min-width: 5em;
 }
 
-#injectscript-container {
+.codeflask-container {
   display: contents;
 }
 
-#injectscript-container .codeflask {
+.codeflask-container .codeflask {
   position: relative;
-  height: 500px;
+  height: 400px;
 }
 
 .result .test_presets li {

--- a/www/assets/js/site.js
+++ b/www/assets/js/site.js
@@ -45,8 +45,6 @@ function wptLogout(redirectUrl) {
   } catch (e) {}
 })(jQuery);
 
-window.codeFlasks = {};
-
 (function ($) {
   $(document).ready(function () {
     // Advanced Settings toggle
@@ -77,34 +75,17 @@ window.codeFlasks = {};
     // jQuery UI Tabs
     $("#test_subbox-container").tabs();
     $("#test_subbox-container").on("tabsshow", async function (event, ui) {
-      if (
-        ui.tab.id === "tab-advanced" &&
-        !document.getElementById("injectscript-container")
-      ) {
-        // load Flask
-        const { default: CodeFlask } = await import(
-          "/assets/js/codeflask.module.js"
-        );
-        var injectScript = document.getElementById("injectScript");
-        // editor container
-        var codeEl = document.createElement("div");
-        codeEl.id = "injectscript-container";
-        injectScript.parentNode.insertBefore(codeEl, injectScript);
-        // switch textarea to a hidden input
-        var hidden = document.createElement("input");
-        hidden.type = "hidden";
-        hidden.id = "injectScript";
-        hidden.name = "injectScript";
-        injectScript.parentNode.replaceChild(hidden, injectScript);
-        // go!
-        var codeArea = new CodeFlask(codeEl, {
-          language: "js",
-        });
-        codeArea.onUpdate(function (code) {
-          hidden.value = code;
-        });
-        window.codeFlasks.injectScript = codeArea;
+      if (ui.tab.id === "ui-tab-advanced") {
+        initCodeField("injectScript");
+        initCodeField("customHeaders");
       }
+      if (ui.tab.id === "ui-tab-custom-metrics") {
+        initCodeField("custom");
+      }
+      if (ui.tab.id === "ui-tab-script") {
+        initCodeField("enter_script");
+      }
+
     });
 
     // Truncatable
@@ -251,8 +232,12 @@ window.codeFlasks = {};
   }
 })();
 
+window.codeFlasks = {};
 /**
- * Handle file picks
+ * Handle file picks.
+ * Relies on the global `window.codeFlasks` for interoperability with the
+ * code highlighting.
+ *
  * @param {string} source Element ID of the file picker
  * @param {string} dest Element ID of the input where file content goes
  */
@@ -283,4 +268,36 @@ function initFileReader(source, dest) {
       false
     );
   }
+}
+
+/**
+ * Initialize fields for code highlighting (using codeflask)
+ * Relies on the global `window.codeFlasks` for interoperability with the
+ * file pickers.
+ *
+ * @param {string} source Element ID of the textarea
+ */
+async function initCodeField(source, language = "js") {
+  if (window.codeFlasks[source]) {
+    return; // already initialized
+  }
+  // load Flask
+  const { default: CodeFlask } = await import("/assets/js/codeflask.module.js");
+  const originalTextarea = document.getElementById(source);
+  // editor container
+  const codeEl = document.createElement("div");
+  codeEl.classList.add("codeflask-container");
+  originalTextarea.parentNode.insertBefore(codeEl, originalTextarea);
+  // switch textarea to a hidden input
+  const hidden = document.createElement("input");
+  hidden.type = "hidden";
+  hidden.id = source;
+  hidden.name = originalTextarea.name;
+  originalTextarea.parentNode.replaceChild(hidden, originalTextarea);
+  // go!
+  const codeArea = new CodeFlask(codeEl, {
+    language,
+  });
+  codeArea.onUpdate((code) => (hidden.value = code));
+  window.codeFlasks[source] = codeArea;
 }

--- a/www/home.php
+++ b/www/home.php
@@ -414,18 +414,18 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
 
                                     <div id="test_subbox-container">
                                         <ul class="ui-tabs-nav ui-tabs-nav-advanced">
-                                            <li><a href="#test-settings">Test Settings</a></li>
-                                            <li><a href="#advanced-settings" id="tab-advanced">Advanced</a></li>
-                                            <li><a href="#advanced-chrome">Chromium</a></li>
+                                            <li><a href="#test-settings" id="ui-tab-settings">Test Settings</a></li>
+                                            <li><a href="#advanced-settings" id="ui-tab-advanced">Advanced</a></li>
+                                            <li><a href="#advanced-chrome" id="ui-tab-chromium">Chromium</a></li>
                                             <?php if (!GetSetting('no_basic_auth_ui') || isset($_GET['auth'])) { ?>
-                                                <li><a href="#auth">Auth</a></li>
+                                                <li><a href="#auth" id="ui-tab-auth">Auth</a></li>
                                             <?php } ?>
-                                            <li><a href="#script">Script</a></li>
-                                            <li><a href="#block">Block</a></li>
-                                            <li><a href="#spof">SPOF</a></li>
-                                            <li><a href="#custom-metrics">Custom</a></li>
+                                            <li><a href="#script" id="ui-tab-script">Script</a></li>
+                                            <li><a href="#block" id="ui-tab-block">Block</a></li>
+                                            <li><a href="#spof" id="ui-tab-spof">SPOF</a></li>
+                                            <li><a href="#custom-metrics" id="ui-tab-custom-metrics">Custom</a></li>
                                             <?php if (ShowBulk()) { ?>
-                                                <li><a href="#bulk">Bulk Testing</a></li>
+                                                <li><a href="#bulk" id="ui-tab-bulk">Bulk Testing</a></li>
                                             <?php } ?>
                                         </ul>
                                         <div id="test-settings" class="test_subbox">
@@ -942,16 +942,16 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
                                         <div id="custom-metrics" class="test_subbox ui-tabs-hide">
                                             <div>
                                                 <p>
-                                                    <label for="custom_metrics" class="full_width">Custom Metrics:</label>
+                                                    <label for="custom" class="full_width">Custom Metrics:</label>
                                                     <small>
                                                         Type in or read <label for="custom_metrics_file" class="linklike">from a text file</label>
                                                     </small>
                                                     <input type="file" id="custom_metrics_file" accept="text/*" class="a11y-hidden">
                                                     <script>
-                                                        document.addEventListener('DOMContentLoaded', () => initFileReader('custom_metrics_file', 'custom_metrics'));
+                                                        document.addEventListener('DOMContentLoaded', () => initFileReader('custom_metrics_file', 'custom'));
                                                     </script>
                                                 </p>
-                                                <textarea name="custom" class="large" id="custom_metrics" cols="0" rows="0"></textarea>
+                                                <textarea name="custom" class="large" id="custom" cols="0" rows="0"></textarea>
                                             </div>
                                             <div class="notification-container">
                                                 <div class="notification">


### PR DESCRIPTION
Moved the one-off codeflask init code to a function. Also enabled code highlighting in 3 more textareas.

`custom-metrics` was a duplicate `id` so had to rename it.

2 of the new textareas are not JavaScript, but they look pretty nonetheless, e.g.:

<img width="967" alt="Screen Shot 2022-10-04 at 7 00 39 PM" src="https://user-images.githubusercontent.com/51308/193946022-738d9a69-8347-45b6-8d51-afbc69c673ba.png">

