### PR TITLE
fix(account): remove option to upgrade plan

### DIFF
--- a/www/templates/account/includes/subscription-plan.php
+++ b/www/templates/account/includes/subscription-plan.php
@@ -19,10 +19,9 @@
                     <label class="dropdown">
                         <input type="checkbox" class="dd-input" id="test">
                         <div class="dd-button">
-                            Update Subscription
+                            Cancel Subscription
                         </div>
                         <ul class="dd-menu">
-                            <li><a href="/account/update_plan">Update Subscription</a></li>
                             <li><a href="#" id="cancel-subscription">Cancel Subscription</a> </li>
                         </ul>
                     </label>


### PR DESCRIPTION
This is hopefully temporary. The data we need in order to upgrade a plan is unavailable. Right now, it's required that a user has an invoice in order to do so. This doesn't work for anybody who signed up pre-Chargify.