### PR TITLE
IniReader -> SettingsFileReader

### DIFF
--- a/www/home.php
+++ b/www/home.php
@@ -7,7 +7,7 @@
 include 'common.inc';
 
 use WebPageTest\Util;
-use WebPageTest\Util\IniReader;
+use WebPageTest\Util\SettingsFileReader;
 
 // see if we are overriding the max runs
 $max_runs = GetSetting('maxruns', 9);
@@ -42,8 +42,8 @@ if (isset($req_url)) {
 }
 $placeholder = 'Enter a website URL...';
 
-$profiles = IniReader::parse('profiles.ini', true);
-$connectivity = IniReader::parse('connectivity.ini', true, true);
+$profiles = SettingsFileReader::ini('profiles.ini', true);
+$connectivity = SettingsFileReader::ini('connectivity.ini', true, true);
 
 $mobile_devices = LoadMobileDevices();
 
@@ -801,7 +801,7 @@ $hasNoRunsLeft = $is_logged_in ? (int)$remaining_runs <= 0 : false;
                                                     <input type="text" name="cmdline" id="cmdline" class="text" style="width: 400px;" autocomplete="off">
                                                 </li>
                                                 <?php
-                                                $extensions = IniReader::getExtensions();
+                                                $extensions = SettingsFileReader::getExtensions();
                                                 if ($extensions) {
                                                     ?>
                                                 <li>

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -51,7 +51,7 @@ use WebPageTest\Util;
 use WebPageTest\Util\Cache;
 use WebPageTest\Template;
 use WebPageTest\RateLimiter;
-use WebPageTest\Util\IniReader;
+use WebPageTest\Util\SettingsFileReader;
 
 require_once(INCLUDES_PATH . '/ec2/ec2.inc.php');
 require_once(INCLUDES_PATH . '/include/CrUX.php');
@@ -518,7 +518,7 @@ if (!isset($test)) {
     }
 
     if (isset($_REQUEST['extensions']) && is_string($_REQUEST['extensions']) && strlen($_REQUEST['extensions']) == 32) {
-        $extensions = IniReader::getExtensions();
+        $extensions = SettingsFileReader::getExtensions();
         $requested = $_REQUEST['extensions'];
         if (array_key_exists($requested, $extensions)) {
             $test['extensions'] = $_REQUEST['extensions'];
@@ -2516,14 +2516,8 @@ function CheckIp(&$test)
         $date = gmdate("Ymd");
         $ip2 = @$test['ip'];
         $ip = $_SERVER['REMOTE_ADDR'];
-        if (file_exists('./settings/server/blockip.txt')) {
-            $blockIps = file('./settings/server/blockip.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        } elseif (file_exists('./settings/common/blockip.txt')) {
-            $blockIps = file('./settings/common/blockip.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        } else {
-            $blockIps = file('./settings/blockip.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        }
-        if (isset($blockIps) && is_array($blockIps) && count($blockIps)) {
+        $blockIps = SettingsFileReader::plain('blockip.txt');
+        if (is_array($blockIps) && count($blockIps)) {
             foreach ($blockIps as $block) {
                 $block = trim($block);
                 if (strlen($block)) {
@@ -2565,20 +2559,8 @@ function CheckUrl($url)
         $url = 'https://' . $url;
     }
     if ($forceValidate || (!$usingAPI && !$admin)) {
-        if (file_exists('./settings/server/blockurl.txt')) {
-            $blockUrls = file('./settings/server/blockurl.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        } elseif (file_exists('./settings/common/blockurl.txt')) {
-            $blockUrls = file('./settings/common/blockurl.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        } else {
-            $blockUrls = file('./settings/blockurl.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        }
-        if (file_exists('./settings/server/blockdomains.txt')) {
-            $blockHosts = file('./settings/server/blockdomains.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        } elseif (file_exists('./settings/common/blockdomains.txt')) {
-            $blockHosts = file('./settings/common/blockdomains.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        } else {
-            $blockHosts = file('./settings/blockdomains.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        }
+        $blockUrls = SettingsFileReader::plain('blockurl.txt');
+        $blockHosts = SettingsFileReader::plain('blockdomains.txt');
         if (
             $blockUrls !== false && count($blockUrls) ||
             $blockHosts !== false && count($blockHosts)

--- a/www/src/Util/SettingsFileReader.php
+++ b/www/src/Util/SettingsFileReader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WebPageTest\Util;
 
-class IniReader
+class SettingsFileReader
 {
     public static function getExtensions(): array
     {
@@ -21,9 +21,9 @@ class IniReader
      * @param string $filename E.g. "locations.ini"
      * @param bool $processSections Same as the second param to `parse_ini_file`
      * @param bool $allowSample If true also look for e.g. "locations.ini.sample"
-     * @return array|null Parsed ini or null
+     * @return array|false Parsed ini or false
      */
-    public static function parse($filename, $processSections = false, $allowSample = false)
+    public static function ini($filename, $processSections = false, $allowSample = false)
     {
         $paths = [
             realpath(SETTINGS_PATH . '/server/' . $filename),
@@ -39,6 +39,30 @@ class IniReader
                 return parse_ini_file($path, $processSections);
             }
         }
-        return null;
+        return false;
+    }
+
+    /**
+     * Returns an array of file lines (PHP's file()) by looking ar the default location
+     * and any overwrites in /common and /server
+     *
+     * @param string $filename E.g. "blockdomains.txt"
+     * @param int $flags Same as the second param to `file()`
+     * @return array|false Parsed text file or false
+     */
+    public static function plain($filename, $flags = FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)
+    {
+        $paths = [
+            realpath(SETTINGS_PATH . '/server/' . $filename),
+            realpath(SETTINGS_PATH . '/common/' . $filename),
+            realpath(SETTINGS_PATH . '/' . $filename),
+        ];
+
+        foreach ($paths as $path) {
+            if ($path && file_exists($path)) {
+                return file($path, $flags);
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
* support plain text files
* rename
* update callsites

Result: no errors with display_errors=1 when looking for missing files in runtest.php and home.php

In general the pattern of looking for /server, /common and default is too copy-pastey so end goal is it should go away