### PR TITLE
Crux redesign 

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -5599,8 +5599,8 @@ table.details td.reqMime {
   flex-wrap: wrap;
   justify-content: space-between;
   width: 100%;
-  margin: 1rem 0 3rem 0;
-  padding: 0 0 3rem;
+  margin: 1rem 0 1rem 0;
+  padding: 0;
   gap: 3rem;
   text-align: center;
 }
@@ -5704,110 +5704,159 @@ table.details td.reqMime {
 }
 
 .cruxbars {
-  margin: 0;
-  z-index: 1;
-  padding: inherit;
-  text-align: left;
   display: flex;
-  justify-content: flex-start;
+  gap: 2rem;
+  flex-flow: row wrap;
+  justify-content: space-between;
 }
-
-.cruxlabel .legend {
-  font-size: smaller;
-  font-weight: normal;
+.cruxbars div.crux_metric {
+  flex: 1 0 30%;
+  margin: 0;
 }
-
-.cruxlabel .fvarrow {
-  color: #1a1a1a;
-}
-
-/* these are for crux embeds */
-
-.cruxembed .cruxbars {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.5rem;
-}
-
-@media (min-width: 30em) {
-  .cruxembed .cruxbars {
-    grid-template-columns: 1fr 1fr;
+@media (max-width: 80em) {
+  .cruxbars div.crux_metric {
+    flex: 1 0 40%;
   }
 }
+.crux_subhed {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: .5em;
+  margin-bottom: 1.5em;
+  border-bottom: 1px solid #eee;
+  gap: 2em;
+}
 
-@media (min-width: 60em) {
-  .cruxembed .cruxbars {
-    grid-template-columns: repeat(8, 1fr);
+.crux_subhed p {
+  font-size: .9em;
+  margin: 0;
+  line-height: 1.4;
+  color: #444;
+}
+.crux_subhed p.crux_subhed_cite {
+  font-size: .9em;
+  color: #8B8B8B;
+  font-style: normal;
+}
+@media (max-width: 50em) {
+  .cruxbars div.crux_metric {
+    flex: 1 0 100%;
   }
-
-  .cruxembed .cruxbars svg {
-    grid-column: span 2;
+  .crux_subhed {
+    display: block;
   }
-
-  .cruxembed .cruxbars svg:last-child:nth-child(4n - 1) {
-    grid-column-end: -3;
-  }
-
-  .cruxembed .cruxbars svg:nth-last-child(2):nth-child(4n + 1) {
-    grid-column-end: 5;
+  .crux_subhed p {
+    margin: .5em 0;
   }
 }
-
-.summary-container .crux h3 {
-  font-size: 1.2rem;
-  color: #2a3c64;
-  margin: 2em 0 0;
-}
-
-.summary-container .crux h3 em {
-  display: block;
-  font-size: 0.7em;
-  margin: 0.4em 0;
-  line-height: 1.5;
-}
-
-.cruxembed .crux h3 {
-  margin-top: 2rem;
-}
-
-.crux_legends {
-  display: inline-flex;
-  gap: 0.5rem;
-  border: 1px solid #eee;
-  padding: 0.7em 1.5em 0;
-  border-radius: 1rem;
-  margin: 1em 0;
-}
-
-.crux_legends strong {
-  background: none;
-  border: 0px solid #fff;
-  font-weight: 700;
+h4.crux_metric_title {
+  font-size: .9em;
+  font-weight: 900;
   color: #686868;
-  font-size: 0.9em;
-  min-height: 2em;
-}
-
-.summary-container .crux_legends {
-  display: inline-block;
-  padding: 0.3em 1em;
+  white-space: nowrap;
   margin: 0;
 }
 
-.cruxembed .crux .legend {
-  font-size: smaller;
-  font-weight: normal;
-  margin: 0 0 1em;
-  display: block;
-  text-align: right;
+.crux_metric_value {
+  border: 0 solid #fff;
+  display:block;
+  padding: 0 0 0;
+  margin: 0;
+  font-size: 2.2em;
+  font-weight: 900;
+  border-top-width: 0;
+  color: #2a3c64;
+  -webkit-text-stroke: 0.04em currentColor;
+  line-height: 1;
+}
+.crux_metric_value-good {
+  color: #6ca71a;
+}
+.crux_metric_value-fair {
+  color: #d48e08;
+}
+.crux_metric_value-poor {
+  color: #d02424;
+}
+.crux_metric_value em {
+  font-size: .5em;
+  font-weight: 200;
+  text-transform: capitalize;
+  font-style: normal;
+}
+.crux_metric_desc {
+  font-size: .75em;
+  margin: 0 0 .8em;
+  color: #666;
+}
+.crux_bars {
+  display: flex;
+  position: relative;
+}
+.crux_bars:before,
+.crux_bars:after {
+  content: "";
+  width: 0;
+  height: 0;
+  border-top: 10px solid #fff;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  margin-top: -4px;
+  position: absolute;
+  left: calc(75% - 5px);
+}
+.crux_bars:after {
+  border-top: 8px solid #2a3b64;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  left: calc(75% - 3px);
+  margin-top: -5px;
+}
+.crux_bars li {
+  flex: 0 0 0;
+  color: #fff;
+  padding: .2em 0em;
+  box-sizing: border-box;
+  font-size: .8em;
+  overflow: hidden;
+  text-indent: 1em;
+}
+.crux_bars li.crux_bars-hidelabel {
+  text-indent: -999px;
+}
+.crux_bars-good {
+  background:#6ca71a;
+}
+.crux_bars-fair {
+  background: #d48e08;
+}
+.crux_bars-poor {
+  background: #d02424;
+}
+.crux details.metrics_shown {
+  position: relative;
+  top: auto;
+  right: auto;
+  left: auto;
+  display: inline-block;
+  margin: .5em 0 0;
+}
+.crux details.metrics_shown span.units {
+  color: inherit;
+}
+.crux_diff {
+  font-size: .9em;
+  font-style: normal;
+  margin: .5em 0 0;
+  color: #666;
 }
 
-.cruxembed .crux .fvarrow {
-  color: #1072ba;
+.crux_diff span.units {
+  font-weight: 500;
+  padding-left: 0;
 }
-
-.cruxembed .crux .rvarrow {
-  color: #5dbbe8;
+.crux details.metrics_shown {
+  margin: 2em 0 0;
 }
 
 /* end vitals page styles */
@@ -6575,8 +6624,7 @@ table#tableResults td.ok {
   color: #d48e08;
 }
 
-table.pretty td.poor,
-table#tableResults td.poor {
+table.pretty td.poor, table#tableResults td {
   color: #d02424;
 }
 

--- a/www/details.php
+++ b/www/details.php
@@ -153,14 +153,12 @@ function createForm($formName, $btnText, $id, $owner, $secret)
                     ]);
                 }
 
-                if (isset($testRunResults)) {
+                if (isset($testRunResults) && !$cached) {
                     echo '<div class="cruxembed">';
                     require_once(INCLUDES_PATH . '/include/CrUX.php');
-                    if ($cached) {
-                        InsertCruxHTML(null, $testRunResults);
-                    } else {
-                        InsertCruxHTML($testRunResults, null);
-                    }
+                    
+                    InsertCruxHTML($testRunResults, null);
+                    
                     echo '</div>';
                 }
                 ?>

--- a/www/details.php
+++ b/www/details.php
@@ -156,9 +156,9 @@ function createForm($formName, $btnText, $id, $owner, $secret)
                 if (isset($testRunResults) && !$cached) {
                     echo '<div class="cruxembed">';
                     require_once(INCLUDES_PATH . '/include/CrUX.php');
-                    
+
                     InsertCruxHTML($testRunResults, null);
-                    
+
                     echo '</div>';
                 }
                 ?>

--- a/www/include/CrUX.php
+++ b/www/include/CrUX.php
@@ -163,6 +163,16 @@ function InsertCruxHTML($fvRunResults, $rvRunResults, $metric = '', $includeLabe
             <summary><strong>Note:</strong> Why can real browser usage metrics vary from test run metrics?</summary>
             <p>Variance between your test run and real world usage is expected because a WebPageTest run uses a specific connection speed, and real world data spans all connection speeds. To closely match the p75 user in WebPageTest, try rerunning your test using a different connection speed.</p>
             </details>';
+        echo <<<EOD
+        <script>
+        let cruxContain = document.querySelector(".crux");
+        cruxContain.addEventListener("click", (e) => {
+            if( e.target && e.target.closest("a[href='#crux_diff_why'") ){
+                document.getElementById("crux_diff_why").open = true;
+            }
+        });
+        </script>
+        EOD;
 
         echo '</div>';
     }

--- a/www/include/CrUX.php
+++ b/www/include/CrUX.php
@@ -78,6 +78,11 @@ function PruneCruxCache()
 // returns a string of the Real User Measurement title for results.php if CrUX has collectionPeriod
 function RealUserMeasurementCruxTitle($pageData)
 {
+
+    $ret = '<h3 class="hed_sub">Real-World Usage Metrics</h3><div class="crux_subhed"><p class="crux_subhed_desc">Compare this WebPageTest run with browser-collected performance data for this site.</p>';
+
+    $cruxOrigin = $pageData['CrUX']['key']['url'];
+    $cruxStudioURL = "https://lookerstudio.google.com/reporting/bbc5698d-57bb-4969-9e07-68810b9fa348/page/keDQB?params=%7B%22origin%22:%22". urlencode($cruxOrigin) ."%22%7D";
     if (
         isset($pageData['CrUX']['collectionPeriod']) &&
         isset($pageData['CrUX']['collectionPeriod']['firstDate']) &&
@@ -88,16 +93,12 @@ function RealUserMeasurementCruxTitle($pageData)
         $startDate = date('F j\, Y', mktime(0, 0, 0, $firstDate['month'], $firstDate['day'], $firstDate['year']));
         $endDate = date('F j\, Y', mktime(0, 0, 0, $lastDate['month'], $lastDate['day'], $lastDate['year']));
         // Example: Real User Measurements (Collected anonymously by Chrome browser via Chrome User Experience Report, between October 15, 2022 and September 18, 2022)
-        return sprintf('<h3 class="hed_sub">
-                            Real User Measurements
-                            <em>(Collected anonymously by Chrome browser via Chrome User Experience Report, between %s and %s)</em>
-                        </h3>', $startDate, $endDate);
+        $ret .= sprintf('<p class="crux_subhed_cite">(Collected anonymously by Chrome browser from %s to %s | <a href="%s">Full Report</a>)</p>', $startDate, $endDate, $cruxStudioURL);
     } else {
-        return '<h3 class="hed_sub">
-                    Real User Measurements
-                    <em>(Collected anonymously by Chrome browser via Chrome User Experience Report)</em>
-                </h3>';
+        $ret .= sprintf('<p class="crux_subhed_cite">(Collected anonymously by Chrome browser | <a href="%s">Full Report</a>)</p>', $cruxStudioURL);
     }
+    $ret .= "</div>";
+    return $ret;
 }
 
 function InsertCruxHTML($fvRunResults, $rvRunResults, $metric = '', $includeLabels = true, $includeMetricName = true)
@@ -111,15 +112,7 @@ function InsertCruxHTML($fvRunResults, $rvRunResults, $metric = '', $includeLabe
             $pageData = $stepResult->getRawResults();
         }
     }
-    if (isset($rvRunResults)) {
-        $stepResult = $rvRunResults->getStepResult(1);
-        if ($stepResult) {
-            $rvPageData = $stepResult->getRawResults();
-            if (!isset($pageData) && isset($rvPageData) && isset($rvPageData['CrUX'])) {
-                $pageData = array('CrUX' => $rvPageData['CrUX']);
-            }
-        }
-    }
+    
     if (
         isset($pageData) &&
         is_array($pageData) &&
@@ -133,55 +126,49 @@ function InsertCruxHTML($fvRunResults, $rvRunResults, $metric = '', $includeLabe
         }
         echo '<div class="crux">';
         echo RealUserMeasurementCruxTitle($pageData);
-        echo '<div class="crux_legends"><strong>Metrics from this run:</strong>';
-        if (isset($pageData) && (isset($pageData['chromeUserTiming.firstContentfulPaint']) || isset($pageData['chromeUserTiming.LargestContentfulPaint']) || isset($pageData['chromeUserTiming.CumulativeLayoutShift']))) {
-            echo ' &nbsp;<span class="legend"><span class="fvarrow">&#x25BC</span> ';
-            if ($includeLabels) {
-                echo "First View";
-            }
-            echo '</span>';
-        }
-        if (isset($rvPageData) && (isset($rvPageData['chromeUserTiming.firstContentfulPaint']) || isset($rvPageData['chromeUserTiming.LargestContentfulPaint']) || isset($rvPageData['chromeUserTiming.CumulativeLayoutShift']))) {
-            echo ' &nbsp;<span class="legend"><span class="rvarrow">&#x25BC</span>';
-            if ($includeLabels) {
-                echo "Repeat View";
-            }
-            echo '</span>';
-        }
-        echo '</div>';
 
 
         // The individual metrics
         echo '<div class="cruxbars">';
         if ($metric == '') {
             //show all
-            InsertCruxMetricHTML($pageData, $rvPageData, 'chromeUserTiming.firstContentfulPaint', 'first_contentful_paint', 'First Contentful Paint', 'FCP', $includeMetricName);
-            InsertCruxMetricHTML($pageData, $rvPageData, 'chromeUserTiming.LargestContentfulPaint', 'largest_contentful_paint', 'Largest Contentful Paint', 'LCP', $includeMetricName);
-            InsertCruxMetricHTML($pageData, $rvPageData, 'chromeUserTiming.CumulativeLayoutShift', 'cumulative_layout_shift', 'Cumulative Layout Shift', 'CLS', $includeMetricName);
-            InsertCruxMetricHTML($pageData, $rvPageData, null, 'first_input_delay', 'First Input Delay', 'FID', $includeMetricName);
-            InsertCruxMetricHTML($pageData, $rvPageData, 'TTFB', 'experimental_time_to_first_byte', 'Time to First Byte', 'TTFB', $includeMetricName);
-            InsertCruxMetricHTML($pageData, $rvPageData, null, 'experimental_interaction_to_next_paint', 'Interaction to Next Paint', 'INP', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.firstContentfulPaint', 'first_contentful_paint', 'First Contentful Paint', 'FCP', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.LargestContentfulPaint', 'largest_contentful_paint', 'Largest Contentful Paint', 'LCP', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.CumulativeLayoutShift', 'cumulative_layout_shift', 'Cumulative Layout Shift', 'CLS', $includeMetricName);
+            InsertCruxMetricHTML($pageData, null, 'first_input_delay', 'First Input Delay', 'FID', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'TTFB', 'experimental_time_to_first_byte', 'Time to First Byte', 'TTFB', $includeMetricName);
+            InsertCruxMetricHTML($pageData, null, 'experimental_interaction_to_next_paint', 'Interaction to Next Paint', 'INP', $includeMetricName);
         } elseif ($metric == 'fcp') {
-            InsertCruxMetricHTML($pageData, $rvPageData, 'chromeUserTiming.firstContentfulPaint', 'first_contentful_paint', 'First Contentful Paint', 'FCP', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.firstContentfulPaint', 'first_contentful_paint', 'First Contentful Paint', 'FCP', $includeMetricName);
         } elseif ($metric == 'lcp') {
-            InsertCruxMetricHTML($pageData, $rvPageData, 'chromeUserTiming.LargestContentfulPaint', 'largest_contentful_paint', 'Largest Contentful Paint', 'LCP', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.LargestContentfulPaint', 'largest_contentful_paint', 'Largest Contentful Paint', 'LCP', $includeMetricName);
         } elseif ($metric == 'cls') {
-            InsertCruxMetricHTML($pageData, $rvPageData, 'chromeUserTiming.CumulativeLayoutShift', 'cumulative_layout_shift', 'Cumulative Layout Shift', 'CLS', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.CumulativeLayoutShift', 'cumulative_layout_shift', 'Cumulative Layout Shift', 'CLS', $includeMetricName);
         } elseif ($metric == 'fid') {
-            InsertCruxMetricHTML($pageData, $rvPageData, null, 'first_input_delay', 'First Input Delay', 'FID', $includeMetricName);
+            InsertCruxMetricHTML($pageData, null, 'first_input_delay', 'First Input Delay', 'FID', $includeMetricName);
         } elseif ($metric == 'ttfb') {
-            InsertCruxMetricHTML($pageData, $rvPageData, 'TTFB', 'experimental_time_to_first_byte', 'Time to First Byte', 'TTFB', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'TTFB', 'experimental_time_to_first_byte', 'Time to First Byte', 'TTFB', $includeMetricName);
         } elseif ($metric == 'inp') {
-            InsertCruxMetricHTML($pageData, $rvPageData, null, 'experimental_interaction_to_next_paint', 'Interaction to Next Paint', 'INP', $includeMetricName);
+            InsertCruxMetricHTML($pageData, null, 'experimental_interaction_to_next_paint', 'Interaction to Next Paint', 'INP', $includeMetricName);
+        } elseif ($metric == 'cwv') {
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.LargestContentfulPaint', 'largest_contentful_paint', 'Largest Contentful Paint', 'LCP', $includeMetricName);
+            InsertCruxMetricHTML($pageData, 'chromeUserTiming.CumulativeLayoutShift', 'cumulative_layout_shift', 'Cumulative Layout Shift', 'CLS', $includeMetricName);
+            InsertCruxMetricHTML($pageData, null, 'first_input_delay', 'First Input Delay', 'FID', $includeMetricName);
         }
 
+
         echo '</div>';
+
+        echo '<details class="metrics_shown" id="crux_diff_why">
+            <summary><strong>Note:</strong> Why can real browser usage metrics vary from test run metrics?</summary>
+            <p>Variance between your test run and real world usage is expected because a WebPageTest run uses a specific connection speed, and real world data spans all connection speeds. To closely match the p75 user in WebPageTest, try rerunning your test using a different connection speed.</p>
+            </details>';
 
         echo '</div>';
     }
 }
 
-function InsertCruxMetricHTML($fvPageData, $rvPageData, $metric, $crux_metric, $label, $short, $includeLabels = true)
+function InsertCruxMetricHTML($fvPageData, $metric, $crux_metric, $label, $short, $includeLabels = true)
 {
     $fvValue = null;
     $rvValue = null;
@@ -198,90 +185,88 @@ function InsertCruxMetricHTML($fvPageData, $rvPageData, $metric, $crux_metric, $
     }
     if (isset($fvPageData['CrUX']['metrics'][$crux_metric]['percentiles']['p75'])) {
         $p75 = $fvPageData['CrUX']['metrics'][$crux_metric]['percentiles']['p75'];
+        $p75Score = "good";
+        if($p75 >=  $histogram[0]['end'] ){
+            $p75Score = "fair";
+        }
+        if($p75 >=  $histogram[1]['end']){
+            $p75Score = "poor";
+        }
     }
     if (isset($histogram) && is_array($histogram) && count($histogram) == 3) {
-        InsertCruxMetricImage($label, $short, $histogram, $p75, $fvValue, $rvValue, $includeLabels);
+        InsertCruxMetricImage($label, $short, $histogram, $p75, $fvValue, $rvValue, $includeLabels, $p75Score);
     }
 }
 
-function InsertCruxMetricImage($label, $short, $histogram, $p75, $fvValue, $rvValue, $includeLabels = true)
+
+
+function InsertCruxMetricImage($label, $short, $histogram, $p75, $fvValue, $rvValue, $includeLabels = true, $p75Score)
 {
-    // Figure out offsets and adjustments to the svg
-    $width = 200;
+    
     if (is_float($p75)) {
         $p75 = round($p75, 3);
-    }
-    if (is_float($fvValue)) {
-        $fvValue = round($fvValue, 3);
+
     }
     $goodPct = intval(round($histogram[0]['density'] * 100));
     $fairPct = intval(round($histogram[1]['density'] * 100));
     $poorPct = intval(round($histogram[2]['density'] * 100));
-    $poorStart = $goodPct + $fairPct;
-    $poorPct = 100 - $poorStart;
-    $goodText = '';
-    if ($goodPct >= 7) {
-        $pos = $goodPct / 2;
-        $goodText = "<text x='$pos%' y='16' text-anchor='middle' font-size='12' font-family='Open Sans, sans-serif' fill='white'>$goodPct%</text>";
+    $goodClass = $goodPct < 10 ? " crux_bars-hidelabel" : "";
+    $fairClass = $fairPct < 10 ? " crux_bars-hidelabel" : "";
+    $poorClass = $poorPct < 10 ? " crux_bars-hidelabel" : "";
+    $metricDiff = '';
+
+    $metricDiff = '<p class="crux_diff">Field metric only, no WPT test run data.</p>';
+
+
+    if( isset($fvValue) ){
+
+        if (is_float($fvValue)) {
+            $fvValue = round($fvValue, 3);
+        }
+        if( $p75 === $fvValue ){
+            $metricDiff = '<p class="crux_diff">Same result as this WPT run.</p>';
+        }
+
+        if( $p75 !== $fvValue ){
+            $absMetricDiff = abs($p75 - $fvValue);
+
+            if($short !== 'CLS'){
+                $absMetricDiff = formatMsInterval($absMetricDiff, 2);
+            }
+            
+            $wptCompare = "better";
+            $cruxCompare = "worse";
+            if( $p75 < $fvValue ){
+                $wptCompare = "worse";
+                $cruxCompare = "better";
+            }
+            if($short !== 'CLS'){
+                $fvValue = formatMsInterval($fvValue, 2);
+            }
+            $metricDiff = <<<EOD
+            <p class="crux_diff">$absMetricDiff $cruxCompare than this WPT test run's first view ($fvValue). <a href="#crux_diff_why"> Why?</a></p>
+        EOD;
+        }
     }
-    $fairText = '';
-    if ($fairPct >= 7) {
-        $pos = $goodPct + ($fairPct / 2);
-        $fairText = "<text x='$pos%' y='16' text-anchor='middle' font-size='12' font-family='Open Sans, sans-serif' fill='black'>$fairPct%</text>";
+
+
+    if($short !== 'CLS'){
+        $p75 = formatMsInterval($p75, 2);
     }
-    $poorText = '';
-    if ($poorPct >= 7) {
-        $pos = $goodPct + $fairPct + ($poorPct / 2);
-        $poorText = "<text x='$pos%' y='16' text-anchor='middle' font-size='12' font-family='Open Sans, sans-serif' fill='white'>$poorPct%</text>";
-    }
-    $p75arrow = '';
-    $p75text = '';
-    $maxVal = max($p75, $fvValue, $rvValue);
-    $unit = $short === 'CLS' ? '' : ' ms';
-    if (isset($p75)) {
-        $pos = 5 + GetCruxValuePosition($p75, $maxVal, $histogram, $width, $color);
-        $start = $pos - 5;
-        $end = $pos + 5;
-        $p75arrow = "<svg x='5' width='250' y='55' height='15'><polygon points='$start,10 $pos,0 $end,10' fill='$color'/></svg>";
-        $text = "p75 ($p75$unit)";
-        $anchor = $pos < 90 ? 'start' : 'end';
-        $textPos = $pos < 90 ? $pos + 12 : $pos - 5;
-        $p75text = "<text x='$textPos' y='67' font-size='12' text-anchor='$anchor' font-family='Open Sans, sans-serif'>$text</text>";
-    }
-    $fvArrow = '';
-    if (isset($fvValue)) {
-        $pos = 5 + GetCruxValuePosition($fvValue, $maxVal, $histogram, $width, $color);
-        $start = $pos - 5;
-        $end = $pos + 5;
-        $fvArrow = "<svg x='5' width='250' y='15' height='15'><polygon points='$start,5 $pos,15 $end,5' fill='#1072ba'><title>$fvValue$unit</title></polygon></svg>";
-    }
-    $rvArrow = '';
-    if (isset($rvValue)) {
-        $pos = 5 + GetCruxValuePosition($rvValue, $maxVal, $histogram, $width, $color);
-        $start = $pos - 5;
-        $end = $pos + 5;
-        $rvArrow = "<svg x='5' width='250' y='15' height='15'><polygon points='$start,5 $pos,15 $end,5' fill='#5dbbe8'><title>$rvValue$unit</title></polygon></svg>";
-    }
-    $image_width = $width + 20;
+    
     $svg = <<<EOD
-<svg viewBox="0 0 $image_width 80" version='1.1' xmlns='http://www.w3.org/2000/svg'>
-<svg x='10' width='$width' y='30' height='25'>
-    <rect x='0' width='100%' height='100%' fill='#009316'><title>$goodPct%</title></rect>
-    <rect x='$goodPct%' width='100%' height='100%' fill='#ffa400'><title>$fairPct%</title></rect>
-    <rect x='$poorStart%' width='100%' height='100%' fill='#ff4e42'><title>$poorPct%</title></rect>
-    $goodText
-    $fairText
-    $poorText
-</svg>
-$p75arrow
-$rvArrow
-$fvArrow
-$p75text
+<div class="crux_metric">
+<h4 class="crux_metric_title">$label ($short)</h4>
+<p class="crux_metric_value crux_metric_value-$p75Score">$p75 <em>($p75Score)</em></p>
+<p class="crux_metric_desc">At 75th percentile of visits.</p>
+<ul class="crux_bars">
+    <li class="crux_bars-good$goodClass" style="flex-basis: $goodPct%">$goodPct%</li>
+    <li class="crux_bars-fair$fairClass" style="flex-basis: $fairPct%">$fairPct%</li>
+    <li class="crux_bars-poor$poorClass" style="flex-basis: $poorPct%">$poorPct%</li>
+</ul>
+$metricDiff
+</div>
 EOD;
-    if ($includeLabels) {
-        $svg .= "<text x='100' y='16' font-size='13' text-anchor='middle' font-family='Open Sans, sans-serif'>$label ($short)</text>";
-    }
-    $svg .= '</svg>';
     echo $svg;
 }
 

--- a/www/include/CrUX.php
+++ b/www/include/CrUX.php
@@ -82,7 +82,7 @@ function RealUserMeasurementCruxTitle($pageData)
     $ret = '<h3 class="hed_sub">Real-World Usage Metrics</h3><div class="crux_subhed"><p class="crux_subhed_desc">Compare this WebPageTest run with browser-collected performance data for this site.</p>';
 
     $cruxOrigin = $pageData['CrUX']['key']['url'];
-    $cruxStudioURL = "https://lookerstudio.google.com/reporting/bbc5698d-57bb-4969-9e07-68810b9fa348/page/keDQB?params=%7B%22origin%22:%22". urlencode($cruxOrigin) ."%22%7D";
+    $cruxStudioURL = "https://lookerstudio.google.com/reporting/bbc5698d-57bb-4969-9e07-68810b9fa348/page/keDQB?params=%7B%22origin%22:%22" . urlencode($cruxOrigin) . "%22%7D";
     if (
         isset($pageData['CrUX']['collectionPeriod']) &&
         isset($pageData['CrUX']['collectionPeriod']['firstDate']) &&
@@ -112,7 +112,7 @@ function InsertCruxHTML($fvRunResults, $rvRunResults, $metric = '', $includeLabe
             $pageData = $stepResult->getRawResults();
         }
     }
-    
+
     if (
         isset($pageData) &&
         is_array($pageData) &&
@@ -186,10 +186,10 @@ function InsertCruxMetricHTML($fvPageData, $metric, $crux_metric, $label, $short
     if (isset($fvPageData['CrUX']['metrics'][$crux_metric]['percentiles']['p75'])) {
         $p75 = $fvPageData['CrUX']['metrics'][$crux_metric]['percentiles']['p75'];
         $p75Score = "good";
-        if($p75 >=  $histogram[0]['end'] ){
+        if ($p75 >=  $histogram[0]['end']) {
             $p75Score = "fair";
         }
-        if($p75 >=  $histogram[1]['end']){
+        if ($p75 >=  $histogram[1]['end']) {
             $p75Score = "poor";
         }
     }
@@ -202,10 +202,9 @@ function InsertCruxMetricHTML($fvPageData, $metric, $crux_metric, $label, $short
 
 function InsertCruxMetricImage($label, $short, $histogram, $p75, $fvValue, $rvValue, $includeLabels = true, $p75Score)
 {
-    
+
     if (is_float($p75)) {
         $p75 = round($p75, 3);
-
     }
     $goodPct = intval(round($histogram[0]['density'] * 100));
     $fairPct = intval(round($histogram[1]['density'] * 100));
@@ -218,29 +217,28 @@ function InsertCruxMetricImage($label, $short, $histogram, $p75, $fvValue, $rvVa
     $metricDiff = '<p class="crux_diff">Field metric only, no WPT test run data.</p>';
 
 
-    if( isset($fvValue) ){
-
+    if (isset($fvValue)) {
         if (is_float($fvValue)) {
             $fvValue = round($fvValue, 3);
         }
-        if( $p75 === $fvValue ){
+        if ($p75 === $fvValue) {
             $metricDiff = '<p class="crux_diff">Same result as this WPT run.</p>';
         }
 
-        if( $p75 !== $fvValue ){
+        if ($p75 !== $fvValue) {
             $absMetricDiff = abs($p75 - $fvValue);
 
-            if($short !== 'CLS'){
+            if ($short !== 'CLS') {
                 $absMetricDiff = formatMsInterval($absMetricDiff, 2);
             }
-            
+
             $wptCompare = "better";
             $cruxCompare = "worse";
-            if( $p75 < $fvValue ){
+            if ($p75 < $fvValue) {
                 $wptCompare = "worse";
                 $cruxCompare = "better";
             }
-            if($short !== 'CLS'){
+            if ($short !== 'CLS') {
                 $fvValue = formatMsInterval($fvValue, 2);
             }
             $metricDiff = <<<EOD
@@ -250,10 +248,10 @@ function InsertCruxMetricImage($label, $short, $histogram, $p75, $fvValue, $rvVa
     }
 
 
-    if($short !== 'CLS'){
+    if ($short !== 'CLS') {
         $p75 = formatMsInterval($p75, 2);
     }
-    
+
     $svg = <<<EOD
 <div class="crux_metric">
 <h4 class="crux_metric_title">$label ($short)</h4>

--- a/www/result.inc
+++ b/www/result.inc
@@ -273,7 +273,7 @@ $page_description = "Website performance test result$testLabel.";
             if (isset($fvRunResults)) {
                 echo '<div class="cruxembed">';
                 require_once(INCLUDES_PATH . '/include/CrUX.php');
-                InsertCruxHTML($fvRunResults, $rvRunResults, '');
+                InsertCruxHTML($fvRunResults, '');
                 echo '</div>';
             }
             ?>

--- a/www/vitals.php
+++ b/www/vitals.php
@@ -66,12 +66,8 @@ $page_description = "Web Vitals details$testLabel";
             <div id="result" class="results_body vitals-diagnostics crux-embed">
 
             <h3 class="hed_sub">Observed Web Vitals Metrics <em>(Collected in this WPT test run)</em></h3>
-
-            <?php
-            if (isset($testRunResults)) {
-                require_once(INCLUDES_PATH . '/include/CrUX.php');
-            }
-            ?>
+            
+            
             <?php
             if ($isMultistep) {
                 for ($i = 1; $i <= $testRunResults->countSteps(); $i++) {
@@ -84,6 +80,8 @@ $page_description = "Web Vitals details$testLabel";
                 InsertWebVitalsHTML($stepResult);
             }
             ?>
+
+            
             </div>
             </div>
             <?php include('footer.inc'); ?>
@@ -147,6 +145,15 @@ $lcp_request = '';
 function InsertWebVitalsHTML($stepResult)
 {
     InsertWebVitalsHTML_Summary($stepResult);
+    global $testRunResults;
+    if (isset($testRunResults)) {
+        echo '<div class="cruxembed">';
+        require_once(INCLUDES_PATH . '/include/CrUX.php');
+        
+            InsertCruxHTML($testRunResults, null, "cwv");
+        
+        echo '</div>';
+    }
     InsertWebVitalsHTML_LCP($stepResult);
     InsertWebVitalsHTML_CLS($stepResult);
     InsertWebVitalsHTML_TBT($stepResult);
@@ -179,8 +186,8 @@ function InsertWebVitalsHTML_Summary($stepResult)
         }
         echo "<a href='#lcp'><div class='summary-metric $scoreClass'>";
         echo "<h4>Largest Contentful Paint</h4>";
-        echo "<p class='metric-value $scoreClass'>{$lcp['time']}<span class='units'>ms</span></p>";
-        InsertCruxHTML($testRunResults, null, 'lcp', false, false);
+        echo "<p class='metric-value $scoreClass'>". formatMsInterval($lcp['time'],2) . "</p>";
+        //InsertCruxHTML($testRunResults, null, 'lcp', false, false);
         echo "</div></a>";
     }
     // CLS
@@ -222,7 +229,7 @@ function InsertWebVitalsHTML_Summary($stepResult)
         echo "<a href='#cls'><div class='summary-metric $scoreClass'>";
         echo "<h4>Cumulative Layout Shift</h4>";
         echo "<p class='metric-value $scoreClass'>$cls</p>";
-        InsertCruxHTML($testRunResults, null, 'cls', false, false);
+        //InsertCruxHTML($testRunResults, null, 'cls', false, false);
         echo "</div></a>";
     }
     // TBT
@@ -236,8 +243,8 @@ function InsertWebVitalsHTML_Summary($stepResult)
         }
         echo "<a href='#tbt'><div class='summary-metric $scoreClass'>";
         echo "<h4>Total Blocking Time</h4>";
-        echo "<p class='metric-value $scoreClass'>$tbt<span class='units'>ms</span></p>";
-        InsertCruxHTML($testRunResults, null, 'fid', false, true);
+        echo "<p class='metric-value $scoreClass'>" . formatMsInterval($tbt,2) ."</p>";
+        //InsertCruxHTML($testRunResults, null, 'fid', false, true);
         echo "</div></a>";
     }
 

--- a/www/vitals.php
+++ b/www/vitals.php
@@ -149,9 +149,9 @@ function InsertWebVitalsHTML($stepResult)
     if (isset($testRunResults)) {
         echo '<div class="cruxembed">';
         require_once(INCLUDES_PATH . '/include/CrUX.php');
-        
+
             InsertCruxHTML($testRunResults, null, "cwv");
-        
+
         echo '</div>';
     }
     InsertWebVitalsHTML_LCP($stepResult);
@@ -186,7 +186,7 @@ function InsertWebVitalsHTML_Summary($stepResult)
         }
         echo "<a href='#lcp'><div class='summary-metric $scoreClass'>";
         echo "<h4>Largest Contentful Paint</h4>";
-        echo "<p class='metric-value $scoreClass'>". formatMsInterval($lcp['time'],2) . "</p>";
+        echo "<p class='metric-value $scoreClass'>" . formatMsInterval($lcp['time'], 2) . "</p>";
         //InsertCruxHTML($testRunResults, null, 'lcp', false, false);
         echo "</div></a>";
     }
@@ -243,7 +243,7 @@ function InsertWebVitalsHTML_Summary($stepResult)
         }
         echo "<a href='#tbt'><div class='summary-metric $scoreClass'>";
         echo "<h4>Total Blocking Time</h4>";
-        echo "<p class='metric-value $scoreClass'>" . formatMsInterval($tbt,2) ."</p>";
+        echo "<p class='metric-value $scoreClass'>" . formatMsInterval($tbt, 2) . "</p>";
         //InsertCruxHTML($testRunResults, null, 'fid', false, true);
         echo "</div></a>";
     }


### PR DESCRIPTION
fixes #1721 

First steps on redesigning our contextual crux metrics comparison. Can be viewed on my test server.

Impacted views:
- result summary page
- result details page (crux now only shows up for first view runs, not repeat views)
- core web vitals page (now grouped separately from our intro metrics)

Preview in Results summary page (Test Run details page looks similar):
<img width="781" alt="image" src="https://user-images.githubusercontent.com/214783/222575669-04597215-7bac-49a4-949b-06b20dea4e41.png">

Preview in CWV page:
<img width="787" alt="image" src="https://user-images.githubusercontent.com/214783/222575787-11a6275e-77bd-44f6-8f03-a2add8317b28.png">

