### PR TITLE
Don't count LH as a test run if standard WPT test is run

### DIFF
--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -55,7 +55,7 @@ final class UtilTest extends TestCase
         $lighthouse = 1;
         $testtype = '';
         $total_runs = Util::getRunCount($runs, $fvonly, $lighthouse, $testtype);
-        $this->assertEquals(2, $total_runs);
+        $this->assertEquals(1, $total_runs);
     }
     public function testGetRunCountRepeatView(): void
     {
@@ -73,7 +73,7 @@ final class UtilTest extends TestCase
         $lighthouse = 1;
         $testtype = '';
         $total_runs = Util::getRunCount($runs, $fvonly, $lighthouse, $testtype);
-        $this->assertEquals(3, $total_runs);
+        $this->assertEquals(2, $total_runs);
     }
     public function testGetRunCountLighthouseTest(): void
     {

--- a/www/src/Util.php
+++ b/www/src/Util.php
@@ -741,9 +741,6 @@ class Util
         $runcount = max(1, $runs);
         $multiplier = $fvonly ? 1 : 2;
         $total_runs = $runcount * $multiplier;
-        if (!$testtype == 'lighthouse' && $lighthouse == 1) {
-            $total_runs++;
-        }
         return $total_runs;
     }
 


### PR DESCRIPTION
We're no longer going to be counting Lighthouse runs as a separate run when selected alongside a standard WebPageTest result.

This change makes sure that if a standard test is run, running LH has no change on the test run count. However if only LH is run, it should count against users test run limits.