### PR TITLE
Removed .border class in user timing table

### DIFF
--- a/www/include/UserTimingHtmlTable.php
+++ b/www/include/UserTimingHtmlTable.php
@@ -48,7 +48,6 @@ class UserTimingHtmlTable
 
     private function _createHead()
     {
-        $borderClass = $this->hasUserTiming ? ' class="border"' : '';
         $out = "<tr>\n";
         if ($this->isMultistep) {
             $out .= "<th>Step</th>";
@@ -61,7 +60,7 @@ class UserTimingHtmlTable
             }
         }
         if ($this->hasNavTiming) {
-            $out .= "<th$borderClass>";
+            $out .= "<th>";
             if ($this->hasDomInteractive) {
                 $out .= "<a href=\"https://w3c.github.io/navigation-timing/#processing-model\">domInteractive</a></th><th>";
             }
@@ -83,7 +82,6 @@ class UserTimingHtmlTable
 
     private function _createRow($stepResult, $stepUserTiming)
     {
-        $borderClass = $this->hasUserTiming ? ' class="border"' : '';
         $out = "<tr>\n";
         if ($this->isMultistep) {
             $out .= "<td>" . FitText($stepResult->readableIdentifier(), 30) . "</td>";
@@ -96,7 +94,7 @@ class UserTimingHtmlTable
             }
         }
         if ($this->hasNavTiming) {
-            $out .= "<td$borderClass>";
+            $out .= "<td>";
             if ($this->hasDomInteractive) {
                 $out .= $this->_getTimeMetric($stepResult, "domInteractive") . '</td><td>';
             }


### PR DESCRIPTION
Removing this white gap mid-table

# before
<img width="1474" alt="Screen Shot 2022-11-04 at 12 57 59 PM" src="https://user-images.githubusercontent.com/51308/200033528-093c273f-f2d7-45bf-aca9-a85d715bb8f5.png">

# after
<img width="1479" alt="Screen Shot 2022-11-04 at 12 57 46 PM" src="https://user-images.githubusercontent.com/51308/200033532-611e38a1-36b8-4fd8-acf4-ee8c8b78e816.png">

Seems this large white border is only used in CWV results above.

Also null'd the user timings and the table still looks ok:

<img width="1463" alt="Screen Shot 2022-11-04 at 12 58 19 PM" src="https://user-images.githubusercontent.com/51308/200033518-8279b8ee-15ab-4124-885b-ec3314be8b4c.png">