### PR TITLE
Restore LCP background image Opp & Exp

### DIFF
--- a/www/experiments/lcp.inc
+++ b/www/experiments/lcp.inc
@@ -3,6 +3,10 @@
     // LCP info!
     $category = "Quick";
     $events = $testStepResult->getMetric('largestPaints');
+    $lcpType = $testStepResult->getMetric('LargestContentfulPaintType');
+    $lcpNodeType = $testStepResult->getMetric('LargestContentfulPaintNodeType');
+    $lcpImageURL = $testStepResult->getMetric('LargestContentfulPaintImageURL');
+
     $lcp = null;
 if (isset($events) && is_array($events)) {
     // Find the actual LCP event
@@ -43,6 +47,8 @@ if (isset($lcp)) {
                     $lcpSource = $srcmatches[1][0];
                 }
             }
+
+            // old bg check, which may still capture bg images from old test data
             if (isset($lcp['element']['background-image'])) {
                 preg_match_all('/url\(([\s])?([\"|\'])?(.*?)([\"|\'])?([\s])?\)/i', $lcp['element']['background-image'], $matches, PREG_PATTERN_ORDER);
                 if ($matches) {
@@ -52,6 +58,12 @@ if (isset($lcp)) {
                 }
             }
 
+            // new bg check - still doesn't find bg images set via inline style
+            if (isset($lcpType) && $lcpType === "background-image" && isset($lcpImageURL)) {
+                $lcpSource = $lcpImageURL;
+                $lcpFullSource = $lcpImageURL;
+                $isBG = true;
+            }
 
             $expsToAdd = array();
             $expsToAdd[] = (object) [


### PR DESCRIPTION
It seems that the LCP info coming from the browser may have changed recently and no longer includes bg image lcp info on the element object of the LCP event.

But the info is often elsewhere at least in the json.

This keeps our existing logic for old tests with test data that contains LCP bg image info on the element, while adding a check for the new location

fixes #2449