### PR TITLE
Traceroute Broken Link Fix

### DIFF
--- a/www/header.inc
+++ b/www/header.inc
@@ -102,15 +102,24 @@ if (!strcasecmp('Test Result', $tab) && (!isset($nosubheader) || !@$nosubheader)
         // for multistep, link the first URL and show additional text. Otherwise take the test URL
         $numSteps = $gradeRunResults->countSteps();
         $showUrl = $numSteps > 1 || !$url ? $gradeRunResults->getStepResult(1)->getUrl() : $url;
-        $shortUrl = str_replace('http://', '', FitText($showUrl, 180));
-        $shortUrl = $numSteps > 1 ? ($shortUrl . " ($numSteps steps)") : $shortUrl;
         echo "<ul class=\"header_data_urltime\">";
 
-        echo "<li><strong>URL: </strong>";
+        if($test['testinfo']['type'] === "traceroute"){
+            $showUrl = "http://" . $showUrl;
+            echo "<li><strong>HOST/IP: </strong>";
+        }else{
+            echo "<li><strong>URL: </strong>";
+        }
+        
+        $shortUrl = str_replace('http://', '', FitText($showUrl, 180));
+        $shortUrl = $numSteps > 1 ? ($shortUrl . " ($numSteps steps)") : $shortUrl;
+        
+
+        
         if (GetSetting('nolinks')) {
             echo "<span class=\"page-tested\">$shortUrl</span>";
         } else {
-            echo "<a class=\"url\"  rel=\"nofollow\" title=\"$showUrl\" href=\"$showUrl\">$shortUrl</a>";
+            echo "<a class=\"url\"  rel=\"nofollow\" title=\"$showUrl\" href=\"$showUrl\" target=\"_blank\">$shortUrl</a>";
         }
         echo "</li>";
         echo "<li><strong>Date: </strong>";

--- a/www/running.inc
+++ b/www/running.inc
@@ -51,13 +51,16 @@
                 if (GetSetting('nolinks')) {
                     echo "URL: $url<br>\n";
                 } else {
-                    echo "URL: <a rel=\"nofollow\" href=\"$url\">$url</a><br>\n";
+                    if($test['testinfo']['type'] === "traceroute"){
+                        echo "Host/IP: <a rel=\"nofollow\" href=\"http://$url\" target=\"_blank\">$url</a><br>\n";
+                    }else{
+                        echo "URL: <a rel=\"nofollow\" href=\"$url\" target=\"_blank\">$url</a><br>\n";
+                    }   
                 }
                     echo "From: {$test['test']['location']}<br>\n";
                     echo GetTestInfoHtml(false);
                 ?>
                 </p>
-
 
                 <?php
                 $statusText = $status['statusText'];


### PR DESCRIPTION
Broken Links in traceroute test on header.inc & running.inc
<img width="500" alt="image" src="https://user-images.githubusercontent.com/70441430/215766879-9f3a3621-b6ec-4d2d-a533-c6e4aab8ff59.png">

After PR:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/70441430/215767218-ac5faac2-8962-4eea-9007-2fa27df5c086.png">

