### PR TITLE
Consolelog didn't have results_nav banner.

### DIFF
--- a/www/consolelog.php
+++ b/www/consolelog.php
@@ -1,5 +1,8 @@
 <?php
 
+include 'common.inc';
+set_time_limit(30); // Prevent the consolelogs page from running out of control.
+
 // this output buffer hack avoids a bit of circularity
 // on one hand we want the contents of header.inc
 // on the other we want to get access to TestRunResults prior to that


### PR DESCRIPTION
Making sure everything was working on my docker image I noticed consolelog.php didn't have the results_nav so I couldn't continue going to different results pages unless I went back. I thought it would be nice to have the same results_nav presented as the rest of them did.

Current consolelog.php
![webpagetest-console](https://user-images.githubusercontent.com/33207323/196499058-6533bf40-4f7f-4db9-98b5-ea6de714f120.png)

With results_nav banner consolelog.php
![common-included](https://user-images.githubusercontent.com/33207323/196499046-375b9b7f-5219-44f6-9350-b7c41f5f7842.png)
