### PR TITLE
history table cell fix

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -4295,6 +4295,7 @@ table.checklist td {
 .history td.location {
   white-space: nowrap;
   max-width: 10vw;
+  overflow: auto;
 }
 
 .history td.url {


### PR DESCRIPTION
sometimes these cells' contents get real long. This keeps the table from getting wonky

<img width="421" alt="image" src="https://user-images.githubusercontent.com/214783/211045789-389a3681-1acd-4d3e-98da-d12db8fd2a6c.png">
