### PR TITLE
Added isset and is_array checks in FilterLocations

### DIFF
--- a/www/common_lib.inc
+++ b/www/common_lib.inc
@@ -774,7 +774,9 @@ function FilterLocations(&$locations, $includeHidden = '',
           unset($locations[$name]);
         }
       }
-      unset($locRef['hidden']);
+      if (isset($locRef) && is_array($locRef)) {
+        unset($locRef['hidden']);
+      }
 
       // see if the location is restricted
       if (isset($locations[$name]) && isset($locRef['restricted'])) {


### PR DESCRIPTION
When working with PHP 8.1 the page was crashing because we were calling `unset` on `$locRef` even if it was not set. On PHP 7 the page works fine.

The solution is copied from the `master` branch but is not included in the `release` branch.

(the `release` branch is used by https://github.com/WPO-Foundation/wptserver-install/blob/master/ubuntu.sh#L7)