### PR TITLE
`Access-Control-Allow-Origin` in LH JSON exports

### DIFF
--- a/www/lighthouse.php
+++ b/www/lighthouse.php
@@ -17,6 +17,7 @@ if (array_key_exists("HTTP_IF_MODIFIED_SINCE", $_SERVER) && strlen(trim($_SERVER
                 header('Last-Modified: ' . gmdate('r'));
                 header('Cache-Control: public,max-age=31536000', true);
                 header('Content-type: application/json');
+                header('Access-Control-Allow-Origin: *');
                 gz_readfile_chunked($filePath);
             }
         } else {


### PR DESCRIPTION
We do it for a bunch of other JSON exports, see function `json_response()` in common_lib.inc:
https://github.com/WPO-Foundation/webpagetest/blob/master/www/common_lib.inc#L2642

Testing with the new LH diff tool:
https://googlechrome.github.io/lighthouse-ci/difftool/?baseReport=https://gist.githubusercontent.com/paulirish/c149ae183349e330e82cc99836095eb2/raw/8eb6666da6e5d3eb0b15fff0aefa216de0c172aa/www.mikescerealshack.co_2022-03-15_14-49-33.lighthouse.report.json&compareReport=https%3A%2F%2Fwww.webpagetest.org%2Flighthouse.php%3Ftest%3D221214_BiDcSF_CRE%26f%3Djson

Before: fetch error
After: nice diff