### PR TITLE
Remove + from mailto: sharing

### DIFF
--- a/www/include/social_meta.php
+++ b/www/include/social_meta.php
@@ -14,7 +14,7 @@
     $socialDesc = isset($socialDesc) ? $socialDesc : "View this on WebPageTest.org...";
     $emailSubject = "View this on WebPageTest!";
     $tweetURI =  'https://twitter.com/intent/tweet?text=' . urlencode($socialDesc) . '&url=' . urlencode($pageURI) . '&via=realwebpagetest';
-    $emailURI = 'mailto:?subject=' . urlencode($emailSubject) . '&body=' . urlencode($socialDesc) . '  %0D%0A ' . urlencode($pageURI);
+    $emailURI = 'mailto:?subject=' . rawurlencode(htmlspecialchars_decode($emailSubject)) . '&body=' . rawurlencode(htmlspecialchars_decode($socialDesc)) . '  %0D%0A ' . urlencode($pageURI);
 ?>
 
 <meta property="og:title" content="<?php echo $socialTitle; ?>">


### PR DESCRIPTION
Before:

<img width="577" alt="Screen Shot 2022-10-06 at 1 42 34 PM" src="https://user-images.githubusercontent.com/51308/194384686-b5d3d8ed-9e9c-404e-85a0-ad40531ef4d9.png">

After:

<img width="588" alt="Screen Shot 2022-10-06 at 1 42 59 PM" src="https://user-images.githubusercontent.com/51308/194384694-fa647b44-b3e6-4f3a-ae42-cca492ebb3dc.png">

Also tested by adding quotes to subject/body strings to make sure nothing is broken should we decide to add quotes in the future.
