### PR TITLE
Change support link

### DIFF
--- a/www/templates/account/billing/billing-cycle.php
+++ b/www/templates/account/billing/billing-cycle.php
@@ -7,7 +7,7 @@
         <h1>Update Billing Cycle</h1>
         <?php if ($is_paid) : ?>
             <div class="contact-support-button">
-                <a href="https://support.webpagetest.org"><span>Contact Support</span></a>
+                <a href="https://support.catchpoint.com"><span>Contact Support</span></a>
             </div>
         <?php endif; ?>
     </div>

--- a/www/templates/account/includes/modals/cancel-subscription.php
+++ b/www/templates/account/includes/modals/cancel-subscription.php
@@ -2,7 +2,7 @@
     <h3 class="modal_title">Subscription Details</h3>
     <p>Active Plan: <?= $wptCustomer->getWptPlanName() ?></p>
     <p>Cancelling your Pro subscription will downgrade your account to a free Starter plan.</p>
-    <p>Please <a href="https://support.webpagetest.org">contact support</a> with for any upgrades or other changes to your plan.</p>
+    <p>Please <a href="https://support.catchpoint.com">contact support</a> with for any upgrades or other changes to your plan.</p>
     <div class="cancel-subscription-button">
         <button class="pill-button red">Cancel Subscription</button>
     </div>

--- a/www/templates/account/plans/includes/subhed.php
+++ b/www/templates/account/plans/includes/subhed.php
@@ -1,8 +1,8 @@
 <div class="subhed">
     <h1>Purchase Summary</h1>
     <?php if ($is_paid) : ?>
-    <div class="contact-support-button">
-        <a href="https://support.webpagetest.org"><span>Contact Support</span></a>
-    </div>
+        <div class="contact-support-button">
+            <a href="https://support.catchpoint.com"><span>Contact Support</span></a>
+        </div>
     <?php endif; ?>
 </div>

--- a/www/templates/account/plans/upgrade-plan.php
+++ b/www/templates/account/plans/upgrade-plan.php
@@ -8,7 +8,7 @@
         <h1>Update Plan</h1>
         <?php if ($is_paid) : ?>
             <div class="contact-support-button">
-                <a href="https://support.webpagetest.org"><span>Contact Support</span></a>
+                <a href="https://support.catchpoint.com"><span>Contact Support</span></a>
             </div>
         <?php endif; ?>
     </div>

--- a/www/templates/errors/runlimit.php
+++ b/www/templates/errors/runlimit.php
@@ -2,6 +2,6 @@
     <main>
         <h1>Oops!</h1>
         <p>User does not have enough available runs to administer this test.</p>
-        <p><a href="/account">Sign up</a> for a Pro plan to upgrade or <a href="https://support.webpagetest.org">contact us</a> to upgrade your existing Pro account.</p>
+        <p><a href="/account">Sign up</a> for a Pro plan to upgrade or <a href="https://support.catchpoint.com">contact us</a> to upgrade your existing Pro account.</p>
     </main>
 </div>


### PR DESCRIPTION
This replaces all references to support.webpagetest.org with support.catchpoint.com instead, as we are moving to a unified support instance.