### PR TITLE
Monospace font in response bodies

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -7408,9 +7408,15 @@ div.jqmDialog {
   }
 }
 
-div.jqmDialog pre {
+div.jqmDialog pre,
+.jqmDialog .response-body {
   font-size: medium;
   line-height: 1.25em;
+}
+
+.jqmDialog .response-body {
+  font-family: monospace;
+  white-space: pre;
 }
 
 div.jqmdTC {


### PR DESCRIPTION
# before:

<img width="1173" alt="Screen Shot 2022-11-09 at 1 27 00 PM" src="https://user-images.githubusercontent.com/51308/200911461-fd4a576e-92a1-4288-949a-ce613d051c0e.png">

# after:

<img width="1195" alt="Screen Shot 2022-11-09 at 1 26 42 PM" src="https://user-images.githubusercontent.com/51308/200911478-374b772a-d666-48fb-81fd-dea8b5be6a86.png">
