### PR TITLE
fix(ownership): creators are owners, too

### DIFF
--- a/www/common.inc
+++ b/www/common.inc
@@ -387,11 +387,17 @@ if (strlen($id)) {
             $testDate = strftime('%x %X', (int)$test['testinfo']['completed'] + ($tz_offset * 60));
         }
 
+        $creator_id = 0;
+        if (!is_null($request_context->getUser())) {
+            $creator_id = $request_context->getUser()->getUserId() ?? 0;
+        }
+
         // $owner is set by CP details in AttachUser middleware if loaded
         $owner_id_matches_test = array_key_exists('owner', $test['testinfo']) && strlen($owner) && $owner == $test['testinfo']['owner'];
         $uid_matches_test = array_key_exists('uid', $test['testinfo']) && isset($uid) && strlen($uid) && $uid == $test['testinfo']['uid'];
+        $creator_id_matches_test = array_key_exists('creator', $test['testinfo']) && ($creator_id == $test['testinfo']['creator']);
 
-        $isOwner = $owner_id_matches_test || $uid_matches_test;
+        $isOwner = $owner_id_matches_test || $uid_matches_test || $creator_id_matches_test;
         $test_is_private = array_key_exists('private', $test['testinfo']) && !!$test['testinfo']['private'];
 
         if ($test_is_private && !$isOwner) {

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -835,6 +835,14 @@ if (!empty($user_api_key)) {
     $test['owner'] = $request_context->getUser()->getOwnerId();
 }
 
+$creator_id = 0;
+if (!is_null($request_context->getUser())) {
+    $creator_id = $request_context->getUser()->getUserId() ?? 0;
+}
+if ($creator_id != 0) {
+    $test["creator"] = $creator_id;
+}
+
 if (isset($user) && !array_key_exists('user', $test)) {
     $test['user'] = $user;
 }
@@ -2741,6 +2749,9 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
         }
         if (isset($test['owner']) && strlen($test['owner'])) {
             AddIniLine($testInfo, "owner", $test['owner']);
+        }
+        if (!empty($test["creator"])) {
+            AddIniLine($testInfo, "creator", $test["creator"]);
         }
         if (isset($test['type']) && strlen($test['type'])) {
             AddIniLine($testInfo, "type", $test['type']);


### PR DESCRIPTION
Previously, only owners were owners, but also sometimes the creator of
the test does not line up as the owner. This is a fix for that

Relies on this: https://github.com/WPO-Foundation/webpagetest/pull/2719