### PR TITLE
fix: BUG 168255: removed fixed width from form inputs

### DIFF
--- a/www/templates/account/includes/chargify-payment-form.php
+++ b/www/templates/account/includes/chargify-payment-form.php
@@ -90,11 +90,6 @@
                     placeholder: 'MM',
                     message: 'Invalid Month',
                     required: true,
-                    style: {
-                        input: {
-                            width: '158px'
-                        }
-                    }
                 },
                 year: {
                     selector: '#cc_year',
@@ -102,11 +97,6 @@
                     placeholder: 'YYYY',
                     message: 'Invalid Year',
                     required: true,
-                    style: {
-                        input: {
-                            width: '158px'
-                        }
-                    }
                 },
                 cvv: {
                     selector: '#cc_cvv',
@@ -115,11 +105,6 @@
                     required: true,
                     message: 'Invalid CVC',
                     required: true,
-                    style: {
-                        input: {
-                            width: '158px'
-                        }
-                    }
                 }
             }
         });


### PR DESCRIPTION
Small fix to avoid showing scrollbars when using the browser zoom

before
<img width="817" alt="before" src="https://github.com/WPO-Foundation/webpagetest/assets/4400047/f4821924-a42a-4adf-88ef-3e96f2f1ccff">

before with 125% zoom
<img width="904" alt="before_125_zoom" src="https://github.com/WPO-Foundation/webpagetest/assets/4400047/69021ea0-1e50-4642-a469-7ed56c494f55">

after
<img width="837" alt="after" src="https://github.com/WPO-Foundation/webpagetest/assets/4400047/2769ed59-a545-4736-a9c9-f47369331962">

after 125% zoom
<img width="946" alt="after_125_zoom" src="https://github.com/WPO-Foundation/webpagetest/assets/4400047/1e890097-73d4-4000-8316-96edb64c1ca5">





