### PR TITLE
feat(auth): add user ids to tests

### DIFF
--- a/tests/CPClientTest.php
+++ b/tests/CPClientTest.php
@@ -278,6 +278,7 @@ final class CPClientTest extends TestCase
         $handler = $this->createMockResponse(200, '{
             "data": {
               "userIdentity": {
+                "id": 12345,
                 "activeContact": {
                   "id": 263425,
                   "firstName": "Alice",
@@ -312,7 +313,8 @@ final class CPClientTest extends TestCase
         ));
 
         $user = $client->getUser();
-        $this->assertEquals('263425', $user->getUserId());
+        $this->assertEquals('12345', $user->getUserId());
+        $this->assertEquals('263425', $user->getContactId());
         $this->assertEquals('Alice', $user->getFirstName());
         $this->assertEquals('Bob', $user->getLastName());
         $this->assertEquals('', $user->getCompanyName());

--- a/www/common.inc
+++ b/www/common.inc
@@ -401,9 +401,10 @@ if (strlen($id)) {
         // $owner is set by CP details in AttachUser middleware if loaded
         $owner_id_matches_test = array_key_exists('owner', $test['testinfo']) && strlen($owner) && $owner == $test['testinfo']['owner'];
         $uid_matches_test = array_key_exists('uid', $test['testinfo']) && isset($uid) && strlen($uid) && $uid == $test['testinfo']['uid'];
+        $user_id_matches_test = array_key_exists('user_id', $test['testinfo']) && ($user_id == $test['testinfo']['user_id']);
         $creator_id_matches_test = array_key_exists('creator', $test['testinfo']) && ($creator_id == $test['testinfo']['creator']);
 
-        $isOwner = $owner_id_matches_test || $uid_matches_test || $creator_id_matches_test;
+        $isOwner = $owner_id_matches_test || $uid_matches_test || $creator_id_matches_test || $user_id_matches_test;
 
         // Boy what a hack. This gets around us running tests as private that should not have been
         // This happened because we had some profiles set to default private so they ran private for unpaid users

--- a/www/common/AttachUser.php
+++ b/www/common/AttachUser.php
@@ -99,9 +99,12 @@ use WebPageTest\Exception\UnauthorizedException;
                     // Check the expiration (with a 2-day buffer)
                     if (time() <= $account['expiration'] + 172800) {
                         $owner = $account['accountId'];
+                        $user_id = $account['userId'] ?? null;
+                        $contact_id = $account['contactId'] ?? null;
                         $user->setPaidClient(true);
                         $user->setOwnerId($owner);
-                        $user->setUserId($account['contactId']);
+                        $user->setContactId($contact_id);
+                        $user->setUserId($user_id);
                     }
                 }
             }

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -808,11 +808,16 @@ if (!empty($user_api_key)) {
 }
 
 $creator_id = 0;
+$user_id = 0;
 if (!is_null($request_context->getUser())) {
-    $creator_id = $request_context->getUser()->getUserId() ?? 0;
+    $creator_id = $request_context->getUser()->getContactId() ?? 0;
+    $user_id = $request_context->getUser()->getUserId() ?? 0;
 }
 if ($creator_id != 0) {
     $test["creator"] = $creator_id;
+}
+if ($user_id != 0) {
+    $test["user_id"] = $user_id;
 }
 
 if (isset($user) && !array_key_exists('user', $test)) {
@@ -2724,6 +2729,9 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
         }
         if (!empty($test["creator"])) {
             AddIniLine($testInfo, "creator", $test["creator"]);
+        }
+        if (!empty($test["user_id"])) {
+            AddIniLine($testInfo, "user_id", $test["user_id"]);
         }
         if (isset($test['type']) && strlen($test['type'])) {
             AddIniLine($testInfo, "type", $test['type']);

--- a/www/src/CPClient.php
+++ b/www/src/CPClient.php
@@ -188,6 +188,7 @@ class CPClient
             ->setSelectionSet([
                 (new Query('userIdentity'))
                     ->setSelectionSet([
+                        'id',
                         (new Query('activeContact'))
                             ->setSelectionSet([
                                 'id',
@@ -234,7 +235,8 @@ class CPClient
             }
             $user->setRunRenewalDate($run_renewal_date);
             $user->setSubscriptionId($data['wptCustomer']['subscriptionId']);
-            $user->setUserId($data['userIdentity']['activeContact']['id']);
+            $user->setUserId($data['userIdentity']['id']);
+            $user->setContactId($data['userIdentity']['activeContact']['id']);
             $user->setEmail($data['userIdentity']['activeContact']['email']);
             $user->setPaidClient($data['userIdentity']['activeContact']['isWptPaidUser']);
             $user->setPaymentStatus($data['wptCustomer']['status']);

--- a/www/src/User.php
+++ b/www/src/User.php
@@ -14,6 +14,7 @@ class User
     private ?string $owner_id;
     private ?string $access_token;
     private ?int $user_id;
+    private ?int $contact_id;
     private bool $is_paid_cp_client;
     private bool $is_verified;
     private bool $is_wpt_enterprise_client;
@@ -36,6 +37,7 @@ class User
         $this->owner_id = "2445"; // owner id of 2445 was for unpaid users
         $this->access_token = null;
         $this->user_id = null;
+        $this->contact_id = null;
         $this->is_paid_cp_client = false;
         $this->is_verified = false;
         $this->user_priority = 9; //default to lowest possible priority
@@ -131,6 +133,18 @@ class User
     {
         if (isset($user_id)) {
             $this->user_id = $user_id;
+        }
+    }
+
+    public function getContactId(): ?int
+    {
+        return $this->contact_id;
+    }
+
+    public function setContactId(?int $contact_id): void
+    {
+        if (isset($contact_id)) {
+            $this->contact_id = $contact_id;
         }
     }
 


### PR DESCRIPTION
Break contact id out into its own thing, use user ids for gating access to tests for the time being, as well.

This is a hold over until we get a solid authz service in place