### PR TITLE
Add support to LCP vitals page for "url" based LCP images

### DIFF
--- a/www/vitals.php
+++ b/www/vitals.php
@@ -405,7 +405,7 @@ function InsertWebVitalsHTML_LCP($stepResult)
             } elseif (isset($lcp['element']['src']) || isset($lcp['element']['currentSrc'])) {
                 $lcpSource = isset($lcp['element']['currentSrc']) ? $lcp['element']['currentSrc'] : $lcp['element']['src'];
                 echo "<tr><th align='left'>Src</th><td>{$lcpSource}</td></tr>";
-            } elseif (isset($lcp['url']) && strlen($lcp['url'])) {
+            } elseif (!empty($lcp['url'])) {
                 $lcpSource = $lcp['url'];
                 echo "<tr><th align='left'>Url</th><td>{$lcpSource}</td></tr>";
             }

--- a/www/vitals.php
+++ b/www/vitals.php
@@ -405,6 +405,9 @@ function InsertWebVitalsHTML_LCP($stepResult)
             } elseif (isset($lcp['element']['src']) || isset($lcp['element']['currentSrc'])) {
                 $lcpSource = isset($lcp['element']['currentSrc']) ? $lcp['element']['currentSrc'] : $lcp['element']['src'];
                 echo "<tr><th align='left'>Src</th><td>{$lcpSource}</td></tr>";
+            } elseif (isset($lcp['url']) && strlen($lcp['url'])) {
+                $lcpSource = $lcp['url'];
+                echo "<tr><th align='left'>Url</th><td>{$lcpSource}</td></tr>";
             }
             if (isset($lcp['element']['background-image'])) {
                 echo "<tr><th align='left'>Background Image</th><td>{$lcp['element']['background-image']}</td></tr>";


### PR DESCRIPTION
This handles the case where images aren't regular src or background images and properly highlights the image request. Example [here](https://wpt.meenan.us/vitals.php?test=221011_9A_T&run=1&cached=0#lcp).

This doesn't update the experiments code to be aware of the 'url'-based LCP images which still needs to be done.

For https://github.com/WPO-Foundation/webpagetest/issues/2455

This goes with the client change in https://github.com/WPO-Foundation/wptagent/pull/576