### PR TITLE
fix(account): if renewaldate is empty, don't show

### DIFF
--- a/www/templates/account/billing/update-payment.php
+++ b/www/templates/account/billing/update-payment.php
@@ -31,10 +31,8 @@
                 <li><strong>Estimated Taxes</strong> $<?= $tax ?></li>
                 <li>
                     <strong>Due today:</strong> $0.00
-                    <?php if (isset($renewaldate)) : ?>
                     <br>
-                    <strong>Due at the next billing date (<?= $renewaldate ?> ):</strong> $<?= $total ?>
-                    <?php endif; ?>
+                    <strong>Due at the next billing date<?= isset($renewaldate) && !empty($renewaldate) ? ' (' . $renewaldate . ')' : '' ?>:</strong> $<?= $total ?>
                 </li>
             </ul>
             <div class="info-notice">Updating your account's billing address can result in new tax fees.</div>


### PR DESCRIPTION
This is a little annoying, but really sometimes we don't have this data right up front. So, let them know how much they'll owe on the next billing date, but understand that unless the date is set, we shouldn't show parens or anything like that