### PR TITLE
Fix __DIR__ use (in 30 out of 120-ish files)

### DIFF
--- a/tests/Handlers/AccountTest.php
+++ b/tests/Handlers/AccountTest.php
@@ -26,17 +26,9 @@ function setcookie($name, $value, $expiration, $path, $domain)
 function error_log($str)
 {
 }
-define('VER_TYPOGRAPHY_CSS', "foo.css");
-define('VER_LAYOUT_CSS', "layout.css");
-define('VER_CSS', "site.css");
-define('VER_HEADER_CSS', "header.css");
-define('VER_JS', "site.js");
-define('VER_BUTTON_CSS', "button.css");
-define('VER_ACCOUNT_CSS', "account.css");
-define('VER_JS_ACCOUNT', "account.js");
-define('VER_JS_ESTIMATE_TAXES', "estimate-taxes.js");
+
 define('FRIENDLY_URLS', true);
-define('EMBED', false);
+
 
 final class AccountTest extends TestCase
 {

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -10,15 +10,15 @@ final class TemplateTest extends TestCase
     public function testConstructorSetsDefaults(): void
     {
         $dir = realpath(WWW_PATH . '/templates');
-        $layout = realpath(__DIR__ . '/../www/templates/layouts/default.php');
+        $layout = realpath(WWW_PATH . '/templates/layouts/default.php');
         $tpl = new Template();
         $this->assertEquals($dir, $tpl->getDir());
         $this->assertEquals($layout, $tpl->getLayout());
     }
     public function testConstructorSetsValues(): void
     {
-        $dir = realpath(__DIR__ . '/../www/templates/errors');
-        $layout = realpath(__DIR__ . '/../www/templates/layouts/default.php');
+        $dir = realpath(WWW_PATH . '/templates/errors');
+        $layout = realpath(WWW_PATH . '/templates/layouts/default.php');
         $tpl = new Template('errors');
         $this->assertEquals($dir, $tpl->getDir());
         $this->assertEquals($layout, $tpl->getLayout());
@@ -27,13 +27,13 @@ final class TemplateTest extends TestCase
     {
         $tpl = new Template();
         $tpl->setLayout('../../../tests/fixtures/layout-1');
-        $layout = realpath(__DIR__ . '/fixtures/layout-1.php');
+        $layout = realpath(TESTS_PATH . '/fixtures/layout-1.php');
         $this->assertEquals($tpl->getLayout(), $layout);
     }
 
     public function testRenderReturnsRenderedString(): void
     {
-        $dir = realpath(__DIR__ . '/fixtures');
+        $dir = realpath(TESTS_PATH . '/fixtures');
         $tpl = new Template('../../tests/fixtures');
         $tpl->setLayout('../../../tests/fixtures/layout-1');
         $this->assertEquals($dir, $tpl->getDir());

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -18,14 +18,14 @@ final class UtilTest extends TestCase
 
     public function testGetSetting(): void
     {
-        $override_settings_file = __DIR__ . '/fixtures/settings.ini';
+        $override_settings_file = TESTS_PATH . '/fixtures/settings.ini';
         $value = Util::getSetting('product', false, $override_settings_file);
         $this->assertEquals('WebPagetest', $value);
     }
 
     public function testGetSettingWithNullDefault(): void
     {
-        $override_settings_file = __DIR__ . '/fixtures/settings.ini';
+        $override_settings_file = TESTS_PATH . '/fixtures/settings.ini';
         $value = Util::getSetting('product', null, $override_settings_file);
         $this->assertEquals('WebPagetest', $value);
     }

--- a/tests/WaterfallIncTest.php
+++ b/tests/WaterfallIncTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/..' . '/www/waterfall.inc';
+require_once INCLUDES_PATH . '/waterfall.inc';
 
 use PHPUnit\Framework\TestCase;
 

--- a/www/addresses.php
+++ b/www/addresses.php
@@ -6,12 +6,12 @@
 include 'common.inc';
 
 if (isset($_REQUEST['k'])) {
-    $keys_file = __DIR__ . '/settings/keys.ini';
-    if (file_exists(__DIR__ . '/settings/common/keys.ini')) {
-        $keys_file = __DIR__ . '/settings/common/keys.ini';
+    $keys_file = SETTINGS_PATH . '/keys.ini';
+    if (file_exists(SETTINGS_PATH . '/common/keys.ini')) {
+        $keys_file = SETTINGS_PATH . '/common/keys.ini';
     }
-    if (file_exists(__DIR__ . '/settings/server/keys.ini')) {
-        $keys_file = __DIR__ . '/settings/server/keys.ini';
+    if (file_exists(SETTINGS_PATH . '/server/keys.ini')) {
+        $keys_file = SETTINGS_PATH . '/server/keys.ini';
     }
     $keys = parse_ini_file($keys_file, true);
     if (isset($keys['server']['key']) && $_REQUEST['k'] == $keys['server']['key']) {

--- a/www/aggregate.php
+++ b/www/aggregate.php
@@ -5,8 +5,9 @@
 // found in the LICENSE.md file.
 
 include 'common.inc';
-require_once('page_data.inc');
-require_once('testStatus.inc');
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/testStatus.inc';
+
 set_time_limit(3600);
 
 $use_median_run = false;

--- a/www/archive.inc
+++ b/www/archive.inc
@@ -3,9 +3,9 @@
 // Copyright 2020 Catchpoint Systems Inc.
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
-require_once(__DIR__ . '/testStatus.inc');
-require_once(__DIR__ . '/logging.inc');
-require_once(__DIR__ . '/common_lib.inc');
+require_once INCLUDES_PATH . '/testStatus.inc';
+require_once INCLUDES_PATH . '/logging.inc';
+require_once INCLUDES_PATH . '/common_lib.inc';
 /**
 * See if the file should be skipped when archiving (usually just cache files)
 *

--- a/www/breakdown.php
+++ b/www/breakdown.php
@@ -4,15 +4,15 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 include __DIR__ . '/common.inc';
-require_once __DIR__ . '/breakdown.inc';
-require_once __DIR__ . '/contentColors.inc';
-require_once __DIR__ . '/waterfall.inc';
-require_once __DIR__ . '/page_data.inc';
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestPaths.php';
-require_once __DIR__ . '/include/TestRunResults.php';
-require_once __DIR__ . '/include/MimetypeBreakdownHtmlSnippet.php';
-require_once __DIR__ . '/include/AccordionHtmlHelper.php';
+require_once INCLUDES_PATH . '/breakdown.inc';
+require_once INCLUDES_PATH . '/contentColors.inc';
+require_once INCLUDES_PATH . '/waterfall.inc';
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestPaths.php';
+require_once INCLUDES_PATH . '/include/TestRunResults.php';
+require_once INCLUDES_PATH . '/include/MimetypeBreakdownHtmlSnippet.php';
+require_once INCLUDES_PATH . '/include/AccordionHtmlHelper.php';
 
 $page_keywords = array('Content Breakdown','MIME Types','WebPageTest','Website Speed Test','Page Speed');
 $page_description = "Website content breakdown by MIME type$testLabel";

--- a/www/checkIPs.php
+++ b/www/checkIPs.php
@@ -43,12 +43,12 @@ $users = array();
 $keys = array();
 
 // load the API keys
-$keys_file = __DIR__ . '/settings/keys.ini';
-if (file_exists(__DIR__ . '/settings/common/keys.ini')) {
-    $keys_file = __DIR__ . '/settings/common/keys.ini';
+$keys_file = SETTINGS_PATH . '/keys.ini';
+if (file_exists(SETTINGS_PATH . '/common/keys.ini')) {
+    $keys_file = SETTINGS_PATH . '/common/keys.ini';
 }
-if (file_exists(__DIR__ . '/settings/server/keys.ini')) {
-    $keys_file = __DIR__ . '/settings/server/keys.ini';
+if (file_exists(SETTINGS_PATH . '/server/keys.ini')) {
+    $keys_file = SETTINGS_PATH . '/server/keys.ini';
 }
 $keys = parse_ini_file($keys_file, true);
 

--- a/www/common.inc
+++ b/www/common.inc
@@ -5,7 +5,7 @@
 // found in the LICENSE.md file.
 
 // Load app and composer-based dependencies
-require_once(__DIR__ . '/../vendor/autoload.php');
+require_once __DIR__ . '/../vendor/autoload.php';
 
 use WebPageTest\Util;
 use WebPageTest\User;
@@ -52,11 +52,11 @@ if (Util::getSetting('cp_auth')) {
 }
 
 // Load local deps
-require_once(__DIR__ . '/common_lib.inc');
-require_once(__DIR__ . '/plugins.php.inc');
-require_once(__DIR__ . '/util.inc');
+require_once INCLUDES_PATH . '/common_lib.inc';
+require_once INCLUDES_PATH . '/plugins.php.inc';
+require_once INCLUDES_PATH . '/util.inc';
 
-// constants that require common_lib nand cannot be in constants.inc
+// constants that require common_lib and cannot be in constants.inc
 if (GetSetting('friendly_urls') || (array_key_exists('HTTP_MOD_REWRITE', $_SERVER) && $_SERVER['HTTP_MOD_REWRITE'] == 'On')) {
     define('FRIENDLY_URLS', true);
     define('VER_TIMELINE', '28/');       // version of the timeline javascript
@@ -120,7 +120,7 @@ extract($_POST, EXTR_SKIP | EXTR_PREFIX_ALL | EXTR_REFS, 'req');
 extract($_GET, EXTR_SKIP | EXTR_PREFIX_ALL | EXTR_REFS, 'req');
 
 // load dev settings
-$dev_settings = __DIR__ . '/dev.php';
+$dev_settings = WWW_PATH . '/dev.php';
 if (file_exists($dev_settings)) {
     require_once $dev_settings;
 }
@@ -322,11 +322,11 @@ if ($supportsSaml && !$supportsCPAuth) {
  * Load app specific middleware
  */
 if ($supportsCPAuth) {
-    require_once __DIR__ . '/common/AttachClient.php';
-    require_once __DIR__ . '/common/AttachUser.php';
-    require_once __DIR__ . '/common/AttachSignupClient.php';
-    require_once __DIR__ . '/common/AttachBannerMessageManager.php';
-    require_once __DIR__ . '/common/CheckCSRF.php';
+    require_once INCLUDES_PATH . '/common/AttachClient.php';
+    require_once INCLUDES_PATH . '/common/AttachUser.php';
+    require_once INCLUDES_PATH . '/common/AttachSignupClient.php';
+    require_once INCLUDES_PATH . '/common/AttachBannerMessageManager.php';
+    require_once INCLUDES_PATH . '/common/CheckCSRF.php';
 }
 
 // Load the test-specific data
@@ -457,7 +457,7 @@ if (strlen($id)) {
             if ($metaInfo['experiment'] && $metaInfo['experiment']['control'] === false) {
                 $experiment = true;
 
-                require_once __DIR__ . '/include/UrlGenerator.php';
+                require_once INCLUDES_PATH . '/include/UrlGenerator.php';
 
                 $experimentOriginalTestUrlGenerator = UrlGenerator::create(FRIENDLY_URLS, "", $metaInfo['experiment']['source_id'], 0, 0);
                 $experimentOriginalTestHref = $experimentOriginalTestUrlGenerator->resultSummary();
@@ -495,8 +495,8 @@ if (array_key_exists('medianMetric', $_REQUEST)) {
     $median_metric = htmlspecialchars($_REQUEST['medianMetric']);
 }
 
-if (is_file('./settings/custom_common.inc.php')) {
-    include('./settings/custom_common.inc.php');
+if (is_file(SETTINGS_PATH . '/custom_common.inc.php')) {
+    include(SETTINGS_PATH . '/custom_common.inc.php');
 }
 
-require_once __DIR__ . '/experiments/user_access.inc';
+require_once INCLUDES_PATH . '/experiments/user_access.inc';

--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -6,11 +6,10 @@
 
 // Load app and composer-based dependencies
 require_once(__DIR__ . '/../vendor/autoload.php');
+require_once INCLUDES_PATH . '/archive.inc';
+require_once INCLUDES_PATH . '/util.inc';
+require_once INCLUDES_PATH . '/logging.inc';
 
-require_once(__DIR__ . '/archive.inc');
-require_once(__DIR__ . '/util.inc');
-
-require_once(__DIR__ . '/logging.inc');
 use WebPageTest\Util;
 use WebPageTest\Util\Cache;
 
@@ -137,16 +136,16 @@ function GetLocationFallbacks($location)
 function LoadLocationsIni()
 {
     $ec2_allow = GetSetting('ec2_allow');
-    $locations_file = __DIR__ . '/settings/locations.ini';
-    if (file_exists(__DIR__ . '/settings/common/locations.ini')) {
-        $locations_file = __DIR__ . '/settings/common/locations.ini';
+    $locations_file = SETTINGS_PATH . '/locations.ini';
+    if (file_exists(SETTINGS_PATH . '/common/locations.ini')) {
+        $locations_file = SETTINGS_PATH . '/common/locations.ini';
     }
-    if (file_exists(__DIR__ . '/settings/server/locations.ini')) {
-        $locations_file = __DIR__ . '/settings/server/locations.ini';
+    if (file_exists(SETTINGS_PATH . '/server/locations.ini')) {
+        $locations_file = SETTINGS_PATH . '/server/locations.ini';
     }
     $locations = parse_ini_file($locations_file, true);
     if (GetSetting('ec2_locations')) {
-        $ec2 = parse_ini_file(__DIR__ . '/settings/ec2_locations.ini', true);
+        $ec2 = parse_ini_file(SETTINGS_PATH . '/ec2_locations.ini', true);
         if ($ec2 && is_array($ec2) && isset($ec2['locations'])) {
             if ($locations && is_array($locations) && isset($locations['locations'])) {
                 // Merge the top-level locations
@@ -598,8 +597,8 @@ function LoadMobileDevices()
     if (isset($MOBILE_DEVICES)) {
         return $MOBILE_DEVICES;
     }
-    if (is_file(__DIR__ . '/settings/mobile_devices.ini')) {
-        $MOBILE_DEVICES = parse_ini_file(__DIR__ . '/settings/mobile_devices.ini', true);
+    if (is_file(SETTINGS_PATH . '/mobile_devices.ini')) {
+        $MOBILE_DEVICES = parse_ini_file(SETTINGS_PATH . '/mobile_devices.ini', true);
         return $MOBILE_DEVICES;
     }
 }
@@ -1564,7 +1563,7 @@ function GetDailyTestNum()
         $lock = Lock("TestNum");
         if ($lock) {
             if (!$num) {
-                $filename = __DIR__ . '/dat/testnum.dat';
+                $filename = WWW_PATH . '/dat/testnum.dat';
                 $testData = array('day' => $day, 'num' => 0);
                 $newData = json_decode(file_get_contents($filename), true);
                 if (
@@ -2234,7 +2233,7 @@ function GetTesters($locationId, $includeOffline = false, $include_sensitive = t
     }
 
     $location = array();
-    $dir = __DIR__ . "/tmp/testers-$locationId";
+    $dir = TEMP_DIR . "/testers-$locationId";
     if (is_dir($dir)) {
         $now = time();
         $elapsed_time = null;
@@ -2361,7 +2360,7 @@ function GetTesters($locationId, $includeOffline = false, $include_sensitive = t
 */
 function UpdateTester($location, $tester, $testerInfo = null, $cpu = null, $error = null, $rebooted = null)
 {
-    $dir = __DIR__ . "/tmp/testers-$location";
+    $dir = TEMP_DIR . "/testers-$location";
     $tester_file = $dir . '/' . sha1($tester) . '.json';
     if (!is_dir($dir)) {
         mkdir($dir, 0777, true);
@@ -2458,7 +2457,7 @@ function Lock($name, $blocking = true, $maxLockSeconds = 300)
 {
     global $RemainingLocks;
     $lock = null;
-    $tmpdir =  __DIR__ . '/tmp';
+    $tmpdir =  TEMP_DIR;
     if (strlen($name)) {
         if (!is_dir($tmpdir)) {
             mkdir($tmpdir, 0777, true);
@@ -3761,12 +3760,12 @@ function GetServerKey()
         $key = null;
     }
     if (!isset($key)) {
-        $keys_file = __DIR__ . '/settings/keys.ini';
-        if (file_exists(__DIR__ . '/settings/common/keys.ini')) {
-            $keys_file = __DIR__ . '/settings/common/keys.ini';
+        $keys_file = SETTINGS_PATH . '/keys.ini';
+        if (file_exists(SETTINGS_PATH . '/common/keys.ini')) {
+            $keys_file = SETTINGS_PATH . '/common/keys.ini';
         }
-        if (file_exists(__DIR__ . '/settings/server/keys.ini')) {
-            $keys_file = __DIR__ . '/settings/server/keys.ini';
+        if (file_exists(SETTINGS_PATH . '/server/keys.ini')) {
+            $keys_file = SETTINGS_PATH . '/server/keys.ini';
         }
         $keys = parse_ini_file($keys_file, true);
         if (isset($keys) && isset($keys['server']['key'])) {
@@ -3953,14 +3952,14 @@ function GenerateTestID($private = false, $locationShard = null)
     }
     $today = new DateTime("now", new DateTimeZone('UTC'));
     $testId = $today->format('ymd_') . $id;
-    $path = __DIR__ . '/' . GetTestPath($testId);
+    $path = WWW_PATH . '/' . GetTestPath($testId);
 
   // make absolutely CERTAIN that this test ID doesn't already exist
     while (is_dir($path)) {
         // fall back to random ID's
         $id = ShardKey($test_num, $locationShard) . md5(uniqid(rand(), true));
         $testId = $today->format('ymd_') . $id;
-        $path = __DIR__ . '/' . GetTestPath($testId);
+        $path = WWW_PATH . '/' . GetTestPath($testId);
     }
 
     return $testId;
@@ -3985,7 +3984,7 @@ function AddIniLine(&$ini, $key, $value)
 function ProcessUploadedTest($id)
 {
     if (ValidateTestId($id)) {
-        $testPath = __DIR__ . '/' . GetTestPath($id);
+        $testPath = WWW_PATH . '/' . GetTestPath($id);
         if (gz_is_file("$testPath/job.json")) {
             $job = json_decode(gz_file_get_contents("$testPath/job.json"), true);
             $test = $job;

--- a/www/compare_screens.php
+++ b/www/compare_screens.php
@@ -7,7 +7,7 @@ if (array_key_exists("HTTP_IF_MODIFIED_SINCE", $_SERVER) && strlen(trim($_SERVER
     header("HTTP/1.0 304 Not Modified");
 } else {
     include 'common.inc';
-    $labelFont = __DIR__ . '/video/font/sourcesanspro-semibold.ttf';
+    $labelFont = WWW_PATH . '/video/font/sourcesanspro-semibold.ttf';
     $tests = ParseTests();
     if ($tests) {
         $width = 0;

--- a/www/consolelog.php
+++ b/www/consolelog.php
@@ -1,4 +1,5 @@
 <?php
+include 'common.inc';
 
 // this output buffer hack avoids a bit of circularity
 // on one hand we want the contents of header.inc
@@ -7,7 +8,7 @@ ob_start();
 define('NOBANNER', true); // otherwise Twitch banner shows 2x
 $tab = 'Test Result';
 $subtab = 'Console Log';
-include_once 'header.inc';
+include_once INCLUDES_PATH . '/header.inc';
 $results_header = ob_get_contents();
 ob_end_clean();
 
@@ -17,7 +18,7 @@ $testInfo = TestInfo::fromFiles($testPath);
 $testRunResults = TestRunResults::fromFiles($testInfo, $run, $cached, $fileHandler);
 
 // template
-require_once __DIR__ . '/resources/view.php';
+require_once WWW_PATH . '/resources/view.php';
 echo view('pages.consolelog', [
     'test_results_view' => true,
     'body_class' => 'result',

--- a/www/consolelog.php
+++ b/www/consolelog.php
@@ -1,5 +1,5 @@
 <?php
-include 'common.inc';
+require_once __DIR__ . '/common.inc';
 
 // this output buffer hack avoids a bit of circularity
 // on one hand we want the contents of header.inc

--- a/www/constants.inc
+++ b/www/constants.inc
@@ -7,6 +7,10 @@
 define('APP_ROOT', realpath(__DIR__ . '/../'));
 define('WWW_PATH', realpath(APP_ROOT . '/www/'));
 define('ASSETS_PATH', realpath(WWW_PATH . '/assets/'));
+define('TESTS_PATH', realpath(APP_ROOT . '/tests/'));
+define('INCLUDES_PATH', WWW_PATH); // same as www for now
+define('SETTINGS_PATH', realpath(WWW_PATH . '/settings/'));
+define('TEMP_DIR', realpath(WWW_PATH . '/tmp/'));
 
 define('VER_WEBPAGETEST', '21.07');   // webpagetest version
 define('VER_TYPOGRAPHY_CSS', @md5_file(ASSETS_PATH . '/css/typography.css'));          // version of the typography css file

--- a/www/customWaterfall.php
+++ b/www/customWaterfall.php
@@ -4,14 +4,14 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 include 'common.inc';
-require_once('object_detail.inc');
-require_once('page_data.inc');
-require_once('waterfall.inc');
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestRunResults.php';
-require_once __DIR__ . '/include/RunResultHtmlTable.php';
-require_once __DIR__ . '/include/UserTimingHtmlTable.php';
-require_once __DIR__ . '/include/WaterfallViewHtmlSnippet.php';
+require_once INCLUDES_PATH . '/object_detail.inc';
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/waterfall.inc';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestRunResults.php';
+require_once INCLUDES_PATH . '/include/RunResultHtmlTable.php';
+require_once INCLUDES_PATH . '/include/UserTimingHtmlTable.php';
+require_once INCLUDES_PATH . '/include/WaterfallViewHtmlSnippet.php';
 
 $testInfo = TestInfo::fromFiles($testPath);
 $testRunResults = TestRunResults::fromFiles($testInfo, $run, $cached, null);

--- a/www/details.php
+++ b/www/details.php
@@ -4,23 +4,23 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 include 'common.inc';
-require_once('object_detail.inc');
-require_once('page_data.inc');
-require_once('waterfall.inc');
+require_once INCLUDES_PATH . '/object_detail.inc';
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/waterfall.inc';
 
 // Prevent the details page from running out of control.
 set_time_limit(30);
 
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestResults.php';
-require_once __DIR__ . '/include/TestRunResults.php';
-require_once __DIR__ . '/include/RunResultHtmlTable.php';
-require_once __DIR__ . '/include/UserTimingHtmlTable.php';
-require_once __DIR__ . '/include/WaterfallViewHtmlSnippet.php';
-require_once __DIR__ . '/include/ConnectionViewHtmlSnippet.php';
-require_once __DIR__ . '/include/RequestDetailsHtmlSnippet.php';
-require_once __DIR__ . '/include/RequestHeadersHtmlSnippet.php';
-require_once __DIR__ . '/include/AccordionHtmlHelper.php';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestResults.php';
+require_once INCLUDES_PATH . '/include/TestRunResults.php';
+require_once INCLUDES_PATH . '/include/RunResultHtmlTable.php';
+require_once INCLUDES_PATH . '/include/UserTimingHtmlTable.php';
+require_once INCLUDES_PATH . '/include/WaterfallViewHtmlSnippet.php';
+require_once INCLUDES_PATH . '/include/ConnectionViewHtmlSnippet.php';
+require_once INCLUDES_PATH . '/include/RequestDetailsHtmlSnippet.php';
+require_once INCLUDES_PATH . '/include/RequestHeadersHtmlSnippet.php';
+require_once INCLUDES_PATH . '/include/AccordionHtmlHelper.php';
 
 $testInfo = TestInfo::fromFiles($testPath);
 $testResults = TestResults::fromFiles($testInfo);
@@ -178,7 +178,7 @@ function createForm($formName, $btnText, $id, $owner, $secret)
 
                 if (isset($testRunResults)) {
                     echo '<div class="cruxembed">';
-                    require_once(__DIR__ . '/include/CrUX.php');
+                    require_once(INCLUDES_PATH . '/include/CrUX.php');
                     if ($cached) {
                         InsertCruxHTML(null, $testRunResults);
                     } else {

--- a/www/details_snippet.php
+++ b/www/details_snippet.php
@@ -5,8 +5,8 @@
 // found in the LICENSE.md file.
 
 require 'common.inc';
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestStepResult.php';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestStepResult.php';
 
 
 global $testPath, $run, $cached, $step;  // set in common.inc. This is for IDE to know what exists
@@ -23,47 +23,47 @@ if (!$stepResult->isValid()) {
 
 switch ($requestedSnippet) {
     case "waterfall":
-        require_once __DIR__ . '/include/WaterfallViewHtmlSnippet.php';
+        require_once INCLUDES_PATH . '/include/WaterfallViewHtmlSnippet.php';
 
         $waterfallSnippet = new WaterfallViewHtmlSnippet($testInfo, $stepResult);
         echo $waterfallSnippet->create();
         break;
 
     case "connection":
-        require_once __DIR__ . '/include/ConnectionViewHtmlSnippet.php';
+        require_once INCLUDES_PATH . '/include/ConnectionViewHtmlSnippet.php';
 
         $waterfallSnippet = new ConnectionViewHtmlSnippet($testInfo, $stepResult);
         echo $waterfallSnippet->create();
         break;
 
     case "requestDetails":#
-        require_once __DIR__ . '/include/RequestDetailsHtmlSnippet.php';
+        require_once INCLUDES_PATH . '/include/RequestDetailsHtmlSnippet.php';
 
         $requestDetailsSnippet = new RequestDetailsHtmlSnippet($testInfo, $stepResult, $useLinks);
         echo $requestDetailsSnippet->create();
         break;
 
     case "requestHeaders":
-        require_once __DIR__ . '/include/RequestHeadersHtmlSnippet.php';
+        require_once INCLUDES_PATH . '/include/RequestHeadersHtmlSnippet.php';
 
         $requestHeadersSnippet = new RequestHeadersHtmlSnippet($stepResult, $useLinks);
         echo $requestHeadersSnippet->create();
         break;
 
     case "mimetypeBreakdown":
-        require_once __DIR__ . '/include/MimetypeBreakdownHtmlSnippet.php';
+        require_once INCLUDES_PATH . '/include/MimetypeBreakdownHtmlSnippet.php';
         $snippetRv = new MimetypeBreakdownHtmlSnippet($testInfo, $stepResult);
         echo $snippetRv->create();
         break;
 
     case "domainBreakdown":
-        require_once __DIR__ . '/include/DomainBreakdownHtmlSnippet.php';
+        require_once INCLUDES_PATH . '/include/DomainBreakdownHtmlSnippet.php';
         $snippetRv = new DomainBreakdownHtmlSnippet($testInfo, $stepResult);
         echo $snippetRv->create();
         break;
 
     case "performanceOptimization":
-        require_once __DIR__ . '/include/PerformanceOptimizationHtmlSnippet.php';
+        require_once INCLUDES_PATH . '/include/PerformanceOptimizationHtmlSnippet.php';
         $snippet = new PerformanceOptimizationHtmlSnippet($testInfo, $stepResult);
         echo $snippet->create();
         break;

--- a/www/devtools.inc.php
+++ b/www/devtools.inc.php
@@ -4,7 +4,7 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 $DevToolsCacheVersion = '1.7';
-require_once __DIR__ . '/include/TestPaths.php';
+require_once INCLUDES_PATH . '/include/TestPaths.php';
 
 /**
 * Load the timeline data for the given test run (from a timeline file or a raw dev tools dump)
@@ -1613,7 +1613,7 @@ function GetDevToolsCPUTime($testPath, $run, $cached, $endTime = 0)
 function GetDevToolsCPUTimeForStep($localPaths, $endTime = 0)
 {
     if (!$endTime) {
-        require_once(__DIR__ . '/page_data.inc');
+        require_once(INCLUDES_PATH . '/page_data.inc');
         $pageData =  loadPageStepData($localPaths);
         if (isset($pageData) && is_array($pageData) && isset($pageData['fullyLoaded'])) {
             $endTime = $pageData['fullyLoaded'];

--- a/www/domains.php
+++ b/www/domains.php
@@ -5,11 +5,11 @@
 // found in the LICENSE.md file.
 include 'common.inc';
 
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestPaths.php';
-require_once __DIR__ . '/include/TestRunResults.php';
-require_once __DIR__ . '/include/DomainBreakdownHtmlSnippet.php';
-require_once __DIR__ . '/include/AccordionHtmlHelper.php';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestPaths.php';
+require_once INCLUDES_PATH . '/include/TestRunResults.php';
+require_once INCLUDES_PATH . '/include/DomainBreakdownHtmlSnippet.php';
+require_once INCLUDES_PATH . '/include/AccordionHtmlHelper.php';
 
 $page_keywords = array('Domains','WebPageTest','Website Speed Test');
 $page_description = "Website domain breakdown$testLabel";

--- a/www/draw.inc
+++ b/www/draw.inc
@@ -4,8 +4,8 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 
-$rbIcon = imagecreatefrompng(__DIR__ . '/assets/images/render-block-icon.png');
-$nsIcon = imagecreatefrompng(__DIR__ . '/assets/images/not-secure-icon.png');
+$rbIcon = imagecreatefrompng(WWW_PATH . '/assets/images/render-block-icon.png');
+$nsIcon = imagecreatefrompng(WWW_PATH . '/assets/images/not-secure-icon.png');
 
 /**
 * Draw label next to a request like "10 ms (404)".

--- a/www/experiments.php
+++ b/www/experiments.php
@@ -10,13 +10,13 @@ require_once __DIR__ . '/common.inc';
 
 use WebPageTest\Util;
 
-require_once __DIR__ . '/optimization_detail.inc.php';
-require_once __DIR__ . '/breakdown.inc';
-require_once __DIR__ . '/testStatus.inc';
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestResults.php';
-require_once __DIR__ . '/include/RunResultHtmlTable.php';
-require_once __DIR__ . '/include/TestResultsHtmlTables.php';
+require_once INCLUDES_PATH . '/optimization_detail.inc.php';
+require_once INCLUDES_PATH . '/breakdown.inc';
+require_once INCLUDES_PATH . '/testStatus.inc';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestResults.php';
+require_once INCLUDES_PATH . '/include/RunResultHtmlTable.php';
+require_once INCLUDES_PATH . '/include/TestResultsHtmlTables.php';
 
 // if this is an experiment itself, we don't want to offer opps on it, so we redirect to the source test's opps page.
 if ($experiment && isset($experimentOriginalExperimentsHref)) {
@@ -79,7 +79,7 @@ $page_description = "Website performance test result$testLabel.";
             <?php
             $tab = 'Test Result';
             $subtab = 'Opportunities & Experiments';
-            require_once __DIR__ . '/header.inc';
+            require_once INCLUDES_PATH . '/header.inc';
             ?>
             <div class="results_main_contain">
             <div class="results_main">
@@ -130,12 +130,12 @@ $page_description = "Website performance test result$testLabel.";
                     $requests = $testStepResult->getRequests();
 
 
-                    include __DIR__ . '/experiments/common.inc';
+                    include INCLUDES_PATH . '/experiments/common.inc';
 
-                    include __DIR__ . '/experiments/summary.inc';
+                    include INCLUDES_PATH . '/experiments/summary.inc';
                 if ($experiment) {
                     $moreExperimentsLink = false;
-                    include __DIR__ . '/experiments/meta.inc';
+                    include INCLUDES_PATH . '/experiments/meta.inc';
                 }
                 ?>
 

--- a/www/export.php
+++ b/www/export.php
@@ -18,8 +18,8 @@ if ($userIsBot) {
     exit;
 }
 
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/har/HttpArchiveGenerator.php';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/har/HttpArchiveGenerator.php';
 
 $options = array();
 if (isset($_REQUEST['bodies'])) {

--- a/www/getTesters.php
+++ b/www/getTesters.php
@@ -5,12 +5,12 @@
 // found in the LICENSE.md file.
 include 'common.inc';
 if (isset($_REQUEST['k'])) {
-    $keys_file = __DIR__ . '/settings/keys.ini';
-    if (file_exists(__DIR__ . '/settings/common/keys.ini')) {
-        $keys_file = __DIR__ . '/settings/common/keys.ini';
+    $keys_file = SETTINGS_PATH . '/keys.ini';
+    if (file_exists(SETTINGS_PATH . '/common/keys.ini')) {
+        $keys_file = SETTINGS_PATH . '/common/keys.ini';
     }
-    if (file_exists(__DIR__ . '/settings/server/keys.ini')) {
-        $keys_file = __DIR__ . '/settings/server/keys.ini';
+    if (file_exists(SETTINGS_PATH . '/server/keys.ini')) {
+        $keys_file = SETTINGS_PATH . '/server/keys.ini';
     }
     $keys = parse_ini_file($keys_file, true);
     if (isset($keys['server']['key']) && $_REQUEST['k'] == $keys['server']['key']) {

--- a/www/graph_page_data.inc
+++ b/www/graph_page_data.inc
@@ -3,8 +3,8 @@
 // Copyright 2020 Catchpoint Systems Inc.
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
-require_once(__DIR__ . '/common_lib.inc');
-require_once(__DIR__ . '/page_data.inc');
+require_once INCLUDES_PATH . '/common_lib.inc';
+require_once INCLUDES_PATH . '/page_data.inc';
 
 function GetNumeric($value)
 {

--- a/www/head.inc
+++ b/www/head.inc
@@ -1,7 +1,7 @@
 <?php
 
 if (!isset($noanalytics)) {
-    require_once __DIR__ . '/templates/layouts/google-tag-manager.inc';
+    require_once WWW_PATH . '/templates/layouts/google-tag-manager.inc';
 } ?>
 
 <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
@@ -111,11 +111,11 @@ echo "\n</style>\n";
 // include the analytics code if it is appropriate
 if (!isset($noanalytics)) {
     echo "<script>";
-    require_once __DIR__ . '/assets/js/catchpoint-rum.js';
+    require_once WWW_PATH . '/assets/js/catchpoint-rum.js';
     echo "</script>";
 }
 
 if (isset($test_is_private) && !$test_is_private) {
-    include __DIR__ . '/include/social_meta.php';
+    include INCLUDES_PATH . '/include/social_meta.php';
 }
 ?>

--- a/www/header.inc
+++ b/www/header.inc
@@ -6,13 +6,13 @@
 
 use WebPageTest\Util;
 
-require_once __DIR__ . '/page_data.inc';
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestResults.php';
-require_once __DIR__ . '/include/TestRunResults.php';
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestResults.php';
+require_once INCLUDES_PATH . '/include/TestRunResults.php';
 
 if (!isset($noanalytics)) {
-    require_once __DIR__ . '/templates/layouts/google-tag-manager-noscript.inc';
+    require_once WWW_PATH . '/templates/layouts/google-tag-manager-noscript.inc';
 }
 
 if (isset($testPath)) {
@@ -58,7 +58,7 @@ if (!EMBED) {
         echo '<div class="alert-banner">' . $alert . '</div>';
     }
 
-    require_once __DIR__ . '/templates/layouts/includes/wpt-header.php';
+    require_once WWW_PATH . '/templates/layouts/includes/wpt-header.php';
     ?>
 
     <?php
@@ -90,7 +90,7 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
         $firstRunResults = $testResults->getRunResult(1, false);
 
         echo '<div class="results_header_contain">';
-        require_once(__DIR__ . '/cta-banner.inc');
+        require_once(INCLUDES_PATH . '/cta-banner.inc');
 
         echo '<div id="header_container">';
 
@@ -177,7 +177,7 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
 
         $browser = $testResults->getBrowser();
             //check to make sure we have a browser icon
-        if (isset($browser) && file_exists(__DIR__ . '/assets/images/test_icons/' . strtolower($browser->getName()) . '.svg')) {
+        if (isset($browser) && file_exists(WWW_PATH . '/assets/images/test_icons/' . strtolower($browser->getName()) . '.svg')) {
             //exists so let's use it
             $browserIcon = true;
         } else {
@@ -248,7 +248,7 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
                     $experimentData = $metaInfo['experiment'];
                     echo "<p class=\"meta_exp_applied_hed\">Experiment Info:</p>";
                     echo '<ul class="meta_exp_applied_list">';
-                    include __DIR__ . '/experiments/list_applied.inc';
+                    include INCLUDES_PATH . '/experiments/list_applied.inc';
                     echo '</ul>';
                     echo "<p>Related Links: <a href=\"" . $controlTestHref . "\">Original (Control Run)</a>, <a href=\"" . $experimentOriginalTestHref . "\">Original Test</a></p><ul>";
                 }
@@ -326,7 +326,7 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
             </script>
             <?php
         } else {
-            require_once __DIR__ . '/screen_shot_embed.php';
+            require_once WWW_PATH . '/screen_shot_embed.php';
         }
 
         echo '</div></div></div>';

--- a/www/home.php
+++ b/www/home.php
@@ -41,23 +41,23 @@ if (isset($req_url)) {
     $url = htmlspecialchars($req_url);
 }
 $placeholder = 'Enter a website URL...';
-$profile_file = __DIR__ . '/settings/profiles.ini';
-if (file_exists(__DIR__ . '/settings/common/profiles.ini')) {
-    $profile_file = __DIR__ . '/settings/common/profiles.ini';
+$profile_file = SETTINGS_PATH . '/profiles.ini';
+if (file_exists(SETTINGS_PATH . '/common/profiles.ini')) {
+    $profile_file = SETTINGS_PATH . '/common/profiles.ini';
 }
-if (file_exists(__DIR__ . '/settings/server/profiles.ini')) {
-    $profile_file = __DIR__ . '/settings/server/profiles.ini';
+if (file_exists(SETTINGS_PATH . '/server/profiles.ini')) {
+    $profile_file = SETTINGS_PATH . '/server/profiles.ini';
 }
 $profiles = parse_ini_file($profile_file, true);
-$connectivity_file = './settings/connectivity.ini.sample';
-if (file_exists('./settings/connectivity.ini')) {
-    $connectivity_file = './settings/connectivity.ini';
+$connectivity_file = SETTINGS_PATH . '/connectivity.ini.sample';
+if (file_exists(SETTINGS_PATH . '/connectivity.ini')) {
+    $connectivity_file = SETTINGS_PATH . '/connectivity.ini';
 }
-if (file_exists('./settings/common/connectivity.ini')) {
-    $connectivity_file = './settings/common/connectivity.ini';
+if (file_exists(SETTINGS_PATH . '/common/connectivity.ini')) {
+    $connectivity_file = SETTINGS_PATH . '/common/connectivity.ini';
 }
-if (file_exists('./settings/server/connectivity.ini')) {
-    $connectivity_file = './settings/server/connectivity.ini';
+if (file_exists(SETTINGS_PATH . '/server/connectivity.ini')) {
+    $connectivity_file = SETTINGS_PATH . '/server/connectivity.ini';
 }
 $connectivity = parse_ini_file($connectivity_file, true);
 $mobile_devices = LoadMobileDevices();
@@ -100,7 +100,7 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
     <title>WebPageTest - Website Performance and Optimization Test</title>
     <?php
     $useScreenshot = true;
-    require_once __DIR__ . '/head.inc';
+    require_once INCLUDES_PATH . '/head.inc';
     ?>
 </head>
 
@@ -1027,7 +1027,7 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
             <div class="home_content_contain">
                 <div class="home_content">
                     <?php
-                    include(__DIR__ . '/include/home-subsections.inc');
+                    include(INCLUDES_PATH . '/include/home-subsections.inc');
                     ?>
                 </div>
                 <!--home_content_contain-->

--- a/www/http2_dependencies.php
+++ b/www/http2_dependencies.php
@@ -4,12 +4,12 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 include 'common.inc';
-require_once('object_detail.inc');
-require_once('page_data.inc');
-require_once('draw.inc');
-require_once('contentColors.inc');
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestRunResults.php';
+require_once INCLUDES_PATH . '/object_detail.inc';
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/draw.inc';
+require_once INCLUDES_PATH . '/contentColors.inc';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestRunResults.php';
 
 // not functional; just to declare what to expect from common.inc
 global $testPath, $run, $cached, $step, $id, $url, $test;
@@ -159,7 +159,7 @@ function get_short_path($path)
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-    
+
     <script src="https://www.gstatic.com/charts/loader.js"></script>
     <script>
       google.charts.load('current', {packages:["orgchart"]});

--- a/www/jsonResult.php
+++ b/www/jsonResult.php
@@ -41,16 +41,16 @@ if (
 }
 
 require_once('common.inc');
-require_once('page_data.inc');
-require_once('testStatus.inc');
-require_once('video/visualProgress.inc.php');
-require_once('breakdown.inc');
-require_once('devtools.inc.php');
-require_once('archive.inc');
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/testStatus.inc';
+require_once INCLUDES_PATH . '/video/visualProgress.inc.php';
+require_once INCLUDES_PATH . '/breakdown.inc';
+require_once INCLUDES_PATH . '/devtools.inc.php';
+require_once INCLUDES_PATH . '/archive.inc';
 
-require_once __DIR__ . '/include/JsonResultGenerator.php';
-require_once __DIR__ . '/include/TestInfo.php';
-require_once __DIR__ . '/include/TestResults.php';
+require_once INCLUDES_PATH . '/include/JsonResultGenerator.php';
+require_once INCLUDES_PATH . '/include/TestInfo.php';
+require_once INCLUDES_PATH . '/include/TestResults.php';
 
 if (isset($test['test']['batch']) && $test['test']['batch']) {
     $_REQUEST['f'] = 'json';

--- a/www/object_detail.inc
+++ b/www/object_detail.inc
@@ -3,8 +3,8 @@
 // Copyright 2020 Catchpoint Systems Inc.
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
-require_once __DIR__ . '/devtools.inc.php';
-require_once __DIR__ . '/include/UrlGenerator.php';
+require_once INCLUDES_PATH . '/devtools.inc.php';
+require_once INCLUDES_PATH . '/include/UrlGenerator.php';
 
 /**
 * Load the object data file.

--- a/www/optimization_detail.inc.php
+++ b/www/optimization_detail.inc.php
@@ -3,9 +3,9 @@
 // Copyright 2020 Catchpoint Systems Inc.
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
-require_once __DIR__ . '/page_data.inc';
-require_once __DIR__ . '/object_detail.inc';
-require_once __DIR__ . '/include/TestRunResults.php';
+require_once INCLUDES_PATH . '/page_data.inc';
+require_once INCLUDES_PATH . '/object_detail.inc';
+require_once INCLUDES_PATH . '/include/TestRunResults.php';
 
 /**
  * Parse the page data and load the optimization-specific details for one step


### PR DESCRIPTION
Includes of common.inc and autoload.php need to remain with __DIR__ for now, as the constants are not yet loaded.

Will address the rest of the instances in follow up diffs, let's see what this one breaks.