### PR TITLE
fix(header): allow tests to pass

### DIFF
--- a/tests/Handlers/AccountTest.php
+++ b/tests/Handlers/AccountTest.php
@@ -599,66 +599,66 @@ final class AccountTest extends TestCase
         Account::resendEmailVerification($req);
     }
 
-    /** These tests are frail, going to comment to ship and then address why they fail **/
-//    public function testGetAccountPageDefaultFree(): void
-//    {
-//        $page = "";
-//
-//        $req = new RequestContext([]);
-//        $user = new User();
-//        $user->setUserId(12345);
-//        $req->setUser($user);
-//
-//        $client = $this->createMock(CPClient::class);
-//        $client->expects($this->once())
-//            ->method('getFullWptPlanSet');
-//        $client->expects($this->once())
-//            ->method('getUserContactInfo')
-//            ->with(12345)
-//            ->willReturn([
-//                'firstName' => "Goober",
-//                'lastName' => "Goob",
-//                'companyName' => ""
-//            ]);
-//        $req->setClient($client);
-//
-//        $bmm = $this->createMock(BannerMessageManager::class);
-//        $bmm->expects($this->once())
-//            ->method('get')
-//            ->willReturn([]);
-//        $req->setBannerMessageManager($bmm);
-//
-//        Account::getAccountPage($req, $page);
-//    }
-//
-//    public function testGetAccountPageDefaultFreeCompanyNull(): void
-//    {
-//        $page = "";
-//
-//        $req = new RequestContext([]);
-//        $user = new User();
-//        $user->setUserId(12345);
-//        $req->setUser($user);
-//
-//        $client = $this->createMock(CPClient::class);
-//        $client->expects($this->once())
-//            ->method('getFullWptPlanSet');
-//        $client->expects($this->once())
-//            ->method('getUserContactInfo')
-//            ->with(12345)
-//            ->willReturn([
-//                'firstName' => "Goober",
-//                'lastName' => "Goob",
-//                'companyName' => null
-//            ]);
-//        $req->setClient($client);
-//
-//        $bmm = $this->createMock(BannerMessageManager::class);
-//        $bmm->expects($this->once())
-//            ->method('get')
-//            ->willReturn([]);
-//        $req->setBannerMessageManager($bmm);
-//
-//        Account::getAccountPage($req, $page);
-//    }
+    public function testGetAccountPageDefaultFree(): void
+    {
+        $page = "";
+
+        $req = new RequestContext([]);
+        $user = new User();
+        $user->setUserId(12345);
+        $req->setUser($user);
+
+        $client = $this->createMock(CPClient::class);
+        $client->expects($this->once())
+            ->method('getFullWptPlanSet');
+        $client->expects($this->once())
+            ->method('getUserContactInfo')
+            ->with(12345)
+            ->willReturn([
+                'firstName' => "Goober",
+                'lastName' => "Goob",
+                'companyName' => ""
+            ]);
+        $req->setClient($client);
+
+        $bmm = $this->createMock(BannerMessageManager::class);
+        $bmm->expects($this->once())
+            ->method('get')
+            ->willReturn([]);
+        $req->setBannerMessageManager($bmm);
+
+        $_GLOBALS['request_context'] = $req;
+        Account::getAccountPage($req, $page);
+    }
+
+    public function testGetAccountPageDefaultFreeCompanyNull(): void
+    {
+        $page = "";
+
+        $req = new RequestContext([]);
+        $user = new User();
+        $user->setUserId(12345);
+        $req->setUser($user);
+
+        $client = $this->createMock(CPClient::class);
+        $client->expects($this->once())
+            ->method('getFullWptPlanSet');
+        $client->expects($this->once())
+            ->method('getUserContactInfo')
+            ->with(12345)
+            ->willReturn([
+                'firstName' => "Goober",
+                'lastName' => "Goob",
+                'companyName' => null
+            ]);
+        $req->setClient($client);
+
+        $bmm = $this->createMock(BannerMessageManager::class);
+        $bmm->expects($this->once())
+            ->method('get')
+            ->willReturn([]);
+        $req->setBannerMessageManager($bmm);
+
+        Account::getAccountPage($req, $page);
+    }
 }

--- a/www/templates/layouts/includes/wpt-header.php
+++ b/www/templates/layouts/includes/wpt-header.php
@@ -79,7 +79,9 @@ if ($id) {
                                 </div>
                                 <div class="wptheader_nav_menu_section">
                                     <?php
-                                    if (!(!is_null($request_context->getUser()) && $request_context->getUser()->isPaid() )) {
+                                    $user_exists = !is_null($request_context) && !is_null($request_context->getUser());
+                                    $is_paid_user = $user_exists && $request_context->getUser()->isPaid();
+                                    if (!$is_paid_user) {
                                         ?>
                                         <p class="wptheader_nav_cta">
                                             <span>Ready to go <strong>Pro?</strong></span>


### PR DESCRIPTION
So, globals come through as null in phpunit, we could likely set "backupGlobals" to false in the config, but I don't know that I want to do that, so here's a fallback that gives us a little coverage

If we ever need to write this test so we see the rendering differences for paid users, we'll need a better setup than this