### PR TITLE
Fixed an exception when possibly-render-blocking-reqs doesn't exist

### DIFF
--- a/www/experiments/render-blocking-3rd-party.inc
+++ b/www/experiments/render-blocking-3rd-party.inc
@@ -5,7 +5,7 @@ $requests = $testStepResult->getRequests();
 $blocking3pReqs = array();
 $blocking3pHosts = array();
 $potentiallyBlocking3pReqs = array();
-$potentiallyB3pHosts = array();
+$potentiallyBlocking3pHosts = array();
 $possibleRenderBlockers = $testStepResult->getMetric('possibly-render-blocking-reqs');
 $blockingIndicator = false;
 

--- a/www/experiments/render-blocking-3rd-party.inc
+++ b/www/experiments/render-blocking-3rd-party.inc
@@ -21,7 +21,7 @@ foreach ($requests as $request) {
                 && ($request['contentType'] === "text/css" || $request['requestType'] === "script" || $request['request_type'] === "Script")
                 && $request['all_end'] < $startRender
     ) {
-        if (in_array($request['full_url'], $possibleRenderBlockers)) {
+        if (isset($possibleRenderBlockers) && in_array($request['full_url'], $possibleRenderBlockers)) {
             array_push($potentiallyBlocking3pReqs, $request['full_url']);
             array_push($potentiallyBlocking3pHosts, $request['host']);
         }

--- a/www/experiments/render-blocking-3rd-party.inc
+++ b/www/experiments/render-blocking-3rd-party.inc
@@ -21,7 +21,7 @@ foreach ($requests as $request) {
                 && ($request['contentType'] === "text/css" || $request['requestType'] === "script" || $request['request_type'] === "Script")
                 && $request['all_end'] < $startRender
     ) {
-        if (isset($possibleRenderBlockers) && in_array($request['full_url'], $possibleRenderBlockers)) {
+        if (!empty($possibleRenderBlockers) && in_array($request['full_url'], $possibleRenderBlockers)) {
             array_push($potentiallyBlocking3pReqs, $request['full_url']);
             array_push($potentiallyBlocking3pHosts, $request['host']);
         }


### PR DESCRIPTION
I'm assuming `possibly-render-blocking-reqs` is a custom metric on the public instance but doesn't necessarily exist elsewhere.