### PR TITLE
Add option to remove borders from filmstrips

### DIFF
--- a/www/video/filmstrip.php
+++ b/www/video/filmstrip.php
@@ -204,7 +204,7 @@ foreach ($tests as &$test) {
             $left += $colMargin;
             $width = imagesx($thumb);
             $padding = ($columnWidth - $width) / 2;
-            if (isset($border)) {
+            if (isset($border) && !array_key_exists('noborder', $_GET)) {
                 imagefilledrectangle($im, $left - 2 + $padding, $top - 2, $left + imagesx($thumb) + 2 + $padding, $top + imagesy($thumb) + 2, $border);
             }
             imagecopy($im, $thumb, $left + $padding, $top, 0, 0, $width, imagesy($thumb));


### PR DESCRIPTION
Add support for `&noborder=1` to filmstrip.php

## Before

<img width="676" alt="Screenshot 2023-03-14 at 11 49 01 AM" src="https://user-images.githubusercontent.com/51308/225058443-41a1c063-3258-4062-a2e6-dc5ffa525ab7.png">

## After

<img width="559" alt="Screenshot 2023-03-14 at 11 49 37 AM" src="https://user-images.githubusercontent.com/51308/225058424-84bd8798-e2e0-48d3-a155-92e016a81c53.png">
