### PR TITLE
Add enable-features to the list of Chrome command-line flags

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -3383,7 +3383,7 @@ function ValidateCommandLine($cmd, &$error)
         $flags = explode(' ', $cmd);
         if ($flags && is_array($flags) && count($flags)) {
             foreach ($flags as $flag) {
-                if (strlen($flag) && !preg_match('/^--(([a-zA-Z0-9\-\.\+=,_< "]+)|((data-reduction-proxy-http-proxies|data-reduction-proxy-config-url|proxy-server|proxy-pac-url|force-fieldtrials|force-fieldtrial-params|trusted-spdy-proxy|origin-to-force-quic-on|oauth2-refresh-token|unsafely-treat-insecure-origin-as-secure|user-data-dir|ignore-certificate-errors-spki-list)=[a-zA-Z0-9\-\.\+=,_:\/"%]+))$/', $flag)) {
+                if (strlen($flag) && !preg_match('/^--(([a-zA-Z0-9\-\.\+=,_< "]+)|((data-reduction-proxy-http-proxies|data-reduction-proxy-config-url|proxy-server|proxy-pac-url|force-fieldtrials|force-fieldtrial-params|trusted-spdy-proxy|origin-to-force-quic-on|oauth2-refresh-token|unsafely-treat-insecure-origin-as-secure|user-data-dir|ignore-certificate-errors-spki-list|enable-features)=[a-zA-Z0-9\-\.\+=,_:\/"%]+))$/', $flag)) {
                     $error = 'Invalid command-line option: "' . htmlspecialchars($flag) . '"';
                 }
             }


### PR DESCRIPTION
Add enable-features to the list of Chrome command-line flags that allow extended characters.  It often needs `:` and `/` to provide config values for individual features.

This regex used to be the main line of defense against running arbitrary commands on the agents but that was fixed a while back and the agents now correctly escape ALL command-line params (but it doesn't hurt to keep this regex as an additional protection).