### PR TITLE
Fix border in results summary table

### DIFF
--- a/www/include/TestResultsHtmlTables.php
+++ b/www/include/TestResultsHtmlTables.php
@@ -148,10 +148,10 @@ class TestResultsHtmlTables
         }
         $out = "<tr>\n";
 
-        $out .= "<th align=\"left\" valign=\"middle\">\n";
+        $out .= "<td align=\"left\" valign=\"middle\">\n";
         $breakdownUrl = $urlGenerator->resultPage("breakdown");
         $out .= "<a href=\"$breakdownUrl\">Content Breakdown</a>";
-        $out .= "</th>";
+        $out .= "</td>";
 
         $span = $tableColumns - 1;
         $out .= "<td align=\"left\" valign=\"middle\" colspan=\"$span\">";
@@ -213,7 +213,7 @@ class TestResultsHtmlTables
     private function _createResultCell($stepResult, $even)
     {
         $evenClass = $even ? " even" : "";
-        $out = "<th align=\"left\" class='resultCell$evenClass'>\n";
+        $out = "<td align=\"left\" class='resultCell$evenClass'>\n";
         if ($this->isMultistep) {
             $out .= FitText($stepResult->readableIdentifier(), 30);
         } else {
@@ -225,7 +225,7 @@ class TestResultsHtmlTables
         $out .=  $this->_getTraceLinks($stepResult);
         $out .=  $this->_getNetlogLinks($stepResult);
         $out .=  $this->_getDebuglogLinks($stepResult);
-        $out .=  '</th>';
+        $out .=  '</td>';
         return $out;
     }
 


### PR DESCRIPTION
Doesn't feel like a table header

### before
<img width="659" alt="Screenshot 2023-01-20 at 4 56 30 PM" src="https://user-images.githubusercontent.com/51308/213812662-a2442576-a626-4ea9-a601-be3e7b563b50.png">

### after
<img width="445" alt="Screenshot 2023-01-20 at 4 56 17 PM" src="https://user-images.githubusercontent.com/51308/213812664-5788797c-c07a-4335-b11d-1090594e63ec.png">
