### PR TITLE
feat(acct): notify cc errors

### DIFF
--- a/www/templates/account/plans/plan-summary.php
+++ b/www/templates/account/plans/plan-summary.php
@@ -3,6 +3,7 @@
     <?php require_once __DIR__ . '/includes/subhed.php'; ?>
     <?php require_once __DIR__ . '/includes/billing-address-form.php'; ?>
     <!-- main form -->
+    <div id="notification-banner-container"></div>
     <form id="wpt-account-upgrade" method="post" action="/account">
         <!-- payment -->
         <div class="box card-section">
@@ -72,6 +73,12 @@
                 button.disabled = false;
                 button.removeAttribute('disabled');
                 button.innerText = 'Upgrade Plan';
+
+                const upgradeError = new CustomEvent("cc-upgrade-error", {
+                  bubbles: true,
+                  detail: err.errors
+                });
+                event.target.dispatchEvent(upgradeError);
                 console.log('token ERROR - err: ', err);
             }
         );
@@ -97,6 +104,17 @@
             const submitButton = form.querySelector('button[type=submit]');
             submitButton.disabled = false;
             submitButton.removeAttribute('disabled');
+        });
+    })();
+</script>
+<script>
+    (() => {
+        document.addEventListener('cc-upgrade-error', e => {
+            const el = document.createElement('div');
+            el.classList.add('notification-banner', 'notification-banner__error');
+            el.innerText = e.detail;
+            document.querySelector('#notification-banner-container').appendChild(el);
+
         });
     })();
 </script>


### PR DESCRIPTION
Not the prettiest, but at least we have errors as they're passed to us. We could put together a more comprehensive and kind set of braintree errors and pass recommendations along. There's a whole list here:

https://webforcehq.zendesk.com/hc/en-us/articles/4404571172372-Braintree-Decline-Codes