### PR TITLE
Add ability to sort order that experiments apply

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -1260,8 +1260,14 @@ h4.experiments_list_hed-recs {
 .experiments_foot details div p.experiments_jump {
   color: #333;
   font-size: 1rem;
+  margin-bottom: .5em;
 }
+.experiments_foot details div p.experiments_jump i {
+  display: block;
+  font-weight: 300;
+  font-size: .8em;
 
+}
 .experiments_foot details ol {
   max-height: 70vh;
   overflow: auto;
@@ -1271,10 +1277,14 @@ h4.experiments_list_hed-recs {
 }
 
 .experiments_foot details ol li {
-  padding: 0.4em 1em;
+  padding: 0.6em 0;
+  font-size: .8em;
+  border-bottom: 1px solid #eee;
   list-style-position: inside;
 }
-
+.experiments_foot details ol li:last-child {
+  border: 0;
+}
 .experiments_foot details ol:after {
   border-top: 0.6em solid rgb(250 250 250);
   border-right: 0.6em solid transparent;
@@ -1302,6 +1312,34 @@ h4.experiments_list_hed-recs {
   width: auto;
   min-width: auto;
   text-align: left;
+  font-size: 1em;
+}
+.experiments_foot details ol button.experiment_sort {
+  border: 1px solid #ccc;
+  background: #ddd;
+  border-radius: 2em;
+  padding: 0.3em 1em 0.3em 0.6em;
+  text-decoration: none;
+  color: #2a3b64;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.9em;
+  margin-left: 0.5em;
+  font-weight: 700;
+  float: right;
+}
+.experiments_foot details ol button.experiment_sort:hover,
+.experiments_foot details ol button.experiment_sort:focus {
+  background: #fff;
+}
+.experiments_foot details ol button.experiment_sort:before {
+  content: "";
+  border-bottom: 6px solid #2a3b64;
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  vertical-align: middle;
+  margin-right: 0.3rem;
+  display: inline-block;
 }
 
 .experiments_create {

--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -1313,6 +1313,7 @@ h4.experiments_list_hed-recs {
   min-width: auto;
   text-align: left;
   font-size: 1em;
+  max-width: 70%;
 }
 .experiments_foot details ol button.experiment_sort {
   border: 1px solid #ccc;

--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -1341,6 +1341,9 @@ h4.experiments_list_hed-recs {
   margin-right: 0.3rem;
   display: inline-block;
 }
+.experiments_foot details ol li:first-child button.experiment_sort {
+  display: none; 
+}
 
 .experiments_create {
   margin-bottom: -8rem;

--- a/www/experiments.php
+++ b/www/experiments.php
@@ -611,7 +611,19 @@ $page_description = "Website performance test result$testLabel.";
     form.addEventListener("change", saveExperimentFormState );
     form.addEventListener("submit", saveExperimentFormState );
 
+    // append inputs to end of form on submit to impact post order
+    function sortExperimentOrder(){
+        var appliedOrder = document.querySelectorAll('.exps-active li');
+        appliedOrder.forEach(li => {
+            var associatedInput = form.querySelector( "[name=\"" + li.getAttribute('data-input-name') + "\"][value=\"" + li.getAttribute('data-input-value') + "\"]" );
+            if(associatedInput){
+                form.append(associatedInput);
+                console.log(associatedInput);
+            }
+        });
+    }
 
+    form.addEventListener("submit", sortExperimentOrder );
 
     var expsActive;
     function updateCount(){
@@ -635,18 +647,25 @@ $page_description = "Website performance test result$testLabel.";
             expsActiveInfo.innerHTML = '<summary><strong>' + expsActive.length + '</strong> experiment'+ (expsActive.length>1?'s':'') +' selected.</summary>';
 
             let expsActiveLinksContain = document.createElement('div');
-            expsActiveLinksContain.innerHTML = '<p class="experiments_jump">Scroll to:</p>';
+            expsActiveLinksContain.innerHTML = '<p class="experiments_jump">Experiments apply in this order: <i>(Order matters! Some experiments will override others.)</i></p>';
             let expsActiveLinks = document.createElement('ol');
             
             expsActive.forEach(exp => {
                 let newLi = document.createElement('li');
+                newLi.setAttribute("data-input-name", exp.getAttribute('name'));
+                newLi.setAttribute("data-input-value", exp.getAttribute('value'));
                 let expDesc = exp.closest(".experiment_description");
-                newLi.innerHTML = '<button type="button">'+ expDesc.querySelector('h5').innerText +'</button>';
+                newLi.innerHTML = '<button type="button" class="experiment_scroll">'+ expDesc.querySelector('h5').innerText +'</button><button type="button" class="experiment_sort">Sort</button>';
                 expsActiveLinks.append(newLi);
-                newLi.addEventListener("click", () => {
+                newLi.querySelector('button.experiment_scroll').addEventListener("click", () => {
                     expDesc.scrollIntoView({behavior: 'smooth'});
                 });
-                
+                newLi.querySelector('button.experiment_sort').addEventListener("click", () => {
+                    var prevLi = newLi.previousElementSibling;
+                    if(prevLi){
+                        prevLi.before(newLi);
+                    }
+                });
             });
 
             expsActiveLinksContain.append(expsActiveLinks);


### PR DESCRIPTION
This adds sort functionality to the experiments feature so that users can control the order experiments are applied. This is helpful in cases where one experiment can destroy the changes that another made. For example, if you add a defer attribute to all scripts, and then replace the HTML of the entire page, that first change will be destroyed. The opposite order would let you replace the html then add defer.

As a first pass, this is implemented with sort buttons. We may add drag sort later if desired.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/214783/201156815-3feaf56f-b354-484c-b5ee-d8195e093002.png">
