### PR TITLE
fix(signup): button size too small on safari

### DIFF
--- a/www/assets/css/account.css
+++ b/www/assets/css/account.css
@@ -810,6 +810,7 @@ body.theme-b {
   display: inline-block;
   padding: 0.7em 2.2em;
   color: #111;
+  font-size: 1em;
 }
 
 .signup-flow-layout .form-input button[type="submit"]:disabled,


### PR DESCRIPTION
No font-size set means we're stuck with browser vendor defaults and safari says "small"

Before:

![before-signup-button](https://user-images.githubusercontent.com/109699/210448625-0e7ee6b0-6a90-4b38-bc57-21d69962329a.png)


After:

![after-signup-button](https://user-images.githubusercontent.com/109699/210448640-494a8ac7-f67d-4837-8414-33099c0bdf1d.png)
