### PR TITLE
Remove html class account-layout from /learn

### DIFF
--- a/www/learn/lightning-fast-web-performance/index.php
+++ b/www/learn/lightning-fast-web-performance/index.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="account-layout">
+<html>
 
 <head>
     <title>Lightning-Fast Web Performance Online Course from WebPageTest</title>


### PR DESCRIPTION
this class seems unnecessary and was causing the links in the header to be unreadable

<img width="851" alt="Screenshot 2023-05-30 at 1 42 08 AM" src="https://github.com/WPO-Foundation/webpagetest/assets/51308/2dc9b56e-509e-4bfa-b110-4ea6b934818d">
