### PR TITLE
fix: graph (plot full results) link

### DIFF
--- a/www/result.inc
+++ b/www/result.inc
@@ -215,7 +215,7 @@ $page_description = "Website performance test result$testLabel.";
                                 if ($rvRunResults) {
                                     echo "<a href=\"" . $repeatlink . "\" class=\"result_plot\">Compare Repeat Views</a>";
                                 }
-                                $graphLink = "graph_page_data.php?tests=$id&medianMetric=$median_metric" . ($req_fp ? "&fp=$req_fp" : '');
+                                $graphLink = "/graph_page_data.php?tests=$id&medianMetric=$median_metric" . ($req_fp ? "&fp=$req_fp" : '');
 
                                 echo "<a href='$graphLink' class='result_plot'>Plot Full Results</a>";
                             }


### PR DESCRIPTION
The req_fp refactor removed the leading `/` which has resulted in a broken link, this PR restores the leading `/`, with this restored link goes to a page that behaves as expected.

Before: https://www.webpagetest.org/result/250912_YiDcJ5_5ES/graph_page_data.php?tests=250912_YiDcJ5_5ES&medianMetric=SpeedIndex
After: https://www.webpagetest.org/graph_page_data.php?tests=250912_YiDcJ5_5ES&medianMetric=SpeedIndex

![Fullscreen_13_09_2025__09_34](https://github.com/user-attachments/assets/9b36f254-cc5f-4e64-abec-27b4079740a1)
