### PR TITLE
New metric to minimize the observer effect on CSS

### DIFF
--- a/www/assets/js/conditional_metrics/generated-html.js
+++ b/www/assets/js/conditional_metrics/generated-html.js
@@ -1,0 +1,26 @@
+// this is similar to rendered-html metric
+// except it includes doctype and
+// rewrites CSS only conditionally
+const clonedDoc = document.cloneNode(true);
+const clonedStyles = clonedDoc.querySelectorAll("style")
+let styles = document.querySelectorAll("style").forEach((style, idx) => {
+  let generatedCSS = "";
+  for (let i in style.sheet.cssRules) {
+    if (style.sheet.cssRules[i] && style.sheet.cssRules[i].cssText) {
+      generatedCSS += style.sheet.cssRules[i].cssText + "\n";
+    }
+  }
+  if (!generatedCSS) {
+    return;
+  }
+  // just count the }s before and after as a rough idea if the inner style was CSSOM'd
+  if (generatedCSS.split("}").length !== style.textContent.split("}").length) {
+    clonedStyles[idx].textContent =
+      "/* inner styles set by WPT to match CSSOM */\n" + generatedCSS;
+  }
+});
+let doctype = new XMLSerializer().serializeToString(clonedDoc.doctype);
+if (doctype) {
+  doctype += "\n";
+}
+return doctype + clonedDoc.documentElement.outerHTML;

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -662,11 +662,19 @@ if (!isset($test)) {
         $test['block'] .= ' adsWrapper.js adsWrapperAT.js adsonar.js sponsored_links1.js switcher.dmn.aol.com';
     }
 
+    if ($test['bodies']) {
+        $test['customMetrics'] = array();
+        $code = file_get_contents(ASSETS_PATH . '/js/conditional_metrics/generated-html.js');
+        $test['customMetrics']['generated-html'] = $code;
+    }
+
     // see if there are any custom metrics to extract
     if (is_dir('./settings/custom_metrics')) {
         $files = glob('./settings/custom_metrics/*.js');
         if ($files !== false && is_array($files) && count($files)) {
-            $test['customMetrics'] = array();
+            if (!isset($test['customMetrics'])) {
+                $test['customMetrics'] = array();
+            }
             foreach ($files as $file) {
                 $name = basename($file, '.js');
                 $code = file_get_contents($file);

--- a/www/settings/custom_metrics/doctype.js
+++ b/www/settings/custom_metrics/doctype.js
@@ -1,1 +1,0 @@
-return new XMLSerializer().serializeToString(document.doctype);


### PR DESCRIPTION
* like rendered-html but with doctype and less aggressive <style> rewrite
* count curly braces as an idea if a CSS was modified
* works on a clone of the doc so we don't mangle <style> twice
* run before rendered-html which does mangle <styles>
* delete the doctype metric since we have no use for it after this diff
* only collect the metric if the response bodies are gathered, otherwise we cannot html diff anyway