### PR TITLE
move constants together

### DIFF
--- a/tests/Handlers/AccountTest.php
+++ b/tests/Handlers/AccountTest.php
@@ -36,6 +36,7 @@ define('VER_ACCOUNT_CSS', "account.css");
 define('VER_JS_ACCOUNT', "account.js");
 define('VER_JS_ESTIMATE_TAXES', "estimate-taxes.js");
 define('FRIENDLY_URLS', true);
+define('EMBED', false);
 
 final class AccountTest extends TestCase
 {

--- a/www/breakdown.inc
+++ b/www/breakdown.inc
@@ -6,8 +6,6 @@
 require_once('object_detail.inc');
 require_once('contentColors.inc');
 
-define('BREAKDOWN_CACHE_VERSION', 4);
-
 /**
 * Aggregate the individual requests by mime type
 *

--- a/www/common.inc
+++ b/www/common.inc
@@ -57,6 +57,15 @@ require_once(__DIR__ . '/common_lib.inc');
 require_once(__DIR__ . '/plugins.php.inc');
 require_once(__DIR__ . '/util.inc');
 
+// constants that require common_lib nand cannot be in constants.inc
+if (GetSetting('friendly_urls') || (array_key_exists('HTTP_MOD_REWRITE', $_SERVER) && $_SERVER['HTTP_MOD_REWRITE'] == 'On')) {
+    define('FRIENDLY_URLS', true);
+    define('VER_TIMELINE', '28/');       // version of the timeline javascript
+} else {
+    define('FRIENDLY_URLS', false);
+    define('VER_TIMELINE', '');       // Leave the timeline version empty
+}
+
 // Create global request context for future use
 $request_context = new RequestContext($_REQUEST, $_SERVER);
 
@@ -167,14 +176,6 @@ if (isset($_SERVER["HTTP_FASTLY_CLIENT_IP"])) {
     $_SERVER["REMOTE_ADDR"] = $_SERVER["HTTP_FASTLY_CLIENT_IP"];
 }
 
-if (GetSetting('friendly_urls') || (array_key_exists('HTTP_MOD_REWRITE', $_SERVER) && $_SERVER['HTTP_MOD_REWRITE'] == 'On')) {
-    define('FRIENDLY_URLS', true);
-    define('VER_TIMELINE', '28/');       // version of the timeline javascript
-} else {
-    define('FRIENDLY_URLS', false);
-    define('VER_TIMELINE', '');       // Leave the timeline version empty
-}
-
 $privateInstall = true;
 if (
     array_key_exists('HTTP_HOST', $_SERVER) &&
@@ -212,9 +213,7 @@ if (!is_dir($tempDir)) {
 }
 $tempDir = realpath($tempDir) . '/';
 
-if (isset($_REQUEST['embed'])) {
-    define('EMBED', true);
-} elseif (isset($_REQUEST['bare'])) {
+if (!EMBED && isset($_REQUEST['bare'])) {
     $noanalytics = true;
 }
 $is_ssl = isSslConnection();

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -10,8 +10,6 @@ require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/archive.inc');
 require_once(__DIR__ . '/util.inc');
 
-define('VIDEO_CODE_VERSION', 20);
-
 require_once(__DIR__ . '/logging.inc');
 use WebPageTest\Util;
 use WebPageTest\Util\Cache;

--- a/www/constants.inc
+++ b/www/constants.inc
@@ -24,3 +24,8 @@ define('VER_JS_ACCOUNT', @md5_file(ASSETS_PATH . '/js/account.js'));          //
 define('VER_JS_ESTIMATE_TAXES', @md5_file(ASSETS_PATH . '/js/estimate-taxes.js'));
 define('VER_JS_COUNTRY_LIST', @md5_file(ASSETS_PATH . '/js/country-list/country-list.js'));
 define('UNKNOWN_TIME', -1);           // Value used as a flag for an unknown time.
+
+define('BREAKDOWN_CACHE_VERSION', 4);
+define('VIDEO_CODE_VERSION', 20);
+
+define('EMBED', isset($_REQUEST['embed']));

--- a/www/header.inc
+++ b/www/header.inc
@@ -19,17 +19,6 @@ if (isset($testPath)) {
     $testInfo = TestInfo::fromFiles($testPath);
     $testResults = TestResults::fromFiles($testInfo);
 }
-if (isset($testResults)) {
-    $adultKeywords = array();
-    if (is_file('./settings/adult.txt')) {
-        $adultKeywords = file('./settings/adult.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-    }
-    $isAdult = $testResults->isAdultSite($adultKeywords);
-    if ($isAdult) {
-        define('ADULT_SITE', true);
-        $adult_site = true;
-    }
-}
 
 // For users that aren't logged in, include details about the test so it can be stored in indexdb for local history support
 if (
@@ -55,7 +44,7 @@ if (!isset($experiment)) {
     $experiment = false;
 }
 
-if (!defined('EMBED')) {
+if (!EMBED) {
     ?>
     <?php
     $alert = Util::getSetting('alert');
@@ -80,7 +69,7 @@ if (!defined('EMBED')) {
 
 <?php
 //If we're looking at a test result, include the extra header section and sub-menu
-if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader) && !defined('EMBED')) {
+if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader) && !EMBED) {
     // make sure the test is actually complete and the second check can be applied to non-compare pages
     if (isset($test['test']['completeTime']) || (!isset($tests) && file_exists("$testPath/test.complete") )) {
         if (!isset($testResults) || !isset($testInfo)) {

--- a/www/resultBatch.inc
+++ b/www/resultBatch.inc
@@ -14,7 +14,6 @@ $csv = false;
 $json = false;
 if (array_key_exists('f', $_REQUEST)) {
     if ($_REQUEST['f'] == 'csv') {
-        //define('RESTORE_DATA_ONLY', true);
         $csv = true;
         $json_response = array();
     } elseif ($_REQUEST['f'] == 'json') {

--- a/www/templates/layouts/header.inc
+++ b/www/templates/layouts/header.inc
@@ -20,17 +20,6 @@ if (isset($testPath)) {
     $testInfo = TestInfo::fromFiles($testPath);
     $testResults = TestResults::fromFiles($testInfo);
 }
-if (isset($testResults)) {
-    $adultKeywords = array();
-    if (is_file('../../settings/adult.txt')) {
-        $adultKeywords = file('../../settings/adult.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-    }
-    $isAdult = $testResults->isAdultSite($adultKeywords);
-    if ($isAdult) {
-        define('ADULT_SITE', true);
-        $adult_site = true;
-    }
-}
 
 // For users that aren't logged in, include details about the test so it can be stored in indexdb for local history support
 if (
@@ -55,7 +44,7 @@ if (
 // If $tab is null, make it an empty string for strcasecmp
 $tab ??= "";
 
-if (defined('EMBED')) {
+if (EMBED) {
   // You don't need a header
     return;
 }

--- a/www/templates/layouts/includes/wpt-header.php
+++ b/www/templates/layouts/includes/wpt-header.php
@@ -93,7 +93,7 @@ if ($id) {
                         </details>
                     </li>
 
-                    <?php if ($supportsAuth && !defined('EMBED')) : ?>
+                    <?php if ($supportsAuth && !EMBED) : ?>
                         <?= addTab('Pricing', '/signup'); ?>
                     <?php endif; ?>
 
@@ -138,7 +138,7 @@ if ($id) {
 
                     <?php
 
-                    if ($supportsAuth && !defined('EMBED')) {
+                    if ($supportsAuth && !EMBED) {
                         if ($supportsCPAuth) {
                             $is_logged_in = isset($request_context) && !is_null($request_context->getUser()) && !is_null($request_context->getUser()->getAccessToken());
                             ?>

--- a/www/templates/layouts/main_hed.inc
+++ b/www/templates/layouts/main_hed.inc
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../../include/TestResults.php';
 require_once __DIR__ . '/../../include/TestRunResults.php';
 
 //If we're looking at a test result, include the extra header section and sub-menu
-if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader) && !defined('EMBED')) {
+if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader) && !EMBED) {
     // make sure the test is actually complete
     if (isset($test['test']['completeTime'])) {
         if (!isset($testResults) || !isset($testInfo)) {

--- a/www/video/compare.php
+++ b/www/video/compare.php
@@ -379,7 +379,7 @@ if (!isset($_REQUEST['tests']) && isset($_REQUEST['t'])) {
                     background: #296ee1;
                 }
                 <?php
-                if (defined('EMBED')) {
+                if (EMBED) {
                     ?>
                 #location {display: none;}
                 #bottom {display: none;}
@@ -679,11 +679,6 @@ function ScreenShotTable()
                 $end = $test['video']['end'];
             }
         }
-
-        // if (!defined('EMBED')) {
-        //     echo '<br>';
-        // }
-
         echo '<table id="videoContainer"><tr>';
 
 
@@ -709,7 +704,7 @@ function ScreenShotTable()
             // Print the index outside of the link tag
             echo $test['index'] . ': ';
 
-            if (!defined('EMBED')) {
+            if (!EMBED) {
                 echo " <span id=\"label_{$test['id']}\">" . WrapableString(htmlspecialchars($test['name'])) . "</span>";
             } else {
                 echo WrapableString(htmlspecialchars($test['name']));
@@ -722,7 +717,7 @@ function ScreenShotTable()
             }
             echo '</a>';
 
-            if (!defined('EMBED')) {
+            if (EMBED) {
                 $urlGenerator = UrlGenerator::create(FRIENDLY_URLS, "", $test['id'], $test['run'], $test['cached'], $test['step']);
                 $href = $urlGenerator->resultPage("details") . "#waterfall_view_step" . $test['step'];
                 echo "<a class=\"video_runlabel_backlink\" href=\"$href\">Test Run Details</a>";
@@ -1018,7 +1013,7 @@ function ScreenShotTable()
 
         <div class="compare_contain_wrap">
 
-        <?php if (!defined('EMBED')) {
+        <?php if (!EMBED) {
             // display the waterfall if there is only one test
             $end_seconds = $filmstrip_end_time / 1000;
             if (count($tests) == 1) {

--- a/www/video/filmstrip_settings.php
+++ b/www/video/filmstrip_settings.php
@@ -39,14 +39,14 @@ if (isset($lcp)) {
 
 echo ' <details class="box details_panel">
             <summary class="details_panel_hed"><span><i class="icon_plus"></i> <span>Adjust Filmstrip Settings</span></span></summary>
-             
+
             <div class="details_panel_content">';
 
 
         // START TIMELINE OPTIONS
-if (!defined('EMBED')) {
+if (!EMBED) {
     ?>
-       
+
             <form name="layout" method="get" action="/video/compare.php">
             <?php
             echo "<input type=\"hidden\" name=\"tests\" value=\"" . htmlspecialchars($_REQUEST['tests']) . "\">\n";
@@ -193,7 +193,7 @@ if (!defined('EMBED')) {
                     echo '<div class="compare_video_form"><label for="slow"><input type="checkbox" id="slow" name="slow" value="1"> Slow Motion</label>';
                     echo "<input id=\"SubmitBtn\" type=\"submit\" value=\"View Video\"></div>";
                     echo "</form>"; ?>
-       
+
 
         <div id="advanced" style="display:none;">
             <h3>Advanced Visual Comparison Configuration</h3>
@@ -211,7 +211,7 @@ if (!defined('EMBED')) {
             </tbody>
             </table>
             </div>
-            
+
             <p>You can also customize the background and text color by passing HTML color values to <b>bg</b> and <b>text</b> query parameters.</p>
             <p>Examples:</p>
             <ul>
@@ -232,4 +232,3 @@ if (!defined('EMBED')) {
 
 
     echo '</div></details>'; ?>
-                    


### PR DESCRIPTION
The idea is to have a single place to look for all constants

* Found a couple (`BREAKDOWN_CACHE_VERSION` and `VIDEO_CODE_VERSION`) sprinkled in the codebase and moved them to the new `constants.inc`
* Deleted code around `ADULT_SITE` which is not referred to anywhere
* Moved `EMBED` to `constants.inc` and tweaked references because it's now always defined.
* Two constants `FRIENDLY_URLS` and `VER_TIMELINE` require `GetSetting()` from `common_lib.inc` so cannot be in `constants.inc`. Moved them closer to where constants.inc is required.

Tested by browsing the site with and without `?embed`, e.g.
https://www.webpagetest.org/video/compare.php?tests=220926_BiDcVY_E4Z-r:1-c:0-e:filmstrip&embed
vs
https://www.webpagetest.org/video/compare.php?tests=220926_BiDcVY_E4Z-r:1-c:0-e:filmstrip