### PR TITLE
bring back the first and repeat view labels and run links.

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -5568,7 +5568,11 @@ li.even {
   position: sticky;
   left: 0; 
 }
-
+@media (max-width: 60em){
+  .scrollableTable table.pretty#tableResults tr.runview th {
+    padding-top: 1em;
+  }
+}
 div.results-filmstrip-container {
   position: relative;
   left: 0;

--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -5556,24 +5556,17 @@ li.even {
 /* results table rows */
 
 .scrollableTable table tr.runview {
-  margin-top: 1em;
+  margin: 0;
 }
 
 .scrollableTable table.pretty#tableResults tr.runview th {
   background: #fff;
-  padding: 1.5em 0 0 0;
-  color: #2a3b64;
+  padding: 0;
+  color: #666;
   font-weight: 500;
-  text-transform: uppercase;
-  font-size: 1em;
+  font-size: .8em;
   position: sticky;
-  left: 0;
-}
-.result-summary
-  .scrollableTable
-  table.pretty#tableResults
-  tr.runview:first-of-type {
-  display: none;
+  left: 0; 
 }
 
 div.results-filmstrip-container {
@@ -6526,11 +6519,9 @@ table#tableResults.pretty td {
   font-size: 2rem;
   padding-right: 1rem;
 }
-
 .result-details thead th {
   text-align: left;
 }
-
 #custom-metrics table.pretty td,
 #custom-metrics table.pretty th {
   overflow: hidden;

--- a/www/result.inc
+++ b/www/result.inc
@@ -176,7 +176,7 @@ $page_description = "Website performance test result$testLabel.";
                           $friendlyMedianMetric = htmlspecialchars($median_metric);
                       }
                       if ($testResults->countRuns() > 1) {
-                          echo '<em>(Showing <a href="#run' . $fvMedian . '">Run ' . $fvMedian . ($rvRunResults ? ", first view." : ".") . '</a> Based on Median Run by:
+                          echo '<em>(Based on Median Run by:
                           <details><summary>' . $friendlyMedianMetric . '</summary>';
                           echo "<ul>";
 


### PR DESCRIPTION
This will bring back these labels. I'd hoped to combine them in the median run note but repeat views messed up that idea.

<img width="946" alt="image" src="https://user-images.githubusercontent.com/214783/224176084-9e3e209e-c95d-452d-a711-64991500a106.png">
