### PR TITLE
xdebug linux fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
         - GID=${GID:-1000}
     # user: "1000:1000"
     # privileged: true
+    extra_hosts: # Needed for xdebug 
+      - "host.docker.internal:host-gateway"
     expose:
       - 9000
     volumes:

--- a/docker/local/server/xdebug/xdebug.ini
+++ b/docker/local/server/xdebug/xdebug.ini
@@ -6,5 +6,4 @@ xdebug.client_port = 9000
 xdebug.client_host= 'host.docker.internal'
 xdebug.remote_enabled=1
 xdebug.start_with_request=yes
-; xdebug.start_with_request=yes
 xdebug.log=/dev/stdout


### PR DESCRIPTION
Fixing the connection problem to the xdebug server inside of the docker container with a hostname mapping.