### PR TITLE
fix(test runs): don't count against exempt host

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -2349,7 +2349,10 @@ function LogTest(&$test, $testId, $url)
         server_sync($apiKey, $runcount, null);
         return;
     }
-    $runcount = Util::getRunCount($test['runs'], $test['fvonly'], $test['lighthouse'], $test['type']);
+
+    $host = parse_url($url, PHP_URL_HOST);
+    $exempt_host = parse_url(Util::getExemptHost(), PHP_URL_HOST);
+    $runcount = ($host == $exempt_host) ? 0 : Util::getRunCount($test['runs'], $test['fvonly'], $test['lighthouse'], $test['type']);
 
     if (!is_dir('./logs')) {
         mkdir('./logs', 0777, true);

--- a/www/src/Util.php
+++ b/www/src/Util.php
@@ -747,9 +747,9 @@ class Util
     /**
      * This is used to determine which hosts don't get counted in test runs
      */
-    public static function getExemptHost(): string
+    public static function getExemptHost(?string $default = ""): string
     {
-        return 'webpagetest.org';
+        return self::getSetting('exempt_from_test_run_count_host', $default);
     }
 
     /**


### PR DESCRIPTION
We like people to be able to test features against things like The Metric Times. This helps!