### PR TITLE
fix: BUG 131913 stop losing the filter text when filtering the test history  

### DIFF
--- a/www/assets/js/history-loggedin.js
+++ b/www/assets/js/history-loggedin.js
@@ -32,12 +32,19 @@
 
   function handleDaySelector() {
     const daySelector = document.querySelector("select[name=days]");
+    const filter = document.getElementById('filter');
+
     daySelector.addEventListener("change", (e) => {
       const days = e.target.value;
       const protocol = window.location.protocol;
       const hostname = window.location.hostname;
-      const redirectUri = protocol + "//" + hostname + "/testlog/" + days + "/";
 
+      if (filter.value) {
+        document.querySelector('form[name=filterLog]').submit();
+        return;
+      }
+
+      const redirectUri = protocol + "//" + hostname + "/testlog/" + days + "/";
       window.location = redirectUri;
     });
   }

--- a/www/resources/views/pages/testhistory.blade.php
+++ b/www/resources/views/pages/testhistory.blade.php
@@ -16,7 +16,7 @@
 
         <div class="history_filter">
             <label for="filter">Filter test history:</label>
-            <input id="filter" name="filter" type="text" onkeyup="filterHistory()" placeholder="Search">
+            <input id="filter" name="filter" type="text" onkeyup="filterHistory()" placeholder="Search" value="{{ $filter ?? '' }}">
             @if ($is_logged_in)
                 <label for="days" class="a11y-hidden">Select how far back you want to see</label>
                 <select name="days" id="days">

--- a/www/testlog.php
+++ b/www/testlog.php
@@ -31,6 +31,9 @@ if ($admin || $privateInstall || $is_logged_in) {
 $csv = isset($_GET['f']) && !strcasecmp($_GET['f'], 'csv');
 $priority = (isset($_REQUEST['priority']) && is_numeric($_REQUEST['priority'])) ? intval($_REQUEST['priority']) : null;
 $days = (int)($_GET['days'] ?? 7);
+$filter    = $_GET["filter"];
+$filterstr = $filter ? preg_replace('/[^a-zA-Z0-9 \@\/\:\.\(\))\-\+]/', '', strtolower($filter)) : null;
+
 
 $GLOBALS['tab'] = 'Test History';
 $GLOBALS['page_description'] = 'History of website performance speed tests run on WebPageTest.';
@@ -52,7 +55,7 @@ if (!$csv && ($is_logged_in || (!isset($user) && !isset($_COOKIE['google_email']
         'local' => isset($_REQUEST['local']) && $_REQUEST['local'],
         'body_class' => 'history',
         'page_title' => 'WebPageTest - Test History',
-
+        'filter' => $filterstr
     ];
 
     echo view('pages.testhistory', $vars);
@@ -70,8 +73,6 @@ if ($result_code == 0 && isset($output) && is_array($output) && count($output)) 
 }
 
 $from      = (isset($_GET["from"]) && strlen($_GET["from"])) ? $_GET["from"] : 'now';
-$filter    = $_GET["filter"];
-$filterstr = $filter ? preg_replace('/[^a-zA-Z0-9 \@\/\:\.\(\))\-\+]/', '', strtolower($filter)) : null;
 $onlyVideo = !empty($_REQUEST['video']);
 $all       = ($admin || !Util::getSetting('forcePrivate')) && !empty($_REQUEST['all']);
 $repeat    = !empty($_REQUEST['repeat']);


### PR DESCRIPTION
this change will prevent losing the text the user has on the text input when filtering the test history, it does so by making sure we keep it on the url query