### PR TITLE
fix(account): no upcoming plan for canceled

### DIFF
--- a/www/templates/account/includes/subscription-plan.php
+++ b/www/templates/account/includes/subscription-plan.php
@@ -32,7 +32,7 @@
             <?php endif; ?>
         <?php endif; ?>
         </ul>
-        <?php if (isset($upcoming_plan)) : ?>
+        <?php if (!$is_pending && isset($upcoming_plan)) : ?>
             <h3>Upcoming Subscription</h3>
             <div class="card-section-subhed card-section-subhed__grid">
                 <span class="plan-name">


### PR DESCRIPTION
There is no need to show an upcoming plan if the user has canceled their account. Not even sure why we get "upcoming plan" from chargify for a canceled user. They're not showing that in their UI at that point.