### PR TITLE
SVG icons in optimization checklist

### DIFF
--- a/www/resources/views/components/icon.blade.php
+++ b/www/resources/views/components/icon.blade.php
@@ -1,1 +1,11 @@
-<img src="/assets/images/{{$type}}.png" width="16" height="16" alt="Icon: {{$type}} ">
+@switch($type)
+    @case('check')
+        <img src="/assets/images/src/icon_grading_check.svg" width="20" height="20" alt="Icon: {{$type}} ">
+        @break
+    @case('warning')
+        <img src="/assets/images/src/icon_grading_warn.svg" width="20" height="20" alt="Icon: {{$type}} ">
+        @break
+    @case('error')
+        <img src="/assets/images/src/icon_grading_alert.svg" width="20" height="20" alt="Icon: {{$type}} ">
+        @break
+@endswitch


### PR DESCRIPTION
# before
<img width="1144" alt="Screen Shot 2022-11-08 at 7 05 58 PM" src="https://user-images.githubusercontent.com/51308/200703784-7e7825c0-78b6-44af-b1c5-e091c8bcc56c.png">

# after
<img width="1180" alt="Screen Shot 2022-11-08 at 7 05 47 PM" src="https://user-images.githubusercontent.com/51308/200703787-ed1f6331-4392-4dfe-b919-8dd9d97dd6c5.png">

We could do this with conditions and do not triplicate the html (like it was before) but I kinda like being able to search for file paths