### PR TITLE
`Access-Control-Allow-Origin` in exports, e.g. HAR

### DIFF
--- a/www/export.php
+++ b/www/export.php
@@ -48,6 +48,7 @@ if (!strlen($filename)) {
 $filename .= ".$id.har";
 header('Content-type: application/json');
 header("Content-disposition: attachment; filename=$filename");
+header('Access-Control-Allow-Origin: *');
 
 // see if we need to wrap it in a JSONP callback
 if (isset($_REQUEST['callback']) && strlen($_REQUEST['callback'])) {


### PR DESCRIPTION
Tried to test a nifty little har diff tool https://compare.sitespeed.io/ and turns out we've missed ACAO header in export.php
(We do have it in various other responses, see `json_response()` or `lighthouse.php`)