### PR TITLE
fix(account): remove upgrade button

### DIFF
--- a/www/src/CPGraphQlTypes/Customer.php
+++ b/www/src/CPGraphQlTypes/Customer.php
@@ -185,6 +185,11 @@ class Customer
         return $this->plan_renewal_date;
     }
 
+    public function isPendingCancelation(): bool
+    {
+        return str_contains($this->status, 'PENDING');
+    }
+
     public function isCanceled(): bool
     {
         return str_contains($this->status, 'CANCEL');

--- a/www/src/Handlers/Account.php
+++ b/www/src/Handlers/Account.php
@@ -888,6 +888,7 @@ class Account
         $is_canceled = $request_context->getUser()->isCanceled();
         $is_expired = $request_context->getUser()->isExpired();
         $is_verified = $request_context->getUser()->isVerified();
+        $is_pending = $request_context->getUser()->isPendingCancelation();
         $is_wpt_enterprise = $request_context->getUser()->isWptEnterpriseClient();
         $user_id = $request_context->getUser()->getUserId();
         $remaining_runs = $request_context->getUser()->getRemainingRuns();
@@ -908,6 +909,7 @@ class Account
         $contact_info = [
             'layout_theme' => 'b',
             'is_paid' => $is_paid,
+            'is_pending' => $is_pending,
             'is_canceled' => $is_canceled,
             'is_expired' => $is_expired,
             'is_verified' => $is_verified,

--- a/www/src/User.php
+++ b/www/src/User.php
@@ -254,6 +254,11 @@ class User
         return $this->payment_status == 'EXPIRED';
     }
 
+    public function isPendingCancelation(): bool
+    {
+        return str_contains($this->payment_status, 'PENDING');
+    }
+
     public function isCanceled(): bool
     {
         return str_contains($this->payment_status, 'CANCEL');

--- a/www/templates/account/includes/subscription-plan.php
+++ b/www/templates/account/includes/subscription-plan.php
@@ -75,7 +75,7 @@
             </label>
         </div>
     </div>
-    <?php else : ?>
+    <?php elseif (!$is_paid || ($is_paid && $is_canceled && $is_pending)) : ?>
     <div class="card-section">
         <div class="account-cta">
             <a href="/account/update_plan" class="pill-button yellow">Upgrade Plan</a>


### PR DESCRIPTION
This button only currently works for users who are pending cancellation.

After official cancellation, users should be changed to free accounts (this is incoming)