### PR TITLE
fix(account): logout bad clients 

### DIFF
--- a/www/construction.php
+++ b/www/construction.php
@@ -10,4 +10,3 @@ echo view('pages.construction', [
     'page_title' => 'WebPageTest - Under Construction',
     'body_class' => 'four-oh-four',
 ]);
-

--- a/www/src/Exception/AuthenticationException.php
+++ b/www/src/Exception/AuthenticationException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebPageTest\Exception;
+
+use WebPageTest\Exception\ClientException;
+use WebPageTest\Util;
+
+class AuthenticationException extends ClientException
+{
+    public function __construct()
+    {
+        $support_link = Util::getSetting('support_link', 'https://support.catchpoint.com');
+        $message = "There was a problem with your account, please try logging in" .
+                   " again. If you receive this error multiple times, please" .
+                   " <a href='{$support_link}'>contact our support team</a>";
+        $route = "/";
+        parent::__construct($message, $route);
+    }
+}

--- a/www/src/User.php
+++ b/www/src/User.php
@@ -87,6 +87,11 @@ class User
             ($this->payment_status == 'ACTIVE' || $this->isPendingCancelation());
     }
 
+    public function isPaidClient(): bool
+    {
+        return $this->is_paid_cp_client;
+    }
+
     public function setPaidClient(bool $is_paid): void
     {
         $this->is_paid_cp_client = $is_paid;


### PR DESCRIPTION
When a user's account is canceled, we moved them to the free client and
suspend their paid one. This will cause issues for them when they're
using the site and will continue to cause problems with them in the
future unless we log them out so they log back in with a better
contact/client for their actual account status.

Note: this cannot go out to prod until post release and account management that makes this possible