### PR TITLE
Removed border radius from results_body

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -582,7 +582,6 @@ span.lh-flag.poor {
 
 .results_body {
   padding: 0 3em;
-  border-radius: 1rem;
   box-shadow: 0 0 4px #ddd;
   margin: 1em -3rem !important;
   background-clip: padding-box;

--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -592,7 +592,6 @@ span.lh-flag.poor {
 @media (max-width: 87.5em) {
   .results_body {
     padding: 0;
-    border-radius: 0;
     box-shadow: none;
     margin: 0 0 !important;
   }


### PR DESCRIPTION
Fixes #2533.

From what I can tell, there is no visual impact from having the border-radius on the `results_body` so it is safe to remove. Was only visible on `min-width: 87.5em` since it was set to `0` on smaller viewports. Removing it resolves the erratic Chrome behavior with `mix-blend-mode`.