### PR TITLE
Counting fix in the insecure requests opp

### DIFF
--- a/www/experiments/insecure-requests.inc
+++ b/www/experiments/insecure-requests.inc
@@ -11,12 +11,13 @@
             array_push($insecureRequests, $request['full_url']);
         }
     }
+    $insecureRequests = array_unique($insecureRequests);
 
     if (count($insecureRequests) > 0) {
         $opp = [
             "title" =>  count($insecureRequests) . " resource" . (count($insecureRequests) > 1 ? "s are" : " is") . " not being loaded over a secure connection.",
             "desc" =>  "Loading requests over HTTPS necessary for ensuring data integrity, protecting users personal information, providing core critical security, and providing access to many new browser features.",
-            "examples" =>  array_unique($insecureRequests),
+            "examples" =>  $insecureRequests,
             "good" =>  false
         ];
     } else {


### PR DESCRIPTION
We're counting requests but reporting resources, so it looks a little confusing when there are duplicate requests.

## before
<img width="713" alt="Screenshot 2023-01-13 at 5 55 39 PM" src="https://user-images.githubusercontent.com/51308/212434141-d8c6cf16-9260-472a-8820-53018c7a73a7.png">

## after
<img width="768" alt="Screenshot 2023-01-13 at 5 55 29 PM" src="https://user-images.githubusercontent.com/51308/212434144-75df0579-ee7a-4d57-aab3-db9993a10988.png">
