### PR TITLE
Fix forcePrivate option so it really prevents the all option 

### DIFF
--- a/www/testlog.php
+++ b/www/testlog.php
@@ -73,7 +73,7 @@ $from      = (isset($_GET["from"]) && strlen($_GET["from"])) ? $_GET["from"] : '
 $filter    = $_GET["filter"];
 $filterstr = $filter ? preg_replace('/[^a-zA-Z0-9 \@\/\:\.\(\))\-\+]/', '', strtolower($filter)) : null;
 $onlyVideo = !empty($_REQUEST['video']);
-$all       = !empty($_REQUEST['all']);
+$all       = ($admin || !Util::getSetting('forcePrivate')) && !empty($_REQUEST['all']);
 $repeat    = !empty($_REQUEST['repeat']);
 $nolimit   = !empty($_REQUEST['nolimit']);
 


### PR DESCRIPTION
Hi,

I see that you have recently refactored the test log and reimplemented the forcePrivate option. However, the option seems to be still broken since it does not prevent any user from appending &all=on to the teslog.php 

This will still show the all tests regardless if the forcePrivate option was configured. This PR will fix that. 