### PR TITLE
Fix Login on LH results

### DIFF
--- a/www/lighthouse-new.php
+++ b/www/lighthouse-new.php
@@ -4,7 +4,7 @@
 // Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 // found in the LICENSE.md file.
 
-include __DIR__ . '/common.inc';
+require_once __DIR__ . '/common.inc';
 
 require_once INCLUDES_PATH . '/page_data.inc';
 require_once INCLUDES_PATH . '/include/TestInfo.php';


### PR DESCRIPTION
Looks like we were including `common.inc` twice which probably resets some checks.

As a result the page loads in signed out state