### PR TITLE
Check for raw param before adding header Content-disposition.

### DIFF
--- a/www/export.php
+++ b/www/export.php
@@ -47,7 +47,12 @@ if (!strlen($filename)) {
 }
 $filename .= ".$id.har";
 header('Content-type: application/json');
-header("Content-disposition: attachment; filename=$filename");
+
+if(isset($_REQUEST['raw']) && $_REQUEST['raw']){
+    $options['raw'] = $_REQUEST['raw'];
+}else{
+    header("Content-disposition: attachment; filename=$filename");
+}
 
 // see if we need to wrap it in a JSONP callback
 if (isset($_REQUEST['callback']) && strlen($_REQUEST['callback'])) {


### PR DESCRIPTION
This is specifically for node wrapper because server was throwing 403 forbidden error due to header missing with the request.

If &raw=1 is passed with the API request it will allow file downloading without checking for header Content-disposition