### PR TITLE
Add an explicit fetchpriority to the test images

### DIFF
--- a/www/http2priorities.html
+++ b/www/http2priorities.html
@@ -56,6 +56,7 @@ function loadImage(visible, callback) {
   const parent = document.getElementById(divName);
   let image = document.createElement("img");
   image.onload = callback;
+  image.fetchPriority = visible ? "high" : "low";
   image.src = uniqueUrl;
   parent.appendChild(image);
 }


### PR DESCRIPTION
For the http/2 priorities test page, this adds fetchpriority=high/low instead of just relying on viewport position when testing priority.

Relevant to https://github.com/andydavies/http2-prioritization-issues/issues/22