### PR TITLE
Fix a subtab name

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -371,7 +371,7 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
 
             if ($experiment) {
                 $tabs['Opportunities & Experiments'] = $experimentOriginalExperimentsHref;
-                $tabs['Experiment Results (Filmstrip)'] = $experimentResultsHref;
+                $tabs['Experiment Results & Filmstrip'] = $experimentResultsHref;
             } else {
                 $tabs['Opportunities & Experiments'] = $menuUrlGenerator->resultPage("experiments", $endParams);
                 $tabs['Filmstrip'] = $menuUrlGenerator->filmstripView("filmstrip", $endParams);


### PR DESCRIPTION
When the string is not consistent, the subtab menu looks off

# before

<img width="548" alt="Screen Shot 2022-11-08 at 1 01 19 PM" src="https://user-images.githubusercontent.com/51308/200641185-0b63e9f3-2673-4735-a2ca-5d322d95b447.png">

# after

<img width="537" alt="Screen Shot 2022-11-08 at 1 01 07 PM" src="https://user-images.githubusercontent.com/51308/200641188-cf27c59f-7cab-41a5-b8b6-38ebbb93596d.png">
