### PR TITLE
Prevent JS error (wptStorage already defined)

### DIFF
--- a/www/webvitals.php
+++ b/www/webvitals.php
@@ -157,8 +157,6 @@ $profiles = parse_ini_file($profile_file, true);
         <?php
           echo "var profiles = " . json_encode($profiles) . ";\n";
         ?>
-        var wptStorage = window.localStorage || {};
-
         var profileChanged = function() {
           var sel = document.getElementById("webvital_profile");
           var txt = document.getElementById("description");


### PR DESCRIPTION
Attempt to define in test.js fails, because it's defined here, where it's not used anyway