### PR TITLE
Option to highlight JSON responses

### DIFF
--- a/www/jsonResult.php
+++ b/www/jsonResult.php
@@ -95,7 +95,13 @@ if (isset($test['test']['batch']) && $test['test']['batch']) {
         ArchiveApi($id);
     }
 
-    json_response($ret);
+    if (!empty($_REQUEST['highlight'])) {
+        echo view('jsonhighlight', [
+            'json' => json_encode($ret, JSON_PRETTY_PRINT),
+        ]);
+    } else {
+        json_response($ret);
+    }
 }
 
 function getRequestInfoFlags()

--- a/www/resources/views/jsonhighlight.blade.php
+++ b/www/resources/views/jsonhighlight.blade.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>WebPageTest JSON</title>
+    <link rel="stylesheet" type="text/css" href="/assets/css/vendor/prism-1.29.0.css">
+    <script src="/assets/js/vendor/prism-1.29.0.js" async></script>
+    <style>
+        pre {
+            background: none !important;
+            padding: 1em;
+            margin: .5em 0;
+        }
+    </style>
+</head>
+
+<body>
+    <pre><code class="language-js">{{ $json }}</code></pre>
+</body>
+
+</html>

--- a/www/testinfo_command-bar.inc
+++ b/www/testinfo_command-bar.inc
@@ -1,8 +1,8 @@
 <div class="test_meta_commands">
-                
+
                 <p class="results_nav_hed">Tools:</p>
-                
-               
+
+
                 <details>
                 <summary>Export</summary>
                   <ul class="testinfo_artifacts-list">
@@ -11,7 +11,8 @@
                       $fvMedian = $testResults->getMedianRunNumber($median_metric, false);
                       $rvMedian = $testResults->getMedianRunNumber($median_metric, true);
 
-                      echo "<li><a href='/jsonResult.php?test=$id&pretty=1'>View Test JSON</a></li>";
+                      echo "<li><a href='/jsonResult.php?test=$id&highlight=1'>View Test JSON</a></li>";
+                      echo "<li><a href='/jsonResult.php?test=$id&pretty=1'>View Test JSON (raw)</a></li>";
                   if (is_file("$testPath/test.log")) {
                       echo "<li><a href=\"/viewlog.php?test=$id\">View Test Log</a></li>";
                   }

--- a/www/testinfo_command-bar.inc
+++ b/www/testinfo_command-bar.inc
@@ -12,7 +12,7 @@
                       $rvMedian = $testResults->getMedianRunNumber($median_metric, true);
 
                       echo "<li><a href='/jsonResult.php?test=$id&highlight=1'>View Test JSON</a></li>";
-                      echo "<li><a href='/jsonResult.php?test=$id&pretty=1'>View Test JSON (raw)</a></li>";
+                      echo "<li><a href='/jsonResult.php?test=$id&pretty=1'>View Test JSON (unformatted)</a></li>";
                   if (is_file("$testPath/test.log")) {
                       echo "<li><a href=\"/viewlog.php?test=$id\">View Test Log</a></li>";
                   }


### PR DESCRIPTION
Like so:

<img width="846" alt="Screenshot 2023-01-06 at 1 52 59 PM" src="https://user-images.githubusercontent.com/51308/211079475-f281d98c-320d-4e14-92e5-2e1492196398.png">


Keep the previous option as (unformatted) but default to the new one:

<img width="554" alt="Screenshot 2023-01-06 at 1 51 28 PM" src="https://user-images.githubusercontent.com/51308/211079230-04e3e637-2aa5-4b05-a841-123044ebbb2c.png">
