### PR TITLE
Edit Initial Response HTML experiment. #2471

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -885,6 +885,7 @@ h4.experiments_list_hed-recs {
 }
 .experiments_list > li:target {
   background: #f8f7e0;
+  scroll-padding-top: 4rem;
 }
 
 .experiment_description code {
@@ -2209,6 +2210,18 @@ footer ul {
   .experiments_details_body {
     padding-left: 2rem;
   }
+}
+
+.experiment_description_go > label.experiment_pair_value textarea[data-fullscreenfocus=true]:focus {
+  position: fixed;
+  top: 10vh;
+  left: 10vw;
+  right: 10vw;
+  bottom: 10vh;
+  z-index: 999999;
+  box-shadow: 0 0 0 11vw rgba(0,0,0,.3);
+  height: 80vh;
+  width: 80vw;
 }
 
 @media (max-width: 50em) {

--- a/www/experiments.php
+++ b/www/experiments.php
@@ -349,11 +349,13 @@ $page_description = "Website performance test result$testLabel.";
                                 } elseif ($exp->expvar && !$exp->expval && $textinput) {
                                     if ($experimentEnabled) {
                                         $placeholderEncodedVal = htmlentities('<script src="https://example.com/test.js"></script>');
+                                        $textinputvalue = $exp->textinputvalue ? $exp->textinputvalue : "";
+                                        $fullscreenfocus = $exp->fullscreenfocus ? "true" : "false";
                                         $out .= <<<EOT
                                         </div>
                                         <div class="experiment_description_go experiment_description_go-multi">
                                         <label class="experiment_pair_check"><input type="checkbox" name="recipes[]" value="{$expNum}-{$exp->expvar}">Run this Experiment with:</label>
-                                        <label class="experiment_pair_value"><span>Value: </span><textarea name="{$expNum}-{$exp->expvar}[]" placeholder="{$placeholderEncodedVal}"></textarea></label>
+                                        <label class="experiment_pair_value"><span>Value: </span><textarea id="experiment-{$exp->id}-textarea" data-fullscreenfocus="{$fullscreenfocus}" name="{$expNum}-{$exp->expvar}[]">{$textinputvalue}</textarea></label>
 
                                         </div>
                                         EOT;
@@ -582,7 +584,7 @@ $page_description = "Website performance test result$testLabel.";
                                 }
                             }
                         }
-                        if( input && !(keyval[1] === 'on' && form.querySelectorAll("[type=checkbox][name='" + keyval[0] + "']")) ){
+                        if( input && !(keyval[1] === 'on' && form.querySelectorAll("[type=checkbox][name='" + keyval[0] + "']")) && keyval[1] !== "" ){
                             input.value = keyval[1];
                             input.setAttribute('data-hydrated', 'true');
                         }

--- a/www/experiments/custom.inc
+++ b/www/experiments/custom.inc
@@ -83,7 +83,7 @@ if( $requests[0]['body_url'] ){
                 'title' => 'Edit Response HTML',
                 "desc" => '<p>This experiment will replace the initial HTML with the submitted value as if it was served that way initially.</p>',
                 "expvar" => 'editresponsehtml',
-                'textinputvalue' => htmlentities(file_get_contents("https://next.webpagetest.org" . $requests[0]['body_url'])),
+                'textinputvalue' => htmlentities(file_get_contents("https://www.webpagetest.org" . $requests[0]['body_url'])),
                 "fullscreenfocus" => true
             ]
         ),

--- a/www/experiments/custom.inc
+++ b/www/experiments/custom.inc
@@ -1,5 +1,9 @@
 <?php
 
+
+
+$requests = $testStepResult->getRequests();
+
 $category = "Custom";
 $assessment[$category]["opportunities"][] = array(
     "title" =>  "Add HTML to document",
@@ -67,6 +71,26 @@ $assessment[$category]["opportunities"][] = array(
     "good" =>  null,
     "inputttext" => true
 );
+
+if( $requests[0]['body_url'] ){
+    $assessment[$category]["opportunities"][] = array(
+        "title" =>  "Edit Response HTML",
+        "desc" =>  "This experiment allows you to freely edit the text of the initial HTML response",
+        "examples" =>  array(),
+        "experiments" =>  array(
+            (object) [
+                'id' => '054',
+                'title' => 'Edit Response HTML',
+                "desc" => '<p>This experiment will replace the initial HTML with the submitted value as if it was served that way initially.</p>',
+                "expvar" => 'editresponsehtml',
+                'textinputvalue' => htmlentities(file_get_contents("https://next.webpagetest.org" . $requests[0]['body_url'])),
+                "fullscreenfocus" => true
+            ]
+        ),
+        "good" =>  null,
+        "inputttext" => true
+    );
+}
 
 
 $assessment[$category]["opportunities"][] = array(

--- a/www/experiments/getExperimentHTML.php
+++ b/www/experiments/getExperimentHTML.php
@@ -1,0 +1,19 @@
+<?php
+require_once '../common.inc';
+use WebPageTest\Util;
+require_once '../include/TestInfo.php';
+$testInfo = json_decode(gz_file_get_contents("../$testPath/testinfo.json.gz"));
+
+if($testInfo && $testInfo->metadata){
+    $recipes = json_decode($testInfo->metadata)->experiment->recipes;
+    $html = "";
+
+    foreach($recipes as $recipe){
+        if( $recipe->{'054'} ){
+            $html = $recipe->{'054'}[0];
+        }
+
+    }
+}
+
+echo $html;

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -1021,6 +1021,10 @@ if (!strlen($error) && CheckIp($test) && CheckUrl($test['url']) && CheckRateLimi
                                 }
                                 $ingredients = implode(",", $ingredients);
                             }
+                            if($recipeSansId === "editresponsehtml"){
+                                // striking out the ingredients here because it's too much to send in a cookie
+                                $ingredients = "";
+                            }
                             // these recipes need encoded values. they all do afterwards! TODO
                             if (
                                 $recipeSansId === "insertheadstart"
@@ -1109,7 +1113,7 @@ if (!strlen($error) && CheckIp($test) && CheckUrl($test['url']) && CheckRateLimi
 
 
                         //replace last step with last step plus recipes
-                        $test['script'] = str_replace($scriptNavigate, "setCookie\t" . $originToUse . "\twpt-experiments=" . urlencode($recipeScript) . "\r\n" . $scriptNavigate, $test['script']);
+                        $test['script'] = str_replace($scriptNavigate, "setCookie\t" . $originToUse . "\twpt-experiments=" . urlencode($recipeScript) . "\r\n" . "setCookie\t" . $originToUse . "\twpt-testid=" . urlencode($id) . "\r\n" . $scriptNavigate, $test['script']);
 
 
                         $id = CreateTest($test, $test['url']);


### PR DESCRIPTION
A proof of concept for review.

This is the experiments page UI to pair with a new Edit HTML Response body experiment. It allows WebPageTest Pro users to freely edit the response HTML of the site being tested, and the experiment runner will deliver that edited HTML directly to the browser as if it was server-generated.

The big advantage here is control over complicated changes to HTML, which is going to be preferable in many cases to running a find and replace experiment.

Here's how it looks in the Opportunities page on any test that has a response body for the initial HTML:
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/214783/212187321-1acb4a60-78a3-44bb-a490-baaf8156f360.png">

Currently at least, on focus, the textarea fills much of the window. We'll need to think about this toggle from an accessibility and usability standpoint, but it's nice for big text edits I think.
<img width="1723" alt="image" src="https://user-images.githubusercontent.com/214783/212187453-91344599-d29b-42cd-a2b6-29d0e00eb89e.png">

This experiment is a bit different than others in that the experiment post data can be quite large, so the experiment runner does not expect to find that posted HTML in the cookie we usually send for experiments, but instead in the test's metadata. There's an endpoint set up in the files of this PR that gets that HTML from the metadata. The experiment proxy fetches that HTML using the test ID that is submitted as a cookie and uses that response as the HTML response.

Here's a result of an experiment that used an completely different HTML source with just an H1 in it:
<img width="1484" alt="image" src="https://user-images.githubusercontent.com/214783/212188209-c2fea5a4-d07d-442d-90af-25844daa950c.png">


Still to-do:
- review experiment post/retrieve workflow to see if it's a good approach for experiments that rely on heavier post data
- limit the experiment proxy to the specific request url instead of any HTML-type request as it currently replaces.
- consider accessibility of textarea expand
- Note: This experiment relies upon a pull request in the experiments repo, so that'll need to merge first.
