### PR TITLE
More colorful description in HTML Diff

### DIFF
--- a/www/resources/views/pages/htmldiff.blade.php
+++ b/www/resources/views/pages/htmldiff.blade.php
@@ -2,13 +2,13 @@
 
 @section('style')
 <style>
-    del {
+    del, .del {
         text-decoration: none;
         color: #b30000;
         background: #fadad7;
     }
 
-    ins {
+    ins, .ins {
         background: #eaf2c2;
         color: #406619;
         text-decoration: none;
@@ -68,7 +68,8 @@
         <div class="results_and_command">
             <div class="results_header">
                 <h2>HTML Diff</h2>
-                <p>A diff between the HTML delivered over the network (red lines) and the generated HTML (green lines)</p>
+                <p>A diff between the HTML delivered over the network <span class="del">(red lines)</span>
+                and the generated HTML <span class="ins">(green lines)</a>.</p>
             </div>
         </div>
         @if ($error_message)
@@ -99,7 +100,7 @@
             const diffWorker = new Worker(
                 URL.createObjectURL(
                     new Blob(
-                        [`(${diffWorkerImplementation.toString()})()`], 
+                        [`(${diffWorkerImplementation.toString()})()`],
                         {type: 'text/javascript'}
                     )
                 )
@@ -141,7 +142,7 @@
                 }
 
                 resultEl.innerHTML = 'Diffing...';
-                
+
                 diffWorker.postMessage({
                     before,
                     after,


### PR DESCRIPTION
# before:

<img width="1104" alt="Screenshot 2022-12-20 at 5 52 04 PM" src="https://user-images.githubusercontent.com/51308/208781754-76ddc527-aba6-4573-8a1a-83bbd0938697.png">

# after:

<img width="1121" alt="Screenshot 2022-12-20 at 5 51 54 PM" src="https://user-images.githubusercontent.com/51308/208781760-4dcbde3e-9a47-499d-9d5b-e610688b56b5.png">
