### PR TITLE
Styleguide: initial implementation

### DIFF
--- a/www/resources/examples/custommetrics.example.php
+++ b/www/resources/examples/custommetrics.example.php
@@ -1,0 +1,27 @@
+<?php
+$EXAMPLES = [
+    [
+        'title' => 'Default',
+        'example' => function () {
+            $data = [
+                'custom' => [
+                    'Colordepth',
+                    'Dpi',
+                    'Images',
+                    'Resolution',
+                    'generated-content-percent',
+                    'generated-content-size',
+                ],
+                'Colordepth' => 24,
+                'Dpi' => '{"dppx":1,"dpcm":37.79527559055118,"dpi":96}',
+                'Images' => '[{"url":"https://www.phpied.com/images/covers/ruar.jpg","width":100,"height":131,"naturalWidth":381,"naturalHeight":499},{"url":"https://www.phpied.com/images/covers/jsp.jpg","width":100,"height":131,"naturalWidth":381,"naturalHeight":499},{"url":"https://www.phpied.com/images/covers/js4php.jpg","width":100,"height":130,"naturalWidth":385,"naturalHeight":499},{"url":"https://www.phpied.com/images/covers/oojs.jpg","width":100,"height":123,"naturalWidth":406,"naturalHeight":500},{"url":"https://www.phpied.com/images/covers/wp.jpg","width":100,"height":131,"naturalWidth":381,"naturalHeight":499}]',
+                'Resolution' => '{"absolute":{"height":1200,"width":1920},"available":{"height":1200,"width":1920}}',
+                'generated-content-percent' => 21,
+                'generated-content-size' => 123,
+            ];
+            return view('partials.custommetrics', [
+                'data' => $data,
+            ]);
+        }
+    ]
+];

--- a/www/resources/examples/htmldiff.example.php
+++ b/www/resources/examples/htmldiff.example.php
@@ -1,0 +1,25 @@
+<?php
+$EXAMPLES = [
+    [
+        'title' => 'Error state example',
+        'type' => 'fullpage',
+        'example' => function () {
+            return view('pages.htmldiff', [
+                'body_class' => 'result',
+                'error_message' =>  'No HTML to speak of',
+            ]);
+        }
+    ],
+    [
+        'title' => 'Simple example',
+        'type' => 'fullpage',
+        'example' => function () {
+            return view('pages.htmldiff', [
+                'body_class' => 'result',
+                'rendered_html' => '<div class="test">hello</div>',
+                'delivered_html' => '<div class="tester"  >hello</div>',
+                'error_message' => null,
+            ]);
+        }
+    ]
+];

--- a/www/resources/views/pages/htmldiff.blade.php
+++ b/www/resources/views/pages/htmldiff.blade.php
@@ -1,4 +1,4 @@
-@extends('default')
+@extends(defined('SG') ? 'styleguide' : 'default')
 
 @section('style')
 <style>

--- a/www/resources/views/styleguide.blade.php
+++ b/www/resources/views/styleguide.blade.php
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    @yield('style')
+    <style>
+        body {
+            display: inherit !important
+        }
+
+        .styleguide-container h1 {
+            padding: 1em;
+            margin: inherit;
+        }
+
+        .styleguide-toc {
+            padding: 1em;
+        }
+
+        .styleguide-toc ul {
+            list-style: inherit;
+            margin: inherit;
+            padding: 1em;
+        }
+
+        .styleguide-partial .styleguide-example {
+            padding: 1em;
+        }
+    </style>
+    <title>
+        <!--TITLE-->
+    </title>
+    <?php
+    $body_class = $body_class ? ' class="' . $body_class . '"' : '';
+    ?>
+    <link rel="stylesheet" href="/assets/css/typography.css?v=<?php echo constant('VER_TYPOGRAPHY_CSS') ?>">
+    <link rel="stylesheet" href="/assets/css/layout.css?v=<?php echo constant('VER_LAYOUT_CSS') ?>">
+    <link rel="stylesheet" href="/assets/css/pagestyle2.css?v=<?php echo constant('VER_CSS') ?>">
+</head>
+
+<body {!!$body_class !!}>
+    <div class="styleguide-container">
+        <h1>
+            <!--TITLE-->
+        </h1>
+        <div class="styleguide-example">
+            <!--CONTENT-->
+            @yield('content')
+        </div>
+        <div class="styleguide-toc">
+            <!--TOC-->
+        </div>
+    </div>
+</body>
+
+</html>

--- a/www/resources/views/styleguide.blade.php
+++ b/www/resources/views/styleguide.blade.php
@@ -5,7 +5,7 @@
     @yield('style')
     <style>
         body {
-            display: inherit !important
+            display: inherit !important;
         }
 
         .styleguide-container h1 {

--- a/www/sg.php
+++ b/www/sg.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+define('SG', 1);
+
+$dir = realpath(__DIR__ . '/resources/examples/');
+$files = scandir($dir);
+
+$ALL_EXAMPLES = [];
+foreach ($files as $file) {
+    if (strpos($file, '.example.php')) {
+        $EXAMPLES = [];
+        include($dir . '/' . $file);
+        $name = str_replace('.example.php', '', $file);
+        $ALL_EXAMPLES[$name] = [];
+        foreach ($EXAMPLES as $idx => $ex) {
+            $ALL_EXAMPLES[$name][$idx] = $ex;
+        }
+    }
+}
+
+if (!empty($_REQUEST['ex'])) {
+    $which = explode(':', $_REQUEST['ex']);
+    $example =  @$ALL_EXAMPLES[$which[0]][$which[1]];
+    $title = sprintf('%s: %s', $which[0], $example['title']);
+    $toc = getTOC();
+    $renderedExample = $example['example']();
+    if ($example['type'] === 'fullpage') {
+        echo str_replace(['<!--TITLE-->', '<!--TOC-->'], [$title, $toc], $renderedExample);;
+    } else {
+        $page = view('styleguide', [
+            'body_class' => 'styleguide-partial',
+        ]);
+        echo str_replace(['<!--TITLE-->', '<!--TOC-->', '<!--CONTENT-->'], [$title, $toc, $renderedExample], $page);
+    }
+} else {
+    $page = view('styleguide', []);
+    echo str_replace(['<!--TITLE-->', '<!--TOC-->'], ['Component explorer', getTOC()], $page);
+}
+
+
+function getTOC()
+{
+    global $ALL_EXAMPLES;
+    $ret = '<ul>';
+    foreach ($ALL_EXAMPLES as $file => $examples) {
+        foreach ($examples as $idx => $ex) {
+            $ret .= sprintf('<li><a href="?ex=%s:%s">%s: %s</a></li>', $file, $idx, $file, $ex['title']);
+        }
+    }
+    $ret .= '</ul>';
+    return $ret;
+}

--- a/www/sg.php
+++ b/www/sg.php
@@ -1,5 +1,9 @@
 <?php
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once 'common.inc';
+if (!$privateInstall && !$admin) {
+    header("HTTP/1.1 403 Unauthorized");
+    exit;
+}
 
 define('SG', 1);
 

--- a/www/styleguide.php
+++ b/www/styleguide.php
@@ -52,6 +52,7 @@ function getTOC()
             $ret .= sprintf('<li><a href="?ex=%s:%s">%s: %s</a></li>', $file, $idx, $file, $ex['title']);
         }
     }
+    $ret .= sprintf('<li><a href="%s">HOME</li>', $_SERVER['PHP_SELF']);
     $ret .= '</ul>';
     return $ret;
 }


### PR DESCRIPTION
How it works: 
1. You create `.example.php` file in `www/resources/examples/`
2. Append to a global `$EXAMPLES` array with a title and a callback that renders a template
3. Load `/styleguide.php` which surfaces all `.example.php`s for browsing

# HOME

<img width="436" alt="Screenshot 2023-03-30 at 12 46 16 PM" src="https://user-images.githubusercontent.com/51308/228908206-0aa1498f-5e02-43cc-aed7-469234ac18cc.png">

# Specific example

<img width="950" alt="Screenshot 2023-03-30 at 12 46 27 PM" src="https://user-images.githubusercontent.com/51308/228908197-73bf5d26-a377-4e3c-ba4a-4678d9d9e6b2.png">
