### PR TITLE
Adding Moto G Power

### DIFF
--- a/docker/local/server/config/mobile_devices.ini
+++ b/docker/local/server/config/mobile_devices.ini
@@ -8,7 +8,7 @@ group=Android
 width=412
 height=767
 dpr=1.75
-throttle_cpu=7
+throttle_cpu=7.5
 ua="Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.85 Mobile Safari/537.36"
 
 [MotoG4]

--- a/docker/local/server/config/mobile_devices.ini
+++ b/docker/local/server/config/mobile_devices.ini
@@ -1,6 +1,16 @@
 ;
 ; Android Devices
 ;
+;
+[MotoGPower]
+label="Motorola G Power"
+group=Android
+width=412
+height=767
+dpr=1.75
+throttle_cpu=7
+ua="Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.85 Mobile Safari/537.36"
+
 [MotoG4]
 label="Motorola G (gen 4)"
 group=Android

--- a/www/settings/mobile_devices.ini
+++ b/www/settings/mobile_devices.ini
@@ -7,7 +7,7 @@ group=Android
 width=412
 height=767
 dpr=1.75
-throttle_cpu=7
+throttle_cpu=7.5
 ua="Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.85 Mobile Safari/537.36"
 
 [MotoG4]

--- a/www/settings/mobile_devices.ini
+++ b/www/settings/mobile_devices.ini
@@ -1,6 +1,15 @@
 ;
 ; Android Devices
 ;
+[MotoGPower]
+label="Motorola G Power"
+group=Android
+width=412
+height=767
+dpr=1.75
+throttle_cpu=7
+ua="Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.85 Mobile Safari/537.36"
+
 [MotoG4]
 label="Motorola G (gen 4)"
 group=Android


### PR DESCRIPTION
Lighthouse recently changed their default device to the Moto G Power (https://github.com/GoogleChrome/lighthouse/pull/14674). This means we have a situation where our default device (the G4) has a much smaller viewport, causing some sizable differences in what folks may see in our LH runs and WPT runs.

This adds the Moto G Power. Using a 7.5x CPU throttling factor seems about right.

A referenced Speedometer 2.0 benchmark on a real device came in at 14.1 +/- 0.21. A few quick tests at 7.5 returned: 14.5, 13.9, 14.1