### PR TITLE
A round of CSS linting

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -23,7 +23,6 @@
     "media-feature-name-no-unknown": true,
     "named-grid-areas-no-invalid": true,
     "no-duplicate-at-import-rules": true,
-    "no-duplicate-selectors": true,
     "no-empty-source": true,
     "no-extra-semicolons": true,
     "no-invalid-double-slash-comments": true,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "format:prettier": "npx prettier@2.7.1 --write 'www/**/*.css' 'www/**/*.js'",
     "format": "composer format:php && composer format:prettier",
     "lint:css": "npx stylelint@14.9.1 'www/**/*.css'",
-    "lint": "phpcs --standard=PSR12 www/src www/cpauth www/common",
+    "lint:php": "phpcs --standard=PSR12 www/src www/cpauth www/common",
+    "lint": "composer lint:php && composer lint:css",
     "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
     "test": "phpunit --configuration tests/phpunit.xml"
   },

--- a/www/assets/css/account.css
+++ b/www/assets/css/account.css
@@ -94,7 +94,7 @@ body.theme-b {
   border-bottom: 1px solid #c8c8c8;
   margin-bottom: 10px;
   font-size: 1.25rem;
-  font-family: "Open Sans";
+  font-family: Open Sans, sans-serif;
   font-style: normal;
   font-weight: 400;
   padding-bottom: 10px;
@@ -162,7 +162,6 @@ body.theme-b {
   cursor: pointer;
   appearance: none;
   border: 0;
-  background-color: inherit;
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M15 2L3 14L2 18L6 17L18 5L15 2ZM15 3.41L16.59 5L14.65 6.94L13.06 5.35L15 3.41ZM5.49 16.1L3.37 16.63L3.9 14.51L5.36 13.06L6.95 14.65L5.49 16.1ZM7.65 13.94L6.06 12.35L12.35 6.06L13.94 7.65L7.65 13.94Z' fill='%23006AD4'/%3E%3C/svg%3E");
   background-position: 50%;
 }
@@ -223,16 +222,13 @@ body.theme-b {
   display: none;
 }
 
-.modal-open {
-  visibility: visible;
-  display: block;
-}
-
 .modal-open + .modal_screen {
   display: block;
 }
 
 .modal-open {
+  visibility: visible;
+  display: block;
   z-index: 1001;
   background: rgb(244, 244, 244);
   box-sizing: border-box;
@@ -1641,7 +1637,7 @@ table.sortable th:not([aria-sort]) button:hover span::after {
 }
 
 .plan-selector .plan-name {
-  font-family: "Open Sans";
+  font-family: Open Sans, sans-serif;
   font-style: normal;
   font-weight: 700;
   font-size: 1.375rem;
@@ -1676,7 +1672,7 @@ span.unit {
 }
 
 .plan-selector .price {
-  font-family: "Open Sans";
+  font-family: Open Sans, sans-serif;
   color: #141e33;
   font-style: normal;
   font-weight: 700;

--- a/www/assets/css/button.css
+++ b/www/assets/css/button.css
@@ -18,11 +18,9 @@
   width: auto;
   background-color: #fff;
   cursor: pointer;
-  display: inline-block;
   text-decoration: none;
   color: #111;
   font-size: 1rem;
-  display: block;
   margin-bottom: 15px;
   display: flex;
   height: 50px;

--- a/www/learn/lightning-fast-web-performance/lfwp-assets/learn-course.css
+++ b/www/learn/lightning-fast-web-performance/lfwp-assets/learn-course.css
@@ -114,15 +114,10 @@ body.learn #main {
 .learn_feature_hed_contain .pill {
   background: #efd36e;
   border-radius: 6.25em;
-  padding: 0.6875em 1.4375em;
   line-height: 1em;
   text-decoration: none;
-  color: #fff;
   margin: 1rem 0 0 0em;
-  display: inline-block;
-  padding: 1.2em 2em;
   font-weight: 700;
-  color: #ffffff;
   border: 1px solid #fff;
   padding: 1em 1.3em;
   display: block;
@@ -234,7 +229,6 @@ body.learn #main {
 }
 
 .learn_feature_hed_visual p {
-  max-width: 100%;
   height: auto;
   display: flex;
   align-content: flex-end;
@@ -775,11 +769,8 @@ video {
   border-radius: 3em;
   font-size: calc(0.9em + 0.3vw);
   font-weight: 600;
-  /* max-width: 8em; */
   flex: 1 0 10em;
-  background: #31639d;
   text-decoration: none;
-  color: #fff;
   border: 2px solid #584d32;
   cursor: pointer;
   padding: 1.1em;
@@ -1001,11 +992,6 @@ div.chapter_extra .experiment_description_go a {
     margin-left: auto;
     margin-right: auto;
   }
-  .curric ul,
-  .see-ahead-vids,
-  .whatyoulllearn ul {
-    /* display: flex; */
-  }
   .see-ahead-vids figure {
     flex: 1 0 29%;
     padding-top: 20%;
@@ -1013,9 +999,6 @@ div.chapter_extra .experiment_description_go a {
   .curric li em {
     float: right;
   }
-}
-
-.curric ul {
 }
 
 .whatyoulllearn li {

--- a/www/themetrictimes/site.css
+++ b/www/themetrictimes/site.css
@@ -51,11 +51,6 @@ p.logosub {
 }
 
 .wptlogo {
-  /* border: 1px solid #aaa; */
-  /* position: absolute; */
-  padding: 0;
-  /* top: 3em; */
-  /* right: 0; */
   margin: 0;
   padding: 0.3rem 0 0;
   display: block;
@@ -126,7 +121,6 @@ main section:last-child article,
 }
 
 h1 {
-  font-size: 1.7em;
   margin: 0 0 0.3em;
   line-height: 1.3;
   font-size: 900;


### PR DESCRIPTION
Disable `no-duplicate-selectors` and fix everything else.

(`no-descending-specificity` was disabled during initial implementation in #2239)

Now we can make `composer lint` part of pre-commit rituals

