### PR TITLE
Timings table update

### DIFF
--- a/www/include/UserTimingHtmlTable.php
+++ b/www/include/UserTimingHtmlTable.php
@@ -29,7 +29,6 @@ class UserTimingHtmlTable
         $this->hasNavTiming = $runResults->hasValidMetric("loadEventStart") ||
                           $runResults->hasValidMetric("domContentLoadedEventStart");
         $this->hasUserTiming = $this->_initUserTimings();
-        $this->hasDomInteractive = $this->runResults->hasValidMetric("domInteractive");
         $this->isMultistep = $runResults->countSteps() > 1;
     }
 
@@ -61,11 +60,8 @@ class UserTimingHtmlTable
         }
         if ($this->hasNavTiming) {
             $out .= "<th>";
-            if ($this->hasDomInteractive) {
-                $out .= "<a href=\"https://w3c.github.io/navigation-timing/#processing-model\">domInteractive</a></th><th>";
-            }
-            $out .= "<a href=\"https://w3c.github.io/navigation-timing/#processing-model\">domContentLoaded</a></th>";
-            $out .= "<th><a href=\"https://w3c.github.io/navigation-timing/#processing-model\">loadEvent</a></th>";
+            $out .= '<a title="The execution time of all `DOMContentLoaded` event listeners" href="https://w3c.github.io/navigation-timing/#processing-model">domContentLoadedEvent</a></th>';
+            $out .= '<th><a title="The execution time of all `onload` event listeners" href="https://w3c.github.io/navigation-timing/#processing-model">loadEvent</a></th>';
         }
         $out .= "</tr>\n";
         return $out;
@@ -95,9 +91,6 @@ class UserTimingHtmlTable
         }
         if ($this->hasNavTiming) {
             $out .= "<td>";
-            if ($this->hasDomInteractive) {
-                $out .= $this->_getTimeMetric($stepResult, "domInteractive") . '</td><td>';
-            }
             $out .= $this->_getTimeRangeMetric($stepResult, 'domContentLoadedEventStart', 'domContentLoadedEventEnd');
             $out .= "</td><td>";
             $out .= $this->_getTimeRangeMetric($stepResult, 'loadEventStart', 'loadEventEnd');

--- a/www/include/UserTimingHtmlTable.php
+++ b/www/include/UserTimingHtmlTable.php
@@ -17,7 +17,6 @@ class UserTimingHtmlTable
     private $isMultistep;
     private $hasNavTiming;
     private $hasUserTiming;
-    private $hasDomInteractive;
 
   /**
    * UserTimingHtmlTable constructor.


### PR DESCRIPTION
* Remove `domInteractive` as it's virtually equivalent to `domContentLoadedEventStart` that's right next to it. Less clutter.
* Rename `domContentLoaded` to `domContentLoadedEvent` to be consistent with `loadEvent` next to it. So the logic for both is that`*Event` stands for W3C timing's `*EventEnd - *EventStart`
* add a `title` for context

## before

<img width="928" alt="Screenshot 2023-01-23 at 3 22 11 PM" src="https://user-images.githubusercontent.com/51308/214142973-7909463d-2026-4888-b26e-777f48798a15.png">

## after

<img width="983" alt="Screenshot 2023-01-23 at 3 21 56 PM" src="https://user-images.githubusercontent.com/51308/214142979-27200b5d-790f-4537-945b-628e9be1244e.png">
