### PR TITLE
secondary anon setting for experiments

### DIFF
--- a/www/experiments/user_access.inc
+++ b/www/experiments/user_access.inc
@@ -3,5 +3,5 @@
 use WebPageTest\Util;
 
 // experiments permissions checks
-$experiments_logged_in = Util::getSetting('cp_auth') && (!is_null($request_context->getClient()) && $request_context->getClient()->isAuthenticated());
+$experiments_logged_in = (Util::getSetting('cp_auth') && (!is_null($request_context->getClient()) && $request_context->getClient()->isAuthenticated())) || Util::getSetting('experiments_anon');
 $experiments_paid = (!is_null($request_context->getUser()) && $request_context->getUser()->isPaid()) || ($experiments_logged_in && Util::getSetting('experiments_open'));


### PR DESCRIPTION
This allows us control over experiments access in staging environments and gives us tiers: anon, logged in, or default (paid)