### PR TITLE
Updating confirm password label

### DIFF
--- a/www/templates/account/includes/modals/password.php
+++ b/www/templates/account/includes/modals/password.php
@@ -12,7 +12,7 @@
                 <input type="password" name="new-password" minlength="8" title="The requirements are at least 8 characters, including a number, lowercase letter, uppercase letter and symbol. No &lt;, &gt;." pattern="<?= $validation_pattern_password ?>" required />
             </div>
             <div class="section">
-                <label class="required" for="confirm-new-password">New Password</label>
+                <label class="required" for="confirm-new-password">Confirm New Password</label>
                 <input type="password" name="confirm-new-password" minlength="8" title="The requirements are at least 8 characters, including a number, lowercase letter, uppercase letter and symbol. No &lt;, &gt;." pattern="<?= $validation_pattern_password ?>" required />
             </div>
             <div class="section">


### PR DESCRIPTION
Right now our confirm password field shows "New Password" for the label. Changing that to "Confirm New Password" to help make it more clear.