### PR TITLE
add icon for connection type

### DIFF
--- a/www/assets/images/test_icons/signal.svg
+++ b/www/assets/images/test_icons/signal.svg
@@ -1,0 +1,7 @@
+<svg width="29" height="29" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3.51941" y="15.5149" width="3.72227" height="8.6106" fill="#E8A557"/>
+<rect x="8.18347" y="13.251" width="3.72227" height="10.8745" fill="#E8A557"/>
+<rect x="12.6681" y="10.6157" width="3.72227" height="13.5097" fill="#E8A557"/>
+<rect x="17.2424" y="7.60938" width="3.72227" height="16.5159" fill="#E8A557"/>
+<rect x="21.8616" y="4.08374" width="3.72227" height="20.0418" fill="#E8A557"/>
+</svg>

--- a/www/header.inc
+++ b/www/header.inc
@@ -225,7 +225,7 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
                 }
 
                 //connectivity
-                echo '<span class="test_presets_tag">' . $connectivity . '</span>';
+                echo '<span class="test_presets_tag"><img src="/assets/images/test_icons/signal.svg" alt="">' . $connectivity . '</span>';
                 //location
                 echo '<span class="test_presets_tag">';
 


### PR DESCRIPTION
<img width="476" alt="image" src="https://user-images.githubusercontent.com/214783/196438804-c846951e-5df3-48a3-890b-0dcc3898bc06.png">


Note: we should add this to the homepage signals as well. 
<img width="388" alt="image" src="https://user-images.githubusercontent.com/214783/196446282-695d54b7-4175-4370-b361-bb76ffbe60d9.png">


That'll be in settings. I'll commit it after this lands.
