### PR TITLE
fix(account): this blows things up

### DIFF
--- a/www/src/CPClient.php
+++ b/www/src/CPClient.php
@@ -374,7 +374,6 @@ class CPClient
                         'maskedCreditCard',
                         'creditCardType',
                         'nextBillingDate',
-                        'billingPeriodEndDate',
                         'numberOfBillingCycles',
                         'ccExpirationDate',
                         'ccImageUrl',


### PR DESCRIPTION
If a user is in a weird state where billing period end date is not set, they get a 500