### PR TITLE
Add cert error to the list of params that allows some special chars

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -3382,7 +3382,7 @@ function ValidateCommandLine($cmd, &$error)
         $flags = explode(' ', $cmd);
         if ($flags && is_array($flags) && count($flags)) {
             foreach ($flags as $flag) {
-                if (strlen($flag) && !preg_match('/^--(([a-zA-Z0-9\-\.\+=,_< "]+)|((data-reduction-proxy-http-proxies|data-reduction-proxy-config-url|proxy-server|proxy-pac-url|force-fieldtrials|force-fieldtrial-params|trusted-spdy-proxy|origin-to-force-quic-on|oauth2-refresh-token|unsafely-treat-insecure-origin-as-secure|user-data-dir)=[a-zA-Z0-9\-\.\+=,_:\/"%]+))$/', $flag)) {
+                if (strlen($flag) && !preg_match('/^--(([a-zA-Z0-9\-\.\+=,_< "]+)|((data-reduction-proxy-http-proxies|data-reduction-proxy-config-url|proxy-server|proxy-pac-url|force-fieldtrials|force-fieldtrial-params|trusted-spdy-proxy|origin-to-force-quic-on|oauth2-refresh-token|unsafely-treat-insecure-origin-as-secure|user-data-dir|ignore-certificate-errors-spki-list)=[a-zA-Z0-9\-\.\+=,_:\/"%]+))$/', $flag)) {
                     $error = 'Invalid command-line option: "' . htmlspecialchars($flag) . '"';
                 }
             }


### PR DESCRIPTION
This adds `ignore-certificate-errors-spki-list` to the list of known params that need to be able to include slashes (safely) in their value.

i.e.

```
--ignore-certificate-errors-spki-list=BSQJ0jkQ7wwhR7KvPZ+DSNK2XTZ/MS6xCbo9qu++VdQ=
```

At some point we should probably make this not use a giant regex so it is easier to read but I'll save that for another day.

See Robin's tweet [here](https://twitter.com/programmingart/status/1578299210381766656).